### PR TITLE
Fix pre-commit CI and upgrade depdendencies

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -10,9 +10,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py312h98912ed_4.conda
@@ -22,43 +22,45 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.16-haed3651_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.10-ha9bf9b1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.14-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h4466546_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-he635cd5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.1-hbfc29b2_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.6-h96cd748_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.3-hffff1cc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.5-h4893938_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.15-h4466546_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h4466546_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.4-h58a74b7_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-hb1af6a8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.11.1-h91d86a7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.10.0-h00ab1b0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-h94269e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.22-hbd3ac97_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.1-h87b94db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.23-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-he027950_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h7671281_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.2-he17ee6b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.10-h826b7d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hcd6a914_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.0-h365ddd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.16-he027950_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-he027950_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.3-hda66527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.329-h46c3b66_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.7.0-h10ac4d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.11.0-h325d260_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h30efb56_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hbb29018_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.0-hbdc6101_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-hf8ad068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
@@ -66,11 +68,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py312h8572e83_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.4-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.0-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.58.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.1-py312h30efb56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.2-py312h7070661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/deno-1.37.2-h335b0a9_1.conda
@@ -79,112 +81,108 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.19.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.6-py312h66d9856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.6-py312h32ad294_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.51.0-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.4-py312h257dd4b_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.1-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-h6b2125f_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py312h7eda2e2_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.2-he02047a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-hf7fa9e8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.0-hf2295e7_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.0-hde27a5a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.0-hed5481d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.3-h8a4344b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.3-h73ef956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.42.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.1-hfa15dee_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.1-h98fc4e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.5-hbaaba92_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.5-haf2f30d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hfac3d4d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.35-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyhd33586a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h7ab15ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py312h7900ff3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h1220068_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.25-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.2-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-h2f55d51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hee9dde6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py312h8572e83_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.2-h2aa1ff5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.2-hb86450c_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.2-h59595ed_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.2-h59595ed_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.2-hc6145d9_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.2-h757c851_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.2-hb016d2e_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.2-h757c851_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h4b47046_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-23_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.3-default_h5d6823c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.8-default_h9def88c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.0-hdb1bdb2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
@@ -192,229 +190,238 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.4-h7c88fdf_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-h8f9377d_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-h9d8aadb_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_9.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.22.0-h9be4e54_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.22.0-hc7a4891_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.48-h71f35ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h8a4344b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.26.0-h26d7fe4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.26.0-ha262f82_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1018.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hbbc8833_1020.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-23_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-hb3ce162_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.3-h2448989_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h9612171_113.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.8-h8b73ec9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.2-h352af49_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-h9e5060d_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h8917695_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hc670b87_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialindex-1.9.3-h9c3ff4c_4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h7bd4643_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h15fa968_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-h4c95cb1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.10.1-h2629f0a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h516909a_1000.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h98912ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.8.3-py312h7900ff3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.3-py312he5832f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py312h9201f00_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.5-h0ab5242_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.6-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.9.0-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.1-py312h9a8786e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.3.0-hf1915f5_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.3.0-hca2cd23_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.3.0-h70512c7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.3.0-ha479ceb_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.1-py312h1103770_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.2-py312h98912ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h1e5e2c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.4-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py312hfb8ada1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.1.240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.18.3-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.18.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.11.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.12.3-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py312hdcec9eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h287a98d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.03.0-h590f24d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h82ecc9d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.1-h1d62c97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.4.1-hb784bbd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hb77b528_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.2-py312h176e3d2_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-17.0.0-py312h9cebb41_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-17.0.0-py312h264c024_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.3-py312h4b3b743_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.7.2-py312h66d9856_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.20.1-py312hf008fa9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.9.0-py312h8ad7a51_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py312h38f1c37_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py312h5d05ceb_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py312h949fe66_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py312h30efb56_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py312h98912ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.2-py312h886d080_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-hc9dc06e_21.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.4.550-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.9-py312h26ef92c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.0.3-py312h8fd38d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h320f8da_24.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.4.557-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.10-py312hc022a17_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rasterstats-0.19.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-51.0-hd3aeb46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.18.0-py312h4b3b743_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rtree-1.2.0-py312hb0aae1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.19.1-py312hf008fa9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.5-py312hbe4c86d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.8-h06160fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.4.1.post1-py312h394d371_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.0-py312heda63a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.3-py312h9e6bd2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.17-he19d79f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py312h775a589_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312hc2bc53b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.5-py312h8413631_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.2-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py312h30efb56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.12.0-hd2e6256_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.45.2-h2c6b66d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.13.0-hd2e6256_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.21.2-ha9641ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.25.0-h769197d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4-py312h98912ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h9a8786e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240203-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.32.0.20240712-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2024a-h3f72095_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h8572e83_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-h59595ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-4.0.0-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-4.0.1-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h98912ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-hac6953d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.42-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-hb711507_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
@@ -423,20 +430,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h3483029_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/ribasim_nl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
@@ -446,43 +454,45 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.16-h9d28af5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.10-hf9de6f9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.14-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h905ab21_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h30f2259_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.1-hce3b3da_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.6-hf76ed93_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.3-ha335edc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.5-h6f42f56_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.15-h905ab21_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h905ab21_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.4-h25b5da4_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.267-hd2aab46_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.11.1-hbb1e571_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.10.0-h7728843_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-h0e82ce4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.22-hb04b931_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.1-hd73d8db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.23-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hd73d8db_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h2713d70_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.2-he29c2fd_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.10-h4406d91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-hf6997d9_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.0-h13137a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.16-hd73d8db_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hd73d8db_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.3-h0a15bd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.329-h554caeb_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.13.0-hf8dbe3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h60298e3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.12.0-h646f05d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.7.0-hf91904f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.11.0-h14965f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312heafc425_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.32.3-h51dda26_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py312h38bf5a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.0-h60fb419_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.1-ha105788_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
@@ -490,10 +500,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.1-py312h9230928_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.4-py312h41838bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.0-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dart-sass-1.58.3-h694c41f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.1-py312hede676d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.2-py312h28f332c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/deno-1.37.2-h51b076b_1.conda
@@ -502,311 +512,313 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.19.2-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.6-py312hc18349f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.6-py312hfc836c0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.2.1-h7728843_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.51.0-py312h41838bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.53.1-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.8.4-py312h1be6df0_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h509af15_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py312h29648be_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.2-hf036a51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h4bbec01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.0-h31b1b29_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.42.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h687a608_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.35-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyh3cd1d5f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py312hb401068_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h6253ea5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.25-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py312hb401068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.2-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-h5f07ac3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-hb2b617a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py312h49ebfd2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.2-hd35d340_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.2-h8d4fe2c_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.2-hd427752_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.2-hd427752_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.2-h39e3226_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.2-h1a3ed6a_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.2-h43798cf_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.2-h1a3ed6a_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h130fc27_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hf036a51_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hf036a51_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-h85bc590_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.9.0-hfcf2730_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hef8daea_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.4-h2239303_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-h694c41f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.1-h858dd01_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.1-h5d197d2_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.1-h385febf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.1-h86719f3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.1-h513f0eb_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.1-hc5f35ca_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.1-h3b8d0bf_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.1-h3127c03_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.1-h0da0525_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.1-h1b48671_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.1-h1b48671_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.1-ha63beff_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.1-h597966e_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.22.0-h651e89d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.22.0-ha67e85c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.1-h384b2fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.26.0-h721cda5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.26.0-h9e84e37_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hab3ca0e_1018.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7760872_113.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_hfef2a42_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.2-h089a9f7_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-h904a336_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.3-h4501773_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hf05f67e_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-he2ba7a0_16.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialindex-1.9.3-he49afe7_4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hebe6af1_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hdc25a2c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.16-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py312h41838bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.8.3-py312hb401068_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.3-py312h1fe5000_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py312hb401068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py312h0d5aeb7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.5-h37d7099_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.9.0-py312h41838bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.1-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nspr-4.35-hea0b92c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.1-py312h8813227_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.2-py312h104f124_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.0-h6c6cd50_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.4-py312h8847cbe_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.1-py312h83c8a23_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.1.240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.18.3-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.18.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.11.1-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py312h1171441_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.12.3-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py312h0c923fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312hbd70edc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.03.0-h0c752f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.07.0-h744cbf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.2-h06f2bd8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.1-h81faed2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.3-h1d90168_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.4.1-hf92c781_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.8-py312h41838bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.2-py312hc4c33ac_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-17.0.0-py312h0be7463_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-17.0.0-py312h12b3929_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.16.3-py312h1b0e595_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.2-py312h74abf1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.2-py312h74abf1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.7.2-py312h3aaa50d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.20.1-py312ha47ea1c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py312he77c50b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py312he77c50b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.9.0-py312h43b3a95_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py312h14d93e9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py312ha320102_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.4-h37a9e06_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py312h104f124_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.2-py312hc789acb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/quarto-1.4.550-h694c41f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.9-py312h2bf6802_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.0.3-py312ha04878a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/quarto-1.4.557-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.10-py312h1c98354_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rasterstats-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.18.0-py312h1b0e595_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rtree-1.2.0-py312h8974cf7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.19.1-py312ha47ea1c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.5.5-py312h8b25c6c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.4.1.post1-py312h7167a34_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.13.0-py312h8adb940_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.3-py312h8fb43f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py312hc214ba5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.5-py312h594820c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.2-py312h41838bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.12.0-h8dd852c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.45.2-h7461747_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.13.0-h1a4aec9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.46.0-h28673e1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh31c8845_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.21.2-h0d80af6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.25.0-h61fe09d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4-py312h41838bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py312hbd25219_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240203-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.32.0.20240712-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tzcode-2024a-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312h49ebfd2_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-he965462_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/watchdog-4.0.0-py312hc2c2f20_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/watchdog-4.0.1-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312h41838bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hfb503d4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h331e495_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/ribasim_nl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py312he70551f_4.conda
@@ -815,43 +827,44 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.16-h7613915_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.10-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.14-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h3df98b0_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.1-h4e3df0f_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.6-hf0b8b6f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.3-h96fac68_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.5-h08df315_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.15-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hf6fcf4e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.4-h944602d_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.267-hfaf0dd0_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.11.1-h249a519_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.10.0-h91493d7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.22-h8c86ca4_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.1-hea5f451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.23-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hea5f451_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h4b8288a_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.2-h269d64e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.10-hfca834b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h519d897_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.0-hb746b11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.16-hea5f451_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hea5f451_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.3-h8c89294_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.329-he0aa860_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.13.0-haf5610f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h148e6f0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.12.0-hf03c1c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.7.0-h148e6f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-bin-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h53d5487_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.28.1-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.32.3-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h91e5215_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.0-h9b0cee5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.1-hc2ea260_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-win_pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1-py_0.tar.bz2
@@ -859,10 +872,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py312h0d7def4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.4-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.58.3-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.1-py312h53d5487_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.2-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/deno-1.37.2-hc8b987e_1.conda
@@ -871,223 +884,226 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.19.2-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.6-py312h95cbb4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.6-py312h4a86439_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-10.2.1-h181d51b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.51.0-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.8.4-py312h36e25a9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.1-h1537add_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hbf5ca3a_15.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h7d00a51_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.0-h39d0aa6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.0-h0a98069_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.42.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.1-h001b923_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.1-hb4038d2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py312h16ac12d_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.2-h5a68840_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-hd7df778_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.3-h7025463_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.3-h4394cf3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.5-hb0a98b8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.5-h5006eae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.35-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.1.0-h57928b3_964.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyha63f2e9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh7428d3b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py312h2e8e312_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.25-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py312h2e8e312_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.7.2-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-hd248416_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py312h0d7def4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.2-h313118b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-15.0.2-h878f99b_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-15.0.2-h63175ca_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-15.0.2-h63175ca_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-15.0.2-h02312f3_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-15.0.2-h55b4db4_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.2-h3f2ff47_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.2-h89268de_1_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-22_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h11e6a32_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_2_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-22_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.3-default_hf64faad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-23_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.8-default_ha5278ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.9.0-h18fefc2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.4-hf83a0e2_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.22.0-h9cad5c0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.22.0-hb581fae_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.1-h5273850_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-hcff673a_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-hefbb53f_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.3-h7025463_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.26.0-h5e7cea3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.26.0-he5eb982_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-haf3e7a6_1018.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-22_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h07c049d_113.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.2-h7ec3a38_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-23_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-h178134c_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.2-hdb24f17_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.3-hab9416b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h94c4f80_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h6c42fcb_16.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialindex-1.9.3-h39d44d4_4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hf2f0abc_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hcb35769_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzip-1.10.1-h1d365fa_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-he774522_1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py312he70551f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.8.3-py312h2e8e312_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.3-py312h26ecaf7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.5-h5bed578_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_692.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_694.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/multimethod-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.9.0-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.10.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.1-py312h49bc9c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.2-py312he70551f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-heb0c069_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.4-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.1-py312h2ab9e98_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.1.240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.18.3-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.18.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.11.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py312h72972c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.3-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.12.3-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py312h6f6a607_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.03.0-hc2f3c52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.2-h94c9ec1_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.1-he13c7e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.3-h7f155c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.4.1-hd9569ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.8-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.2-py312h85e32bb_1_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-17.0.0-py312h7e22eef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-17.0.0-py312h3529c54_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.16.3-py312hfccd98a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.7.2-py312he3b4e22_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.20.1-py312h2615798_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.9.0-py312hd215820_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py312hc725b1e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py312h6f27134_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py312he09f080_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py312h53d5487_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-5.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.4-h889d299_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
@@ -1095,89 +1111,90 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py312h53d5487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py312h53d5487_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py312he70551f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.2-py312h1ac6f91_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-hcef0176_21.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.4.550-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.9-py312hc028deb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.0.3-py312hd7027bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h06adc49_23.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.4.557-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.10-py312he4a2ebf_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rasterstats-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.18.0-py312hfccd98a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rtree-1.2.0-py312h72b5f30_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.19.1-py312h2615798_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.5-py312h7a6832a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.4.1.post1-py312hcacafb1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.0-py312h8753938_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.3-py312h7d70906_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py312h816cc57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.5-py312h3a88d77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.2-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py312h53d5487_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.12.0-h64d2f7d_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.45.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.13.0-h64d2f7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.46.0-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.21.2-h25b666a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.25.0-h414c7de_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h5226925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4-py312he70551f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20240316-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240203-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.32.0.20240712-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312h0d7def4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.7-h1537add_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/watchdog-4.0.0-py312h2e8e312_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/watchdog-4.0.1-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py312he70551f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/ribasim_nl
@@ -1227,52 +1244,51 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/affine
+  - pkg:pypi/affine?source=conda-forge-mapping
   size: 18726
   timestamp: 1674245215155
 - kind: conda
   name: alsa-lib
-  version: 1.2.11
-  build: hd590300_1
-  build_number: 1
+  version: 1.2.12
+  build: h4ab18f5_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.11-hd590300_1.conda
-  sha256: 0e2b75b9834a6e520b13db516f7cf5c9cea8f0bbc9157c978444173dacb98fec
-  md5: 0bb492cca54017ea314b809b1ee3a176
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.12-h4ab18f5_0.conda
+  sha256: 64b95dd06d7ca6b54cea03b02da8f1657b9899ca376d0ca7b47823064f55fb16
+  md5: 7ed427f0871fd41cb1d9c17727c17589
   depends:
   - libgcc-ng >=12
   license: LGPL-2.1-or-later
   license_family: GPL
   purls: []
-  size: 554699
-  timestamp: 1709396557528
+  size: 555868
+  timestamp: 1718118368236
 - kind: conda
   name: annotated-types
-  version: 0.6.0
+  version: 0.7.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.6.0-pyhd8ed1ab_0.conda
-  sha256: 3a2c98154d95cfd54daba6b7d507d31f5ba07ac2ad955c44eb041b66563193cd
-  md5: 997c29372bdbe2afee073dff71f35923
+  url: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_0.conda
+  sha256: 668f0825b6c18e4012ca24a0070562b6ec801ebc7008228a428eb52b4038873f
+  md5: 7e9f4612544c8edbfd6afad17f1bd045
   depends:
   - python >=3.7
   - typing-extensions >=4.0.0
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/annotated-types
-  size: 17026
-  timestamp: 1696634393637
+  - pkg:pypi/annotated-types?source=conda-forge-mapping
+  size: 18235
+  timestamp: 1716290348421
 - kind: conda
   name: anyio
-  version: 4.3.0
+  version: 4.4.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.3.0-pyhd8ed1ab_0.conda
-  sha256: 86aca4a31c09f9b4dbdb332cd9a6a7dbab62ca734d3f832651c0ab59c6a7f52e
-  md5: ac95aa8ed65adfdde51132595c79aade
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.4.0-pyhd8ed1ab_0.conda
+  sha256: 84ac9429812495f12939ab4994f2634f7cacd254f6234a0c2c0243daed15a7ee
+  md5: 1fa97c6e8db1f82c64ff17a5efc4ae8e
   depends:
   - exceptiongroup >=1.0.2
   - idna >=2.8
@@ -1280,14 +1296,14 @@ packages:
   - sniffio >=1.1
   - typing_extensions >=4.1
   constrains:
-  - trio >=0.23
   - uvloop >=0.17
+  - trio >=0.23
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/anyio
-  size: 102331
-  timestamp: 1708355504396
+  - pkg:pypi/anyio?source=conda-forge-mapping
+  size: 104255
+  timestamp: 1717693144467
 - kind: conda
   name: appdirs
   version: 1.4.4
@@ -1302,7 +1318,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/appdirs
+  - pkg:pypi/appdirs?source=conda-forge-mapping
   size: 12840
   timestamp: 1603108499239
 - kind: conda
@@ -1319,7 +1335,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/appnope
+  - pkg:pypi/appnope?source=conda-forge-mapping
   size: 10241
   timestamp: 1707233195627
 - kind: conda
@@ -1340,7 +1356,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/argon2-cffi
+  - pkg:pypi/argon2-cffi?source=conda-forge-mapping
   size: 18602
   timestamp: 1692818472638
 - kind: conda
@@ -1359,7 +1375,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/argon2-cffi-bindings
+  - pkg:pypi/argon2-cffi-bindings?source=conda-forge-mapping
   size: 32556
   timestamp: 1695387174872
 - kind: conda
@@ -1379,7 +1395,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/argon2-cffi-bindings
+  - pkg:pypi/argon2-cffi-bindings?source=conda-forge-mapping
   size: 35142
   timestamp: 1695386704886
 - kind: conda
@@ -1401,7 +1417,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/argon2-cffi-bindings
+  - pkg:pypi/argon2-cffi-bindings?source=conda-forge-mapping
   size: 34750
   timestamp: 1695387347676
 - kind: conda
@@ -1420,7 +1436,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/arrow
+  - pkg:pypi/arrow?source=conda-forge-mapping
   size: 100096
   timestamp: 1696129131844
 - kind: conda
@@ -1438,7 +1454,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/asttokens
+  - pkg:pypi/asttokens?source=conda-forge-mapping
   size: 28922
   timestamp: 1698341257884
 - kind: conda
@@ -1455,7 +1471,7 @@ packages:
   - six >=1.6.1,<2.0
   license: BSD-3-Clause AND PSF-2.0
   purls:
-  - pkg:pypi/astunparse
+  - pkg:pypi/astunparse?source=conda-forge-mapping
   size: 15539
   timestamp: 1610696401707
 - kind: conda
@@ -1473,7 +1489,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/async-lru
+  - pkg:pypi/async-lru?source=conda-forge-mapping
   size: 15342
   timestamp: 1690563152778
 - kind: conda
@@ -1506,472 +1522,536 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/attrs
+  - pkg:pypi/attrs?source=conda-forge-mapping
   size: 54582
   timestamp: 1704011393776
 - kind: conda
   name: aws-c-auth
-  version: 0.7.16
-  build: h7613915_8
-  build_number: 8
+  version: 0.7.22
+  build: h8c86ca4_10
+  build_number: 10
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.16-h7613915_8.conda
-  sha256: 9ac4ebfc14faa7377a0df29ebf562d55e04a99d6d72f8ce8bb6a661e4753cde3
-  md5: 61c802b7e9c8d6215116c01ce7d582d9
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.22-h8c86ca4_10.conda
+  sha256: 76fb4adb653407b4c514fba7b08e0940869989d660c4b11dedb183c01f7bb77a
+  md5: 94493124319f290e7ad45228d54db509
   depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 99468
-  timestamp: 1710282357839
+  size: 101513
+  timestamp: 1720943471630
 - kind: conda
   name: aws-c-auth
-  version: 0.7.16
-  build: h9d28af5_8
-  build_number: 8
+  version: 0.7.22
+  build: hb04b931_10
+  build_number: 10
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.16-h9d28af5_8.conda
-  sha256: f75a39577b61fc649e3a8c926b91218ebad6ea78beb2f2b16f90d3ae9493c1c4
-  md5: 0b451cddce1ea8f9247b386ba3285edc
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.22-hb04b931_10.conda
+  sha256: b95a2f9adc0b77c88b10c6001eb101d6b76bb0efdf80a8fa7e99c510e8236ed2
+  md5: 58e7453d9442ec10c3bfbe3466502baf
   depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
+  - __osx >=10.13
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 90270
-  timestamp: 1710282294532
+  size: 92326
+  timestamp: 1720943225649
 - kind: conda
   name: aws-c-auth
-  version: 0.7.16
-  build: haed3651_8
+  version: 0.7.22
+  build: hbd3ac97_10
+  build_number: 10
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.22-hbd3ac97_10.conda
+  sha256: c8bf9f9901a56a56b18ab044d67ecde69ee1289881267924dd81670ac34591fe
+  md5: 7ca4abcc98c7521c02f4e8809bbe40df
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 105990
+  timestamp: 1720943253516
+- kind: conda
+  name: aws-c-cal
+  version: 0.7.1
+  build: h87b94db_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.1-h87b94db_1.conda
+  sha256: f445f38a4170f0ae02cdf13e1bc23cbb826a4b45f39402f02fe5737b0a8ed3a9
+  md5: 2d76d2cfdcfe2d5c3883d33d8be919e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 47092
+  timestamp: 1720901538926
+- kind: conda
+  name: aws-c-cal
+  version: 0.7.1
+  build: hd73d8db_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.1-hd73d8db_1.conda
+  sha256: 40d2903b718bd4ddf4706ff4e86831c11a012e1a662f73e30073b4f7f364fcca
+  md5: a8735aa1de30e27dc87bde25dd3201d8
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 39142
+  timestamp: 1720901553777
+- kind: conda
+  name: aws-c-cal
+  version: 0.7.1
+  build: hea5f451_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.1-hea5f451_1.conda
+  sha256: 24813fbc554c89a6fe26e319b773a4b977bdfbdd356fbc63aa28d5c3df9567c5
+  md5: 72dff54470c6fc809b845fac58d39aad
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 46905
+  timestamp: 1720901876108
+- kind: conda
+  name: aws-c-common
+  version: 0.9.23
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.23-h2466b09_0.conda
+  sha256: 728f9689bea381beebd8c94e333976eec5970bfe5a6a3bf981ee14f5a9229140
+  md5: df475c2b12da4aa32d4946a1453681f5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 234194
+  timestamp: 1718918578757
+- kind: conda
+  name: aws-c-common
+  version: 0.9.23
+  build: h4ab18f5_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.23-h4ab18f5_0.conda
+  sha256: f3eab0ec3f01ddc3ebdc235d4ae1b3b803d83e40f2cd2389bf8c65ab96e90f02
+  md5: 94d61ae2b2b701008a9d52ce6bbead27
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 235612
+  timestamp: 1718918062664
+- kind: conda
+  name: aws-c-common
+  version: 0.9.23
+  build: hfdf4475_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.23-hfdf4475_0.conda
+  sha256: 63680a7e163a947eb97f68cf1d5dd26fe0fef9443196de4fc31615b28d6095a7
+  md5: 35083fa12de9dc9918de60c112ceab27
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 225527
+  timestamp: 1718918230587
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.18
+  build: hd73d8db_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hd73d8db_7.conda
+  sha256: c8fabda8233f979f9c5173a5ba5f6482c26e8ac8af55e78550fff27e997e0dbd
+  md5: b082d6b9a40e41fd27f48786d318e910
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 18245
+  timestamp: 1718967218275
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.18
+  build: he027950_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-he027950_7.conda
+  sha256: d4c70b8716e19fe56a563ab858ab7440f41c2dd927687357a44e69f23001126d
+  md5: 11e5cb0b426772974f6416545baee0ce
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 19271
+  timestamp: 1718967071890
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.18
+  build: hea5f451_7
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hea5f451_7.conda
+  sha256: 76899d3e3c482fdbd49d7844dc03a4ead7b727e8978f79c5e2a569ef80d815e0
+  md5: 3834f2ba3431fe21692de035a7b992c1
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 22658
+  timestamp: 1718967658946
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.4.2
+  build: h2713d70_15
+  build_number: 15
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h2713d70_15.conda
+  sha256: 410497c0175beb16b9564ce43f44ed284f19ee1b42b968ad1bd69f4d3c49296a
+  md5: 21aeef6fb90f64d3625f06501c4d023c
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 46353
+  timestamp: 1720743940835
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.4.2
+  build: h4b8288a_15
+  build_number: 15
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h4b8288a_15.conda
+  sha256: b7d65c7cd46ae34608e296e7d642b0e8291eb3517a176138a3daa088c2495136
+  md5: 270c3f0f23c48f3ac0074c3e81bdabac
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 54326
+  timestamp: 1720744311520
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.4.2
+  build: h7671281_15
+  build_number: 15
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h7671281_15.conda
+  sha256: b9546f0637c66d4086a169f4210bf0d569140f41c13f0c1c6826355f51f82494
+  md5: 3b45b0da170f515de8be68155e14955a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 54007
+  timestamp: 1720743896466
+- kind: conda
+  name: aws-c-http
+  version: 0.8.2
+  build: h269d64e_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.2-h269d64e_6.conda
+  sha256: 7195e70551e3adea16e632b706e8beebfc1d494115942a5839b6edd689108bbc
+  md5: 1603ce5ebacad267b5b5d2c484c73679
+  depends:
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 180156
+  timestamp: 1720753340047
+- kind: conda
+  name: aws-c-http
+  version: 0.8.2
+  build: he17ee6b_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.2-he17ee6b_6.conda
+  sha256: c2a9501d5e361051457b0afc3ce77496a73c2cf90ad859010812130d512e9271
+  md5: 4e3d1bb2ade85619ac2163e695c2cc1b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 194638
+  timestamp: 1720753051593
+- kind: conda
+  name: aws-c-http
+  version: 0.8.2
+  build: he29c2fd_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.2-he29c2fd_6.conda
+  sha256: 8acfcfb37640b3482ddb7b8f43ca72a698c60ac3208e7f54edf47354cb21a382
+  md5: 9b1b61150532b6c5eda36700a408209d
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 162753
+  timestamp: 1720753184386
+- kind: conda
+  name: aws-c-io
+  version: 0.14.10
+  build: h4406d91_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.10-h4406d91_1.conda
+  sha256: 928f7fdffec3c8c3ee8cb5c2bcc6f23f404d89a9b260e4dac96eb8e12d959d31
+  md5: 975be62a8eb5e601ff6f888420dab870
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 137548
+  timestamp: 1720718795509
+- kind: conda
+  name: aws-c-io
+  version: 0.14.10
+  build: h826b7d6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.10-h826b7d6_1.conda
+  sha256: 68cb6f708e5e1cf50d98f3c896c7a72ab68e71ce9a69be4eea5dbde5c04bebdc
+  md5: 6961646dded770513a781de4cd5c1fe1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
+  - s2n >=1.4.17,<1.4.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 157925
+  timestamp: 1720718674802
+- kind: conda
+  name: aws-c-io
+  version: 0.14.10
+  build: hfca834b_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.10-hfca834b_1.conda
+  sha256: e487ef1ca72ca609e245184259f6a06d2304997fc1fe7e399ab7efcabc1337da
+  md5: edbdbf574dccbab97002d7408f42d334
+  depends:
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 159625
+  timestamp: 1720719292787
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.10.4
+  build: h519d897_8
+  build_number: 8
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h519d897_8.conda
+  sha256: 487c9db3d181b802fd56431bd5cbc79e6624b50f1b8fa1f2988adf4509155797
+  md5: b6a0c6760077bb28547ba3ce5ed04cd1
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 158054
+  timestamp: 1720751730919
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.10.4
+  build: hcd6a914_8
   build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.16-haed3651_8.conda
-  sha256: 75a540b313e5dc212fc0a6057f8a5bee2dda443f17a5a076bd3ea4d7195d483e
-  md5: ce96c083829ab2727c942243ac93ffe0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hcd6a914_8.conda
+  sha256: aa6100ed16b1b6eabccca1ee5e36039862e37a7ee91c852de8d4ca0082dcd54e
+  md5: b81c45867558446640306507498b2c6b
   depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
   - libgcc-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 103298
-  timestamp: 1710281865011
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
-  build: ha9bf9b1_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.10-ha9bf9b1_2.conda
-  sha256: e45d9f1eb862f566bdea3d3229dfc74f31e647a72198fe04aab58ccc03a30a37
-  md5: ce2471034f5459a39636aacc292c96b6
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 55421
-  timestamp: 1709815095625
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
-  build: hf6fcf4e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.10-hf6fcf4e_2.conda
-  sha256: 800b25ee5590f3ddd9186e225c756b9e5d00d3ecce8c2de5d9343af85213d883
-  md5: 7490ede93a75acc3589a2e43f77c79e9
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 55818
-  timestamp: 1709815582485
-- kind: conda
-  name: aws-c-cal
-  version: 0.6.10
-  build: hf9de6f9_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.10-hf9de6f9_2.conda
-  sha256: cb9b20aeec4cd037117fd0bfe2ae5a0a5f6a08a71f941be0f163bb27c87b98ea
-  md5: 393dbe9973160cb09cb3594c9246e260
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 45249
-  timestamp: 1709815427644
-- kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.14-h10d778d_0.conda
-  sha256: 1d207a8aee42700763e6a7801c69721ccc06ce75e62e0e5d8fc6df0197c0a88b
-  md5: c620ac518f3086eaf4f105f64908a57c
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 208228
-  timestamp: 1709669491258
-- kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.14-hcfcfb64_0.conda
-  sha256: 46f4dced6c9d553d65e6f721d51ef43e6a343487a3073299c03a073161d7637f
-  md5: 169998d49ac3c4800187bfc546e1d165
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 222375
-  timestamp: 1709669884758
-- kind: conda
-  name: aws-c-common
-  version: 0.9.14
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.14-hd590300_0.conda
-  sha256: c71dd835b1d8c7097c8d152a65680f119a203b73a6a62c5aac414bafe5e997ad
-  md5: d44fe0d9a6971a4fb245be0055775d9d
-  depends:
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 225655
-  timestamp: 1709669368566
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: h4466546_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h4466546_2.conda
-  sha256: 7fcc6a924691f9de65c82fd559cb1cb2ebd121c42da544a9a43623d69a284e23
-  md5: b0d9153fc7cfa8dc36b8703e1a59f5f3
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 19072
-  timestamp: 1709815144275
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: h905ab21_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h905ab21_2.conda
-  sha256: 021cee135f0d9b58fbc8d212618cd9bd6bd0012da41a6469edf010b2853dd3ef
-  md5: ffd7cfb55b1aa4e3eef477583b1ad87d
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 17930
-  timestamp: 1709815482244
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: hf6fcf4e_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hf6fcf4e_2.conda
-  sha256: ecb5ab2353c4499311fe17c82210955a498526c9563861777b3b0cd6dcc5cfea
-  md5: 6efdf7af73d7043a00394a2f1b039650
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 22366
-  timestamp: 1709815905155
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: h30f2259_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h30f2259_6.conda
-  sha256: 65ea5552f7a87783b75a3ecf6e4acd2aee5357c4275a9932d732ee516acab0a9
-  md5: 0923a8e81839b0b2d9787d85d635b196
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 46261
-  timestamp: 1710264045535
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: h3df98b0_6
-  build_number: 6
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h3df98b0_6.conda
-  sha256: 823a4665b3d38a4078b34b6f891bd388400942a3bcbad55b4c6223c559b15de6
-  md5: 80ca7e9993f6b0141ae5425a69771a9a
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 54211
-  timestamp: 1710264185867
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: he635cd5_6
-  build_number: 6
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-he635cd5_6.conda
-  sha256: 38a30beabafc1dd86c0264b6746315a1010e541a1b3ed7f97e1702873e5eaa51
-  md5: 58fc78e523e35a08423c913751a51fde
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 53665
-  timestamp: 1710263650074
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
-  build: h4e3df0f_7
-  build_number: 7
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.1-h4e3df0f_7.conda
-  sha256: 651bdcbe53630bf9665b76c18a6cb21a7b53fe347b03d88c1cb99ed0281c267e
-  md5: 08ba30d73686a5129f4209c25b31252a
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 180557
-  timestamp: 1710264351681
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
-  build: hbfc29b2_7
-  build_number: 7
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.1-hbfc29b2_7.conda
-  sha256: 0dc5b73aa31cef3faeeb902a11f12e1244ac241f995d73e4f4e3e0c01622f7a1
-  md5: 8476ec099649e9a6de52f7f4d916cd2a
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 194307
-  timestamp: 1710263686092
-- kind: conda
-  name: aws-c-http
-  version: 0.8.1
-  build: hce3b3da_7
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.1-hce3b3da_7.conda
-  sha256: a3e6bfd71bbc4119da1e79f2bce6094f045112c230b3fd5cc9e6ccd36aba3156
-  md5: d287122dfb77c5fa0147fdf368c86d54
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 162710
-  timestamp: 1710263951106
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: h96cd748_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.6-h96cd748_2.conda
-  sha256: 5d7c7af98276949cee0e731ecedbd7e80135a3c3c3ea8246808ebb270732ae69
-  md5: cbf8138080ea12e9d9d66cf7c8bee325
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
-  - s2n >=1.4.8,<1.4.9.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 157933
-  timestamp: 1711318121062
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: hf0b8b6f_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.6-hf0b8b6f_2.conda
-  sha256: 296fa165e91eb388c0a0ccc34bedc44c44cc1b89aab0e804b084203030b1e263
-  md5: e676be43454868d2520ce5fba70c78f2
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 160262
-  timestamp: 1711318595249
-- kind: conda
-  name: aws-c-io
-  version: 0.14.6
-  build: hf76ed93_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.6-hf76ed93_2.conda
-  sha256: ccb7eb57008cf89526694d5248878c6feffa9022aed0d657cb6a631b57f68026
-  md5: 95e1a36ee569ff79e7eeccaf0ec1fe76
-  depends:
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 137954
-  timestamp: 1711318271993
+  size: 164233
+  timestamp: 1720751408585
 - kind: conda
   name: aws-c-mqtt
-  version: 0.10.3
-  build: h96fac68_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.3-h96fac68_2.conda
-  sha256: 70b62dcf6314a9e1f514fe6f838eb02dfc4a28f4d17723768211a60c28c3429b
-  md5: 463c0be9e1fb416192174156f58bb2af
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 157436
-  timestamp: 1710283031953
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.10.3
-  build: ha335edc_2
-  build_number: 2
+  version: 0.10.4
+  build: hf6997d9_8
+  build_number: 8
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.3-ha335edc_2.conda
-  sha256: 99304e5095193b937745d0ce6812d0333186a31c41a51b1e4297ddcd962824eb
-  md5: c8bacb9a988fd8fb6b560a966c4979a8
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-hf6997d9_8.conda
+  sha256: 5b25821cd94e77459c7b0011df094d4ed67d04092639f84b79bf57e506eecd2e
+  md5: dfa33f1d17f9e18b54411bf2eeff0b55
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 139008
-  timestamp: 1710282888188
-- kind: conda
-  name: aws-c-mqtt
-  version: 0.10.3
-  build: hffff1cc_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.3-hffff1cc_2.conda
-  sha256: 6b2de4a0e6e907310127b1025a0030d023e1051da48ea5821dcc6db094d69ab7
-  md5: 14ad8defb307e1edb293c3fc9da8648f
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 163172
-  timestamp: 1710282530222
+  size: 138716
+  timestamp: 1720751463402
 - kind: conda
   name: aws-c-s3
-  version: 0.5.5
-  build: h08df315_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.5-h08df315_0.conda
-  sha256: c8c119c0cabab9fa9b59a0ebdbefd95b12545e461c9b8079b36d6cb0c0114769
-  md5: f35fbfa440d50fb7794d83f76d4adc48
+  version: 0.6.0
+  build: h13137a3_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.0-h13137a3_2.conda
+  sha256: f4bd86c0fa2e779ee01a8fa870177617d51467ea1cffa00a32e1e8abed2e0a5d
+  md5: 7564d61ed7073be23ca8fbce2fc5806a
   depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
+  - __osx >=10.13
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 95794
+  timestamp: 1720949972170
+- kind: conda
+  name: aws-c-s3
+  version: 0.6.0
+  build: h365ddd8_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.0-h365ddd8_2.conda
+  sha256: 5f82835411b3db3ae9d5db575386d83a8cc6f5f61b414afa6155879b2071c2f6
+  md5: 22339cf124753bafda336167f80e7860
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 110393
+  timestamp: 1720949912044
+- kind: conda
+  name: aws-c-s3
+  version: 0.6.0
+  build: hb746b11_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.0-hb746b11_2.conda
+  sha256: 55a9c0de5feee48492905b3bc8c33b530b79621fff5ab47989221e286f987635
+  md5: f2a22db8c6fa50b13b45e5b8f7d18f11
+  depends:
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -1979,473 +2059,536 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 101310
-  timestamp: 1712095344976
-- kind: conda
-  name: aws-c-s3
-  version: 0.5.5
-  build: h4893938_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.5-h4893938_0.conda
-  sha256: fef9c9a628f4f18b509a79bab6e9356724c957058464af5624757cc8c6f0536e
-  md5: 0086628487f8888df34f024a0a0d0289
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 105204
-  timestamp: 1712094810985
-- kind: conda
-  name: aws-c-s3
-  version: 0.5.5
-  build: h6f42f56_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.5-h6f42f56_0.conda
-  sha256: a8cbf29cd471db62b42c0191411d66e446f3454dbb2d5daebd07bee670c1688d
-  md5: 868fbd186bc64457777c705162fd0d88
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 91424
-  timestamp: 1712095165801
+  size: 106792
+  timestamp: 1720950156987
 - kind: conda
   name: aws-c-sdkutils
-  version: 0.1.15
-  build: h4466546_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.15-h4466546_2.conda
-  sha256: 349a05cf5fbcb3f6f358fc05098b210aa7da4ec3ab6d4719c79bb93b50a629f8
-  md5: 258194cedccd33fd8a7b95a8aa105015
+  version: 0.1.16
+  build: hd73d8db_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.16-hd73d8db_3.conda
+  sha256: b944db69a4bf7481362378d81ff634b5eeed88f0b85c6609f195cd68ab3a8948
+  md5: 7932c9b2420f0a809ab1b08e2ea53896
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 49533
+  timestamp: 1718973334715
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.16
+  build: he027950_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.16-he027950_3.conda
+  sha256: 0f957d8cebe9c9b4041c858ca9a20619eb3fa866c71b21478a02d51f219d59cb
+  md5: adbf0c44ca88a3cded175cd809a106b6
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   - libgcc-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 55383
-  timestamp: 1709830510021
+  size: 54943
+  timestamp: 1718973317061
 - kind: conda
   name: aws-c-sdkutils
-  version: 0.1.15
-  build: h905ab21_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.15-h905ab21_2.conda
-  sha256: 77f58ac3aec0cd987f80e202a8197e123beb13b9b25b0137dd921c7a6ddc86ac
-  md5: bb1523b7de7ac6f112b1992cfcfb250b
-  depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 50028
-  timestamp: 1709830709542
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.15
-  build: hf6fcf4e_2
-  build_number: 2
+  version: 0.1.16
+  build: hea5f451_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.15-hf6fcf4e_2.conda
-  sha256: 03f361182431688732e7173f0d71e5778e0616e68d9ebf994d3ecb70483468a0
-  md5: 87fb9f67d4c936a704d6a23a748fad77
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.16-hea5f451_3.conda
+  sha256: f7f80b7650ce03ca9700b8138df625ad4b2a1c49a20ff555cf0fbd4f4b6faa1b
+  md5: 367b3cc3a418fca38f7afc47e753c993
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 54282
-  timestamp: 1709830762581
+  size: 54072
+  timestamp: 1718973704299
 - kind: conda
   name: aws-checksums
   version: 0.1.18
-  build: h4466546_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h4466546_2.conda
-  sha256: 9080f064f572ac1747d32b4dff30452ff44ef2df399e6ec7bf9730da1eb99bba
-  md5: 8a04fc5a5ecaba31f66904b47dcc7797
+  build: hd73d8db_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hd73d8db_7.conda
+  sha256: a4e2dc37e4bbb2d64d1fac29c1d9fbc7c50ad3b5e15ff52e05ae63e8052e54d3
+  md5: c3f25d79d4a36a89b3c638a6e3614f28
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - libgcc-ng >=12
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 49940
-  timestamp: 1709826415680
+  size: 49210
+  timestamp: 1718973197891
 - kind: conda
   name: aws-checksums
   version: 0.1.18
-  build: h905ab21_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h905ab21_2.conda
-  sha256: 5760728e7320a01519bcbbae8dcd31b86e819f66c58f641b86b27ce592e5fff3
-  md5: f17e778398011e88d45edf58f24c18ae
+  build: he027950_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-he027950_7.conda
+  sha256: 094cff556dbf8fdd60505c8285b0a873de101374f568200275d8fd7fb77ad5e9
+  md5: 95611b325a9728ed68b8f7eef2dd3feb
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - libgcc-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 48733
-  timestamp: 1709826868797
+  size: 50220
+  timestamp: 1718973002363
 - kind: conda
   name: aws-checksums
   version: 0.1.18
-  build: hf6fcf4e_2
+  build: hea5f451_7
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hea5f451_7.conda
+  sha256: dfb5d5311ca15516739acd30a7cbfc9077a6164ded265a7247fbf52ea774aea2
+  md5: 1f9a89bde3856fe9feb32eb05f59f231
+  depends:
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 52585
+  timestamp: 1718973550940
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.27.3
+  build: h0a15bd7_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.3-h0a15bd7_2.conda
+  sha256: 718d350e8a0cf3bb09373da2e11820f3cb7e453fd95ad5ab14c104e4701b26bc
+  md5: 58f9e6e6e0848a4dda31c123c577107a
+  depends:
+  - __osx >=10.13
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 291354
+  timestamp: 1720963559899
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.27.3
+  build: h8c89294_2
   build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hf6fcf4e_2.conda
-  sha256: 1a67c0ee80cb2d18bd7cfc9ec1aae2ad78d51adc7ac9442ec70e370bbcef24de
-  md5: ffa6601a628ccc6ec5eddb0def2db1d2
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.3-h8c89294_2.conda
+  sha256: b9cec3aff15f0890d173813cb570d3bb7b7bf5df85ac6e08296d7134cc6e9c1c
+  md5: 0e2b0e8c97696f1584304ca9fe1e601e
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 52016
-  timestamp: 1709827173669
+  size: 255271
+  timestamp: 1720963842160
 - kind: conda
   name: aws-crt-cpp
-  version: 0.26.4
-  build: h25b5da4_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.4-h25b5da4_3.conda
-  sha256: 16c0d8f4d04f18e576ccf9fba2314956cd8667a0d14b1363cd627b600e87e890
-  md5: 0bfe8548d21b566e2bd65c2fed90869e
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.5,<0.5.6.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 283631
-  timestamp: 1712149674072
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.26.4
-  build: h58a74b7_3
-  build_number: 3
+  version: 0.27.3
+  build: hda66527_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.4-h58a74b7_3.conda
-  sha256: f6734310a4b948f4e838748c793b75fac8af195819e9986ae935ef8ab2632a8a
-  md5: 44b522426a11ab2afbd09b0746b0e4cd
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.3-hda66527_2.conda
+  sha256: 3149277f03a55d7dcffdbe489863cacc36a831dbf38b9725bdc653a8c5de134f
+  md5: 734875312c8196feecc91f89856da612
   depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-auth >=0.7.22,<0.7.23.0a0
+  - aws-c-cal >=0.7.1,<0.7.2.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.5,<0.5.6.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
+  - aws-c-http >=0.8.2,<0.8.3.0a0
+  - aws-c-io >=0.14.10,<0.14.11.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.0,<0.6.1.0a0
+  - aws-c-sdkutils >=0.1.16,<0.1.17.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 335999
-  timestamp: 1712149122782
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.26.4
-  build: h944602d_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.4-h944602d_3.conda
-  sha256: 7092bf5ce2f160721d0822a39fb800587c1c8b243d337ab2a66ff6e0a87677fe
-  md5: d3e3d8dc0a30c0670984af623711f3ff
-  depends:
-  - aws-c-auth >=0.7.16,<0.7.17.0a0
-  - aws-c-cal >=0.6.10,<0.6.11.0a0
-  - aws-c-common >=0.9.14,<0.9.15.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.1,<0.8.2.0a0
-  - aws-c-io >=0.14.6,<0.14.7.0a0
-  - aws-c-mqtt >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.5.5,<0.5.6.0a0
-  - aws-c-sdkutils >=0.1.15,<0.1.16.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 245195
-  timestamp: 1712149566037
+  size: 345359
+  timestamp: 1720963443140
 - kind: conda
   name: aws-sdk-cpp
-  version: 1.11.267
-  build: hb1af6a8_4
-  build_number: 4
+  version: 1.11.329
+  build: h46c3b66_9
+  build_number: 9
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-hb1af6a8_4.conda
-  sha256: b5515e6012fc858c6dd3ccf36009470d4ab6e3ba283934809112cca2874fb185
-  md5: 3e735ae06073894080acd78365e78936
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.329-h46c3b66_9.conda
+  sha256: 983f6977cc6b25c8bc785b20859970009242b3812e6b4de592ceb17caf93acb6
+  md5: c840f07ec58dc0b06041e7f36550a539
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - libcurl >=8.6.0,<9.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3617525
-  timestamp: 1711119330056
+  size: 3619739
+  timestamp: 1720816476436
 - kind: conda
   name: aws-sdk-cpp
-  version: 1.11.267
-  build: hd2aab46_4
-  build_number: 4
+  version: 1.11.329
+  build: h554caeb_9
+  build_number: 9
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.267-hd2aab46_4.conda
-  sha256: ce10e38c01771663a0491a5190078484c5c3ae7be315e5b02fc1bc87e4c9856e
-  md5: 76c6a4d1839a71361c31d9bcce3601b7
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.329-h554caeb_9.conda
+  sha256: a9b6751a5a80f8713e55256afccdd96efd3442b9791ce8bd2e40c49ac0dc95f6
+  md5: a875dc66bc06f0bf49dc9739e6e2fbab
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - __osx >=10.13
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - libcurl >=8.6.0,<9.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3397066
-  timestamp: 1711120157637
+  size: 3417533
+  timestamp: 1720817049208
 - kind: conda
   name: aws-sdk-cpp
-  version: 1.11.267
-  build: hfaf0dd0_4
-  build_number: 4
+  version: 1.11.329
+  build: he0aa860_9
+  build_number: 9
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.267-hfaf0dd0_4.conda
-  sha256: c56437510d5f2fe9d41f55809b081d79a861ba9e14c79440584bc8943f6eda76
-  md5: d0530648ca0f77252b70ae9f8c31c0df
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.329-he0aa860_9.conda
+  sha256: 293cb078bb0d85d480a9bb07e4baeaa88992932961f533a6ceff484f0ec71a48
+  md5: 4fe9877157ca105fce0608c339c2f5b1
   depends:
-  - aws-c-common >=0.9.14,<0.9.15.0a0
+  - aws-c-common >=0.9.23,<0.9.24.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3420008
-  timestamp: 1711120472446
+  size: 3443586
+  timestamp: 1720817600288
 - kind: conda
   name: azure-core-cpp
-  version: 1.11.1
-  build: h249a519_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.11.1-h249a519_1.conda
-  sha256: 5cfaed8d28aeceb700b524cff6285777de3a9a732acf7cef4994818df93301f3
-  md5: c4d3c999a102779040815db07d1a2928
+  version: 1.13.0
+  build: h935415a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
+  sha256: b7e0a22295db2e1955f89c69cefc32810309b3af66df986d9fb75d89f98a80f7
+  md5: debd1677c2fea41eb2233a260f48a298
   depends:
-  - libcurl >=8.5.0,<9.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 338134
+  timestamp: 1720853194547
+- kind: conda
+  name: azure-core-cpp
+  version: 1.13.0
+  build: haf5610f_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.13.0-haf5610f_0.conda
+  sha256: e3d828f79368057258140e46404892b0ed8983797c05c04eac3bd24dea71da41
+  md5: 14ed34c3091f89784d926cc7cf4b773b
+  depends:
+  - libcurl >=8.8.0,<9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 485251
-  timestamp: 1707404588911
+  size: 487099
+  timestamp: 1720853456727
 - kind: conda
   name: azure-core-cpp
-  version: 1.11.1
-  build: h91d86a7_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.11.1-h91d86a7_1.conda
-  sha256: 810a890bf66d6368637399ef415dcc8152acd28f4b4b61d4048b7be7cba17d4c
-  md5: 2dbab1d281b7e1da05eee544cbdc8af6
-  depends:
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 342651
-  timestamp: 1707403920150
-- kind: conda
-  name: azure-core-cpp
-  version: 1.11.1
-  build: hbb1e571_1
-  build_number: 1
+  version: 1.13.0
+  build: hf8dbe3c_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.11.1-hbb1e571_1.conda
-  sha256: 4b22a5e01ebd7f09c869cea73ae4853fb18a10a5716c8984598327e34eb2f9da
-  md5: 6e982efd0947cd3e9ba4223fbd988508
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.13.0-hf8dbe3c_0.conda
+  sha256: 1976259d75ef68431039522d7105777ac0621ef8a0f8a31140fa8926b1fe1280
+  md5: 514d3cbb527a88930e816370e34caa19
   depends:
-  - libcurl >=8.5.0,<9.0a0
+  - __osx >=10.13
+  - libcurl >=8.8.0,<9.0a0
   - libcxx >=16
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 300137
-  timestamp: 1707404257146
+  size: 296234
+  timestamp: 1720853326346
 - kind: conda
-  name: azure-storage-blobs-cpp
-  version: 12.10.0
-  build: h00ab1b0_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.10.0-h00ab1b0_1.conda
-  sha256: c88f6bc72ef42fd09471d4c4b2293fa17f730e3ba10290a0bb86de0ff7e9b195
-  md5: 1e63d3866554a4d2e3d1cba5f21a2841
-  depends:
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
-  - azure-storage-common-cpp >=12.5.0,<12.5.1.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 517087
-  timestamp: 1707950609283
-- kind: conda
-  name: azure-storage-blobs-cpp
-  version: 12.10.0
-  build: h7728843_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.10.0-h7728843_1.conda
-  sha256: 2c68d1d28bdf9d465843bdb6818868e0b0af46dafc1f4e41df0af33241707113
-  md5: dc24ba551b749b6bab11e0ef22dc3438
-  depends:
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
-  - azure-storage-common-cpp >=12.5.0,<12.5.1.0a0
-  - libcxx >=16
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 411847
-  timestamp: 1707950907168
-- kind: conda
-  name: azure-storage-blobs-cpp
-  version: 12.10.0
-  build: h91493d7_1
-  build_number: 1
+  name: azure-identity-cpp
+  version: 1.8.0
+  build: h148e6f0_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.10.0-h91493d7_1.conda
-  sha256: e3444d2331c9b40c68a8c5dc07ca3b7cc6c610ab6a23c2ca192f2f93ea5d18b9
-  md5: a542efec5e16debff638674a0fee1316
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h148e6f0_2.conda
+  sha256: 1d5c52c0619d4ab1be47cd7958c5c9ecc327b0f5854ae0354b7c9cc60c73afe4
+  md5: 83ec332c6f07f9e48c8d5706cceab962
   depends:
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
-  - azure-storage-common-cpp >=12.5.0,<12.5.1.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 961363
-  timestamp: 1707951394595
+  size: 383395
+  timestamp: 1721777916149
 - kind: conda
-  name: azure-storage-common-cpp
-  version: 12.5.0
-  build: h0e82ce4_4
-  build_number: 4
+  name: azure-identity-cpp
+  version: 1.8.0
+  build: h60298e3_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-h0e82ce4_4.conda
-  sha256: ecff365d3cdf3b5b04a6f823ec75b07459fb6cc312475180f7a33a237242ea27
-  md5: 8a980ef5c6bc0677f5a60d5d60a4efdd
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h60298e3_2.conda
+  sha256: 7bc11d77aab926aff437b6afc089fe937ab03b9f09d679520d4d4a91717b5337
+  md5: 29dc05d3b825fd7e2efe0263621c2fdb
   depends:
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
+  - __osx >=10.13
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
   - libcxx >=16
-  - libxml2 >=2.12.5,<3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 110010
-  timestamp: 1707412948544
+  size: 148019
+  timestamp: 1721777648770
 - kind: conda
-  name: azure-storage-common-cpp
-  version: 12.5.0
-  build: h91493d7_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_4.conda
-  sha256: 65e56d7a782db1036d4ef47aa701037fb96849247de03db874e511e8a2791cb5
-  md5: 2a7ee0e1ffc37e91aa5c1d59d4aea8b8
+  name: azure-identity-cpp
+  version: 1.8.0
+  build: hd126650_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
+  sha256: f85452eca3ae0e156b1d1a321a1a9f4f58d44ff45236c0d8602ab96aaad3c6ba
+  md5: 36df3cf05459de5d0a41c77c4329634b
   depends:
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 199516
+  timestamp: 1721777604325
+- kind: conda
+  name: azure-storage-blobs-cpp
+  version: 12.12.0
+  build: h646f05d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.12.0-h646f05d_0.conda
+  sha256: 7153e4ba0112246fc93b2b6631c17b1c2c4f7878f2c4a25426e38a78a0b4cd4c
+  md5: d3f572c8ebf9ad5cdc07558b3b2c27ce
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 423224
+  timestamp: 1721865021128
+- kind: conda
+  name: azure-storage-blobs-cpp
+  version: 12.12.0
+  build: hd2e3451_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
+  sha256: 69a0f5c2a08a1a40524b343060debb8d92295e2cc5805c3db56dad7a41246a93
+  md5: 61f1c193452f0daa582f39634627ea33
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 523120
+  timestamp: 1721865032339
+- kind: conda
+  name: azure-storage-blobs-cpp
+  version: 12.12.0
+  build: hf03c1c4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.12.0-hf03c1c4_0.conda
+  sha256: 27a8b5df83d650129fb7ed4f73272f08bd92f72c2622e96c5145048ee442a39f
+  md5: 093769d5e96a6940cf10086af031dbca
+  depends:
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 223885
-  timestamp: 1707412994783
+  size: 967558
+  timestamp: 1721865277797
 - kind: conda
   name: azure-storage-common-cpp
-  version: 12.5.0
-  build: h94269e2_4
-  build_number: 4
+  version: 12.7.0
+  build: h10ac4d7_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-h94269e2_4.conda
-  sha256: 7143e85cfadcc3c789c879e66c3e6dbf8b6d5822d1d75b5b3063955279348233
-  md5: f364272cb4c2f4ce2341067107b82865
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.7.0-h10ac4d7_1.conda
+  sha256: 1030fa54497a73eb78c509d451f25701e2e781dc182e7647f55719f1e1f9bee8
+  md5: ab6d507ad16dbe2157920451d662e4a1
   depends:
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.5,<3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 132389
-  timestamp: 1707412427618
+  size: 143039
+  timestamp: 1721832724803
+- kind: conda
+  name: azure-storage-common-cpp
+  version: 12.7.0
+  build: h148e6f0_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.7.0-h148e6f0_1.conda
+  sha256: e65871ff5c3f6e19d21f9e98318de93fbed2ead70f1e6f379246c5e696bd87a7
+  md5: 9802dfd947dba7777ffcb25078c59c2d
+  depends:
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 239921
+  timestamp: 1721833165139
+- kind: conda
+  name: azure-storage-common-cpp
+  version: 12.7.0
+  build: hf91904f_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.7.0-hf91904f_1.conda
+  sha256: 333599899b25ef22e2a2e1c09bab75203da9f47612e1ff2a40fddae76feb08eb
+  md5: 99146c62f4b2a74c3026f128f42e35bf
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<3.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 124472
+  timestamp: 1721832914540
+- kind: conda
+  name: azure-storage-files-datalake-cpp
+  version: 12.11.0
+  build: h14965f0_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-files-datalake-cpp-12.11.0-h14965f0_1.conda
+  sha256: 73ada329714a4893238737d77be147b1e1412f80fa94191c3f686eae0bee459c
+  md5: d99c3c0c72b11340028cac4689835c0c
+  depends:
+  - __osx >=10.13
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 192115
+  timestamp: 1721925157499
+- kind: conda
+  name: azure-storage-files-datalake-cpp
+  version: 12.11.0
+  build: h325d260_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.11.0-h325d260_1.conda
+  sha256: 1726fa324bb402e52d63227d6cb3f849957cd6841f8cb8aed58bb0c81203befb
+  md5: 11d926d1f4a75a1b03d1c053ca20424b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 274492
+  timestamp: 1721925100762
 - kind: conda
   name: babel
   version: 2.14.0
@@ -2462,26 +2605,26 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/babel
+  - pkg:pypi/babel?source=conda-forge-mapping
   size: 7609750
   timestamp: 1702422720584
 - kind: conda
   name: beartype
-  version: 0.18.2
+  version: 0.18.5
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.2-pyhd8ed1ab_0.conda
-  sha256: ff24717e1a950a1f4410ffba318be3f08f63dd775410d480498d8eb54bbe0306
-  md5: 6d7bc2cc64a16ef059b75fa651288b1c
+  url: https://conda.anaconda.org/conda-forge/noarch/beartype-0.18.5-pyhd8ed1ab_0.conda
+  sha256: b68b7db7b849d999c5cc97b831e06a490c3dcb64aad84367c0969139a7a8f844
+  md5: 28786996506a2f2dd7819b5f3705f4e4
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/beartype
-  size: 753227
-  timestamp: 1712136582296
+  - pkg:pypi/beartype?source=conda-forge-mapping
+  size: 766954
+  timestamp: 1713735111213
 - kind: conda
   name: beautifulsoup4
   version: 4.12.3
@@ -2497,7 +2640,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/beautifulsoup4
+  - pkg:pypi/beautifulsoup4?source=conda-forge-mapping
   size: 118200
   timestamp: 1705564819537
 - kind: conda
@@ -2518,79 +2661,79 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/bleach
-  - pkg:pypi/html5lib
+  - pkg:pypi/bleach?source=conda-forge-mapping
   size: 131220
   timestamp: 1696630354218
 - kind: conda
   name: blosc
-  version: 1.21.5
-  build: h0f2a231_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
-  sha256: e2b15b017775d1bda8edbb1bc48e545e45364edefa4d926732fc5488cc600731
-  md5: 009521b7ed97cca25f8f997f9e745976
+  version: 1.21.6
+  build: h7d75f6d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.6-h7d75f6d_0.conda
+  sha256: 65e5f5dd3d68ed0d9d35e79d64f8141283cad2b55dcd9a04480ceea0e436aca8
+  md5: 3e5669e51737d04f4806dd3e8c424663
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - __osx >=10.13
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 48692
-  timestamp: 1693657088079
+  size: 47051
+  timestamp: 1719266142315
 - kind: conda
   name: blosc
-  version: 1.21.5
-  build: hdccc3a2_0
+  version: 1.21.6
+  build: h85f69ea_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
-  sha256: 73cee35e5366ce998ef36ccccb4c11ef9ead297886cc08269379f91539131288
-  md5: 77a5cea2ce92907b7d1e7954457a526a
+  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
+  md5: 2390269374fded230fcbca8332a4adc0
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
+  - snappy >=1.2.0,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 50069
-  timestamp: 1693657396550
+  size: 50135
+  timestamp: 1719266616208
 - kind: conda
   name: blosc
-  version: 1.21.5
-  build: heccf04b_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
-  sha256: db629047f1721d5a6e3bd41b07c1a3bacd0dee70f4063b61db2aa46f19a0b8b4
-  md5: 3003fa6dd18769db1a616982dcee5b40
+  version: 1.21.6
+  build: hef167b5_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-hef167b5_0.conda
+  sha256: 6cc260f9c6d32c5e728a2099a52fdd7ee69a782fff7b400d0606fcd32e0f5fd1
+  md5: 54fe76ab3d0189acaef95156874db7f9
   depends:
-  - libcxx >=15.0.7
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 49891
-  timestamp: 1693657206065
+  size: 48842
+  timestamp: 1719266029046
 - kind: conda
   name: bokeh
-  version: 3.4.0
+  version: 3.5.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.4.0-pyhd8ed1ab_0.conda
-  sha256: a980687100456202425af0936185ef95c53309044e271daa60d2eeb009410f73
-  md5: eebbbfdb7eb885ddc751c790c3d0ad64
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.5.1-pyhd8ed1ab_0.conda
+  sha256: 3f6558cecdcd2c7865cb43a5b67b66e2387c2f6531eb45b236f33a3c496f4c2f
+  md5: d1e7e496405a75fd48ea94f2560c6843
   depends:
   - contourpy >=1.2
   - jinja2 >=2.9
@@ -2598,16 +2741,16 @@ packages:
   - packaging >=16.8
   - pandas >=1.2
   - pillow >=7.1.0
-  - python >=3.9
+  - python >=3.10
   - pyyaml >=3.10
   - tornado >=6.2
   - xyzservices >=2021.09.1
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/bokeh
-  size: 4997504
-  timestamp: 1710486159794
+  - pkg:pypi/bokeh?source=conda-forge-mapping
+  size: 4774914
+  timestamp: 1721988747522
 - kind: pypi
   name: bokeh-helpers
   version: 0.0.1
@@ -2620,22 +2763,22 @@ packages:
   editable: true
 - kind: conda
   name: branca
-  version: 0.7.1
+  version: 0.7.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
-  sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
-  md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.2-pyhd8ed1ab_0.conda
+  sha256: 9f7df349cb5a8852804d5bb1f5f49e3076a55ac7229b9c114bb5f7461f497ba7
+  md5: 5f1c719f1cac0aee5e6bd6ca7d54a7fa
   depends:
   - jinja2 >=3
   - python >=3.7
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/branca
-  size: 29211
-  timestamp: 1706711216173
+  - pkg:pypi/branca?source=conda-forge-mapping
+  size: 28923
+  timestamp: 1714071906758
 - kind: conda
   name: brotli
   version: 1.1.0
@@ -2768,7 +2911,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/brotli
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 350604
   timestamp: 1695990206327
 - kind: conda
@@ -2791,7 +2934,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/brotli
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 322514
   timestamp: 1695991054894
 - kind: conda
@@ -2812,32 +2955,18 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/brotli
+  - pkg:pypi/brotli?source=conda-forge-mapping
   size: 366883
   timestamp: 1695990710194
 - kind: conda
   name: bzip2
   version: 1.0.8
-  build: h10d778d_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
-  sha256: 61fb2b488928a54d9472113e1280b468a309561caa54f33825a3593da390b242
-  md5: 6097a6ca9ada32699b5fc4312dd6ef18
-  license: bzip2-1.0.6
-  license_family: BSD
-  purls: []
-  size: 127885
-  timestamp: 1699280178474
-- kind: conda
-  name: bzip2
-  version: 1.0.8
-  build: hcfcfb64_5
-  build_number: 5
+  build: h2466b09_7
+  build_number: 7
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
-  sha256: ae5f47a5c86fd6db822931255dcf017eb12f60c77f07dc782ccb477f7808aab2
-  md5: 26eb8ca6ea332b675e11704cce84a3be
+  url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
+  sha256: 35a5dad92e88fdd7fc405e864ec239486f4f31eec229e31686e61a140a8e573b
+  md5: 276e7ffe9ffe39688abc665ef0f45596
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -2845,45 +2974,49 @@ packages:
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
-  size: 124580
-  timestamp: 1699280668742
+  size: 54927
+  timestamp: 1720974860185
 - kind: conda
   name: bzip2
   version: 1.0.8
-  build: hd590300_5
-  build_number: 5
+  build: h4bc722e_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
-  sha256: 242c0c324507ee172c0e0dd2045814e746bb303d1eb78870d182ceb0abc726a8
-  md5: 69b8b6202a07720f448be700e300ccf4
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
+  sha256: 5ced96500d945fb286c9c838e54fa759aa04a7129c59800f0846b4335cee770d
+  md5: 62ee74e96c5ebb0af99386de58cf9553
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   license: bzip2-1.0.6
   license_family: BSD
   purls: []
-  size: 254228
-  timestamp: 1699279927352
+  size: 252783
+  timestamp: 1720974456583
 - kind: conda
-  name: c-ares
-  version: 1.28.1
-  build: h10d778d_0
+  name: bzip2
+  version: 1.0.8
+  build: hfdf4475_7
+  build_number: 7
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
-  sha256: fccd7ad7e3dfa6b19352705b33eb738c4c55f79f398e106e6cf03bab9415595a
-  md5: d5eb7992227254c0e9a0ce71151f0079
-  license: MIT
-  license_family: MIT
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
+  sha256: cad153608b81fb24fc8c509357daa9ae4e49dfc535b2cb49b91e23dbd68fc3c5
+  md5: 7ed4301d437b59045be7e051a0308211
+  depends:
+  - __osx >=10.13
+  license: bzip2-1.0.6
+  license_family: BSD
   purls: []
-  size: 152607
-  timestamp: 1711819681694
+  size: 134188
+  timestamp: 1720974491916
 - kind: conda
   name: c-ares
-  version: 1.28.1
-  build: hcfcfb64_0
+  version: 1.32.3
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.28.1-hcfcfb64_0.conda
-  sha256: 44ded34fdac46d4a37942c1cae3fc871dc6ecb13e0408442c6f8797671b332e6
-  md5: 3b2a518680f790a79a7e77bad1861c3a
+  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.32.3-h2466b09_0.conda
+  sha256: 91e3568f5708916b28863d672120e67f85f86d3d9d892aabe6012153702aa045
+  md5: eb6bcf1d4a0bb3ab98d4bbd402534b80
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -2891,59 +3024,75 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 159060
-  timestamp: 1711820066438
+  size: 165093
+  timestamp: 1721835227167
 - kind: conda
   name: c-ares
-  version: 1.28.1
-  build: hd590300_0
+  version: 1.32.3
+  build: h4bc722e_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
-  sha256: cb25063f3342149c7924b21544109696197a9d774f1407567477d4f3026bf38a
-  md5: dcde58ff9a1f30b0037a2315d1846d1f
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.32.3-h4bc722e_0.conda
+  sha256: 3c5a844bb60b0d52d89c3f1bd828c9856417fe33a6102fd8bbd5c13c3351704a
+  md5: 7624e34ee6baebfc80d67bac76cc9d9d
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 168875
-  timestamp: 1711819445938
+  size: 179736
+  timestamp: 1721834714515
+- kind: conda
+  name: c-ares
+  version: 1.32.3
+  build: h51dda26_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.32.3-h51dda26_0.conda
+  sha256: 2454287fa7d32b2cd089ad2bb46c8f8634b6f409d6fa8892c37ccc66134ec076
+  md5: 5487b45a597e142da7839941ab2494a9
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 160304
+  timestamp: 1721834876236
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.7.4
   build: h56e8100_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-  sha256: 4d587088ecccd393fec3420b64f1af4ee1a0e6897a45cfd5ef38055322cea5d0
-  md5: 63da060240ab8087b60d1357051ea7d6
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
+  sha256: 7f37bb33c7954de1b4d19ad622859feb4f6c58f751c38b895524cad4e44af72e
+  md5: 9caa97c9504072cd060cf0a3142cc0ed
   license: ISC
   purls: []
-  size: 155886
-  timestamp: 1706843918052
+  size: 154943
+  timestamp: 1720077592592
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.7.4
   build: h8857fd0_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
-  sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
-  md5: f2eacee8c33c43692f1ccfd33d0f50b1
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
+  sha256: d16f46c489cb3192305c7d25b795333c5fc17bb0986de20598ed519f8c9cc9e4
+  md5: 7df874a4b05b2d2b82826190170eaa0f
   license: ISC
   purls: []
-  size: 155665
-  timestamp: 1706843838227
+  size: 154473
+  timestamp: 1720077510541
 - kind: conda
   name: ca-certificates
-  version: 2024.2.2
+  version: 2024.7.4
   build: hbcca054_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
-  sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
-  md5: 2f4327a1cbe7f022401b236e915a5fef
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
+  sha256: c1548a3235376f464f9931850b64b02492f379b2f2bb98bc786055329b080446
+  md5: 23ab7665c5f63cfb9f1f6195256daac6
   license: ISC
   purls: []
-  size: 155432
-  timestamp: 1706843687645
+  size: 154853
+  timestamp: 1720077432978
 - kind: conda
   name: cached-property
   version: 1.5.2
@@ -2977,121 +3126,124 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/cached-property
+  - pkg:pypi/cached-property?source=conda-forge-mapping
   size: 11065
   timestamp: 1615209567874
 - kind: conda
   name: cachetools
-  version: 5.3.3
+  version: 5.4.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.3.3-pyhd8ed1ab_0.conda
-  sha256: 561b860cba68da76cab8c6504bb5bfb4756ecb2ec9f124d0c17e76caad4f6dfd
-  md5: cd4c26c702a9bcdc70ff05b609ddacbe
+  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+  sha256: 02f52917d6724960629c20dbdf9f8def95b1784acd600763ea41af47d905afbd
+  md5: c55fbbc5bac8e9efbba71c0d1ed57713
   depends:
   - python >=3.7
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/cachetools
-  size: 14665
-  timestamp: 1708987821240
+  - pkg:pypi/cachetools?source=conda-forge-mapping
+  size: 14722
+  timestamp: 1721092006298
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: h1fef639_0
+  build: h37bd5c4_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
+  sha256: 8d70fbca4887b9b580de0f3715026e05f9e74fad8a652364aa0bccd795b1fa87
+  md5: 448aad56614db52338dc4fd4c758cfb6
+  depends:
+  - __osx >=10.13
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
+  - zlib
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 892544
+  timestamp: 1721139116538
+- kind: conda
+  name: cairo
+  version: 1.18.0
+  build: h91e5215_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
-  sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
-  md5: b3fe2c6381ec74afe8128e16a11eee02
+  url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h91e5215_2.conda
+  sha256: 89568f4f6844c8c195457fbb2ce39acd9a727be4daadebc2464455db2fda143c
+  md5: 7a0b2818b003bd79106c29f55126d2c3
   depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - icu >=73.2,<74.0a0
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.4,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zlib
   license: LGPL-2.1-only or MPL-1.1
   purls: []
-  size: 1520159
-  timestamp: 1697029136038
+  size: 1519852
+  timestamp: 1718986279087
 - kind: conda
   name: cairo
   version: 1.18.0
-  build: h3faef2a_0
+  build: hbb29018_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
-  sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
-  md5: f907bb958910dc404647326ca80c263e
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hbb29018_2.conda
+  sha256: 51cfaf4669ad83499b3da215b915c503d36faf6edf6db4681a70b5710842a86c
+  md5: b6d90276c5aee9b4407dd94eb0cd40a8
   depends:
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
+  - libglib >=2.80.2,<3.0a0
+  - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.43.2,<1.0a0
   - xorg-libice >=1.1.1,<2.0a0
   - xorg-libsm >=1.2.4,<2.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
   - zlib
   license: LGPL-2.1-only or MPL-1.1
   purls: []
-  size: 982351
-  timestamp: 1697028423052
-- kind: conda
-  name: cairo
-  version: 1.18.0
-  build: h99e66fa_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
-  sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
-  md5: 13f830b1bf46018f7062d1b798d53eca
-  depends:
-  - __osx >=10.9
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - icu >=73.2,<74.0a0
-  - libcxx >=16.0.6
-  - libglib >=2.78.0,<3.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pixman >=0.42.2,<1.0a0
-  - zlib
-  license: LGPL-2.1-only or MPL-1.1
-  purls: []
-  size: 885311
-  timestamp: 1697028802967
+  size: 984224
+  timestamp: 1718985592664
 - kind: conda
   name: certifi
-  version: 2024.2.2
+  version: 2024.7.4
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.2.2-pyhd8ed1ab_0.conda
-  sha256: f1faca020f988696e6b6ee47c82524c7806380b37cfdd1def32f92c326caca54
-  md5: 0876280e409658fc6f9e75d035960333
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
+  sha256: dd3577bb5275062c388c46b075dcb795f47f8dac561da7dd35fe504b936934e5
+  md5: 24e7fd6ca65997938fff9e5ab6f653e4
   depends:
   - python >=3.7
   license: ISC
   purls:
-  - pkg:pypi/certifi
-  size: 160559
-  timestamp: 1707022289175
+  - pkg:pypi/certifi?source=conda-forge-mapping
+  size: 159308
+  timestamp: 1720458053074
 - kind: conda
   name: cffi
   version: 1.16.0
@@ -3108,7 +3260,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/cffi
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 282370
   timestamp: 1696002004433
 - kind: conda
@@ -3129,7 +3281,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/cffi
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 287805
   timestamp: 1696002408940
 - kind: conda
@@ -3149,7 +3301,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/cffi
+  - pkg:pypi/cffi?source=conda-forge-mapping
   size: 294523
   timestamp: 1696001868949
 - kind: conda
@@ -3166,65 +3318,66 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/cfgv
+  - pkg:pypi/cfgv?source=conda-forge-mapping
   size: 10788
   timestamp: 1629909423398
 - kind: conda
   name: cfitsio
-  version: 4.4.0
-  build: h60fb419_0
+  version: 4.4.1
+  build: ha105788_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.0-h60fb419_0.conda
-  sha256: 476c45686fd8b3309117fc5c37ce29338f6f241f2598e3506f85ca196fc41cc9
-  md5: fea202fa33621a6c8a8a7146af6b34b7
+  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.1-ha105788_0.conda
+  sha256: 6b54b24abd3122d33d80a59a901cd51b26b6d47fbb9f84c2bf1f87606e9899c6
+  md5: 99445be39aaea44a05046c479f8c6dc9
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.5.0,<9.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: LicenseRef-fitsio
   purls: []
-  size: 852978
-  timestamp: 1709219464153
+  size: 849075
+  timestamp: 1718906514228
 - kind: conda
   name: cfitsio
-  version: 4.4.0
-  build: h9b0cee5_0
+  version: 4.4.1
+  build: hc2ea260_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.0-h9b0cee5_0.conda
-  sha256: aa7f6925a289a09c0009b74b0ed67ed760e05554928336c3834e7d23e25379df
-  md5: 02210be7da0ce4dddad3e566c03a0864
+  url: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.1-hc2ea260_0.conda
+  sha256: 97249ec67f115c05a2a452e62f6aed2e3f3a244ba1f33b0e9395a05f9d7f6fee
+  md5: b3263858e6a924d05dc2e9ce335593ba
   depends:
-  - libcurl >=8.5.0,<9.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LicenseRef-fitsio
   purls: []
-  size: 605317
-  timestamp: 1709219624793
+  size: 601046
+  timestamp: 1718906922426
 - kind: conda
   name: cfitsio
-  version: 4.4.0
-  build: hbdc6101_0
+  version: 4.4.1
+  build: hf8ad068_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.0-hbdc6101_0.conda
-  sha256: fe50510b705d2adf6f7c162293f788ee7fa2eebd33adf30856723667e6a45586
-  md5: 446ac3db6cb017e3dd067cc35cf51442
+  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.1-hf8ad068_0.conda
+  sha256: 74ed4d8b327fa775d9c87e476a7221b74fb913aadcef207622596a99683c8faf
+  md5: 1b7a01fd02d11efe0eb5a676842a7b7d
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libcurl >=8.5.0,<9.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libgcc-ng >=12
   - libgfortran-ng
   - libgfortran5 >=12.3.0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: LicenseRef-fitsio
   purls: []
-  size: 913079
-  timestamp: 1709219211192
+  size: 924198
+  timestamp: 1718906379286
 - kind: conda
   name: charset-normalizer
   version: 3.3.2
@@ -3239,7 +3392,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/charset-normalizer
+  - pkg:pypi/charset-normalizer?source=conda-forge-mapping
   size: 46597
   timestamp: 1698833765762
 - kind: conda
@@ -3257,7 +3410,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click
+  - pkg:pypi/click?source=conda-forge-mapping
   size: 84437
   timestamp: 1692311973840
 - kind: conda
@@ -3276,7 +3429,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click
+  - pkg:pypi/click?source=conda-forge-mapping
   size: 85051
   timestamp: 1692312207348
 - kind: conda
@@ -3294,7 +3447,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click-plugins
+  - pkg:pypi/click-plugins?source=conda-forge-mapping
   size: 8992
   timestamp: 1554588104889
 - kind: conda
@@ -3313,7 +3466,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/cligj
+  - pkg:pypi/cligj?source=conda-forge-mapping
   size: 10255
   timestamp: 1633637895378
 - kind: conda
@@ -3330,7 +3483,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/colorama
+  - pkg:pypi/colorama?source=conda-forge-mapping
   size: 25170
   timestamp: 1666700778190
 - kind: conda
@@ -3348,7 +3501,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/comm
+  - pkg:pypi/comm?source=conda-forge-mapping
   size: 12134
   timestamp: 1710320435158
 - kind: conda
@@ -3369,7 +3522,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/contourpy
+  - pkg:pypi/contourpy?source=conda-forge-mapping
   size: 206433
   timestamp: 1712430299728
 - kind: conda
@@ -3389,7 +3542,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/contourpy
+  - pkg:pypi/contourpy?source=conda-forge-mapping
   size: 256764
   timestamp: 1712430146809
 - kind: conda
@@ -3408,36 +3561,19 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/contourpy
+  - pkg:pypi/contourpy?source=conda-forge-mapping
   size: 248928
   timestamp: 1712430234380
 - kind: conda
   name: coverage
-  version: 7.4.4
-  build: py312h41838bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.4-py312h41838bb_0.conda
-  sha256: f06b2e27da00e0413c3daa2904823ffcdcee51a8aacfcaa8304cb5b0abb3f241
-  md5: b0e22bba5fbc3c8d02e25aeb33475fce
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - tomli
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/coverage
-  size: 354763
-  timestamp: 1710463209003
-- kind: conda
-  name: coverage
-  version: 7.4.4
-  build: py312h98912ed_0
+  version: 7.6.0
+  build: py312h41a817b_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.4-py312h98912ed_0.conda
-  sha256: f160f9c89799bf6a14a023711d56cd800117c7a3ad2e117e1a2ced764b0b5206
-  md5: 7002151fcfe55ded0595fc7c3f5e1209
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.0-py312h41a817b_0.conda
+  sha256: 6df833177a0cea9fa618efc9fda2666fc3ea549f218de2258d32909a9a1327eb
+  md5: 66c68c204a3eaabc3b4221f1c4bcebbe
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -3445,17 +3581,17 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/coverage
-  size: 357166
-  timestamp: 1710462905888
+  - pkg:pypi/coverage?source=conda-forge-mapping
+  size: 362938
+  timestamp: 1720730491981
 - kind: conda
   name: coverage
-  version: 7.4.4
-  build: py312he70551f_0
+  version: 7.6.0
+  build: py312h4389bb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.4-py312he70551f_0.conda
-  sha256: d97c6d7bd7e840882c8c6cd38da578284262f908b3038b8a963f2b978a2240cc
-  md5: 3daefd4205ca6b4fdc96c2ab1a6086ee
+  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.0-py312h4389bb4_0.conda
+  sha256: af26258ab089dcf72ce45316d406ea3d92f47a627569790ed296114ad9ec28d8
+  md5: 1d86ce380d53846d9fb32457e62f276b
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -3466,9 +3602,28 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/coverage
-  size: 372896
-  timestamp: 1710463417388
+  - pkg:pypi/coverage?source=conda-forge-mapping
+  size: 388926
+  timestamp: 1720730986560
+- kind: conda
+  name: coverage
+  version: 7.6.0
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.0-py312hbd25219_0.conda
+  sha256: e2745a44eb96be2b552aab34363b1b82002976504c699c4e5077313068722635
+  md5: 8ed4889999caaa8d3b1b3ba939b2fae5
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/coverage?source=conda-forge-mapping
+  size: 361124
+  timestamp: 1720730589029
 - kind: conda
   name: cycler
   version: 0.12.1
@@ -3483,7 +3638,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/cycler
+  - pkg:pypi/cycler?source=conda-forge-mapping
   size: 13458
   timestamp: 1696677888423
 - kind: conda
@@ -3548,32 +3703,12 @@ packages:
   timestamp: 1640112124844
 - kind: conda
   name: debugpy
-  version: 1.8.1
-  build: py312h30efb56_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.1-py312h30efb56_0.conda
-  sha256: 8a8bd15c7a8435991649ab334816d4d64970c5b0d016f59806bc45f54f31a924
-  md5: bdd639417094ace2fb1ce10b20d68d5d
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/bytecode
-  - pkg:pypi/debugpy
-  size: 2079306
-  timestamp: 1707444570818
-- kind: conda
-  name: debugpy
-  version: 1.8.1
-  build: py312h53d5487_0
+  version: 1.8.2
+  build: py312h275cf98_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.1-py312h53d5487_0.conda
-  sha256: 5e8beecf42088481c88aa97118c52b2142f0e0d48ffed877e973c309c7fc83af
-  md5: 4094ccb019f079de8b0f61a5f366d294
+  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.2-py312h275cf98_0.conda
+  sha256: b50f40759b56625ab2b6c05ef6311de4834f299801fb3290e04fab124112941f
+  md5: 20c6fc38d22363e36db3c2a4aa66b697
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -3583,29 +3718,47 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/bytecode
-  - pkg:pypi/debugpy
-  size: 3105043
-  timestamp: 1707445249662
+  - pkg:pypi/debugpy?source=conda-forge-mapping
+  size: 3089422
+  timestamp: 1719379214342
 - kind: conda
   name: debugpy
-  version: 1.8.1
-  build: py312hede676d_0
+  version: 1.8.2
+  build: py312h28f332c_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.1-py312hede676d_0.conda
-  sha256: f957393cb09e3df00176079253e0f845ab8c87dbca3c38e1a14df21ffe9d7083
-  md5: e0de4e018d6013b6c2e2ae42640fb65c
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.2-py312h28f332c_0.conda
+  sha256: 418b7e7d615687aaf2b879443653603fef4659f1d20b45ab50fcf85c656bfab0
+  md5: 4dbee036ef0d52ff63647f0fffa5bab2
   depends:
+  - __osx >=10.13
   - libcxx >=16
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/bytecode
-  - pkg:pypi/debugpy
-  size: 2065572
-  timestamp: 1707444822563
+  - pkg:pypi/debugpy?source=conda-forge-mapping
+  size: 2078006
+  timestamp: 1719378840368
+- kind: conda
+  name: debugpy
+  version: 1.8.2
+  build: py312h7070661_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.2-py312h7070661_0.conda
+  sha256: 8b30358bbb92d302f41298fa42ae2388faccfa290988bde3285af0bfa607522e
+  md5: b19f2a4267351e36728133431f623e98
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/debugpy?source=conda-forge-mapping
+  size: 2070791
+  timestamp: 1719378841042
 - kind: conda
   name: decorator
   version: 5.1.1
@@ -3620,7 +3773,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/decorator
+  - pkg:pypi/decorator?source=conda-forge-mapping
   size: 12072
   timestamp: 1641555714315
 - kind: conda
@@ -3637,7 +3790,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/defusedxml
+  - pkg:pypi/defusedxml?source=conda-forge-mapping
   size: 24062
   timestamp: 1615232388757
 - kind: conda
@@ -3752,7 +3905,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/distlib
+  - pkg:pypi/distlib?source=conda-forge-mapping
   size: 274915
   timestamp: 1702383349284
 - kind: conda
@@ -3769,7 +3922,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/entrypoints
+  - pkg:pypi/entrypoints?source=conda-forge-mapping
   size: 9199
   timestamp: 1643888357950
 - kind: conda
@@ -3827,43 +3980,42 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/et-xmlfile
+  - pkg:pypi/et-xmlfile?source=conda-forge-mapping
   size: 10602
   timestamp: 1674664251571
 - kind: conda
   name: exceptiongroup
-  version: 1.2.0
-  build: pyhd8ed1ab_2
-  build_number: 2
+  version: 1.2.2
+  build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
+  sha256: e0edd30c4b7144406bb4da975e6bb97d6bc9c0e999aa4efe66ae108cada5d5b5
+  md5: d02ae936e42063ca46af6cdad2dbd1e0
   depends:
   - python >=3.7
   license: MIT and PSF-2.0
   purls:
-  - pkg:pypi/exceptiongroup
-  size: 20551
-  timestamp: 1704921321122
+  - pkg:pypi/exceptiongroup?source=conda-forge-mapping
+  size: 20418
+  timestamp: 1720869435725
 - kind: conda
   name: execnet
-  version: 2.1.0
+  version: 2.1.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.0-pyhd8ed1ab_0.conda
-  sha256: df05ecd8bb082f7e6436413491437be70acfb2af3dbad967dfb86dd249a5109e
-  md5: 7a4b32fbe5442e46841ec77695e36d96
+  url: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
+  sha256: 564bc012d73ca29964e7acca18d60b2fa8d20eea6d258d98cfc24df5167beaf0
+  md5: 15dda3cdbf330abfe9f555d22f66db46
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/execnet
-  size: 38958
-  timestamp: 1712355919692
+  - pkg:pypi/execnet?source=conda-forge-mapping
+  size: 38883
+  timestamp: 1712591929944
 - kind: conda
   name: executing
   version: 2.0.1
@@ -3878,7 +4030,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/executing
+  - pkg:pypi/executing?source=conda-forge-mapping
   size: 27689
   timestamp: 1698580072627
 - kind: conda
@@ -3929,28 +4081,29 @@ packages:
   timestamp: 1710362607162
 - kind: conda
   name: filelock
-  version: 3.13.3
+  version: 3.15.4
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.13.3-pyhd8ed1ab_0.conda
-  sha256: 3bb2b4b8b97160ee7d2ed40b9dbc78555932274e82ef314c8a400a1d17aa4626
-  md5: ff15f46b0d34308f4d40c1c51df07592
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.15.4-pyhd8ed1ab_0.conda
+  sha256: f78d9c0be189a77cb0c67d02f33005f71b89037a85531996583fb79ff3fe1a0a
+  md5: 0e7e4388e9d5283e22b35a9443bdbcc9
   depends:
   - python >=3.7
   license: Unlicense
   purls:
-  - pkg:pypi/filelock
-  size: 15611
-  timestamp: 1711394721380
+  - pkg:pypi/filelock?source=conda-forge-mapping
+  size: 17592
+  timestamp: 1719088395353
 - kind: conda
   name: fiona
   version: 1.9.6
-  build: py312h66d9856_0
+  build: py312h32ad294_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.6-py312h66d9856_0.conda
-  sha256: 8b9f2377852498c97397125847a012a9efe9bca35931ca97f178c0ff190a07a9
-  md5: a7e2048665753cff7f947af55f2dddb0
+  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.6-py312h32ad294_3.conda
+  sha256: 4d82fc8d91b8fd99de87680e5732198a65b17e86afbfa5ed37742255570e2574
+  md5: 6da62c5c06a6416e0130220e4f418bb0
   depends:
   - attrs >=19.2.0
   - certifi
@@ -3959,9 +4112,9 @@ packages:
   - cligj >=0.5
   - gdal
   - libgcc-ng >=12
-  - libgdal >=3.8.4,<3.9.0a0
+  - libgdal >=3.9.0,<3.10.0a0
   - libstdcxx-ng >=12
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - shapely
@@ -3969,17 +4122,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fiona
-  size: 980142
-  timestamp: 1709930966672
+  - pkg:pypi/fiona?source=conda-forge-mapping
+  size: 980171
+  timestamp: 1716309549148
 - kind: conda
   name: fiona
   version: 1.9.6
-  build: py312h95cbb4d_0
+  build: py312h4a86439_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.6-py312h95cbb4d_0.conda
-  sha256: 56018dea5019718f994314ff2f9688bac416d79b4e6aebe984f7dc50f44bf4fd
-  md5: c8572c3ebc648b53a07a2f49a03039f6
+  url: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.6-py312h4a86439_3.conda
+  sha256: fc46a91e1f4cbc44a86ec3056da826f853dc5762f332ff71a16937fbc5e3cc49
+  md5: 1ad0f9394675f301f1ab6ae7ecd1e6fb
   depends:
   - attrs >=19.2.0
   - certifi
@@ -3987,8 +4141,8 @@ packages:
   - click-plugins >=1.0
   - cligj >=0.5
   - gdal
-  - libgdal >=3.8.4,<3.9.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - shapely
@@ -3999,18 +4153,20 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fiona
-  size: 815828
-  timestamp: 1709931822140
+  - pkg:pypi/fiona?source=conda-forge-mapping
+  size: 825806
+  timestamp: 1716310424678
 - kind: conda
   name: fiona
   version: 1.9.6
-  build: py312hc18349f_0
+  build: py312hfc836c0_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.6-py312hc18349f_0.conda
-  sha256: d4b9b7d3077fea8fe688da939837a768fbe91101fe6edd6fecbaacb365d05096
-  md5: 7677246f7ad31813a4e361482abeb0ab
+  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.6-py312hfc836c0_3.conda
+  sha256: 7349c454f4e8a586665f43abafe9a55f0967783c28c8d27178bf10df7cf99785
+  md5: 5c8d9fd86f11d7fe0983949c5990bc51
   depends:
+  - __osx >=10.13
   - attrs >=19.2.0
   - certifi
   - click >=8.0,<9.dev0
@@ -4018,8 +4174,8 @@ packages:
   - cligj >=0.5
   - gdal
   - libcxx >=16
-  - libgdal >=3.8.4,<3.9.0a0
-  - numpy >=1.26.4,<2.0a0
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - shapely
@@ -4027,9 +4183,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fiona
-  size: 859073
-  timestamp: 1709931456769
+  - pkg:pypi/fiona?source=conda-forge-mapping
+  size: 857705
+  timestamp: 1716309854079
 - kind: conda
   name: fmt
   version: 10.2.1
@@ -4080,26 +4236,26 @@ packages:
   timestamp: 1704454938658
 - kind: conda
   name: folium
-  version: 0.16.0
+  version: 0.17.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
-  sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
-  md5: cb1d2aa705a5b1f0fbdabd1beebce205
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.17.0-pyhd8ed1ab_0.conda
+  sha256: d5c4153cad0154112daf0db648afe82ad7930523e2cb9f7379bb2d148fac0537
+  md5: 9b96a3e6e0473b5722fa4fbefcefcded
   depends:
   - branca >=0.6.0
   - jinja2 >=2.9
   - numpy
-  - python >=3.7
+  - python >=3.8
   - requests
   - xyzservices
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/folium
-  size: 73615
-  timestamp: 1709209389903
+  - pkg:pypi/folium?source=conda-forge-mapping
+  size: 78894
+  timestamp: 1718606077008
 - kind: conda
   name: font-ttf-dejavu-sans-mono
   version: '2.37'
@@ -4145,18 +4301,18 @@ packages:
 - kind: conda
   name: font-ttf-ubuntu
   version: '0.83'
-  build: h77eed37_1
-  build_number: 1
+  build: h77eed37_2
+  build_number: 2
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
-  sha256: 056c85b482d58faab5fd4670b6c1f5df0986314cca3bc831d458b22e4ef2c792
-  md5: 6185f640c43843e5ad6fd1c5372c3f80
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_2.conda
+  sha256: c940f6e969143e13a3a9660abb3c7e7e23b8319efb29dbdd5dee0b9939236e13
+  md5: cbbe59391138ea5ad3658c76912e147f
   license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
   license_family: Other
   purls: []
-  size: 1619820
-  timestamp: 1700944216729
+  size: 1622566
+  timestamp: 1714483134319
 - kind: conda
   name: fontconfig
   version: 2.14.2
@@ -4170,7 +4326,7 @@ packages:
   - freetype >=2.12.1,<3.0a0
   - libgcc-ng >=12
   - libuuid >=2.32.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
   purls: []
@@ -4187,7 +4343,7 @@ packages:
   depends:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: MIT
   license_family: MIT
   purls: []
@@ -4205,7 +4361,7 @@ packages:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
@@ -4251,32 +4407,14 @@ packages:
   timestamp: 1566932280397
 - kind: conda
   name: fonttools
-  version: 4.51.0
-  build: py312h41838bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.51.0-py312h41838bb_0.conda
-  sha256: 38d7a31e6dc0150e70b7658f0fa5aa747ae951cd961fb4c0d8ce9f717c2a2a61
-  md5: ebe40134b860cf704ddaf81f684f95a5
-  depends:
-  - brotli
-  - munkres
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/fonttools
-  size: 2688978
-  timestamp: 1712345024723
-- kind: conda
-  name: fonttools
-  version: 4.51.0
-  build: py312h98912ed_0
+  version: 4.53.1
+  build: py312h41a817b_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.51.0-py312h98912ed_0.conda
-  sha256: 2589622654b59454a2b6f1e37b864d429a46849db575415803fbe571e6f564c7
-  md5: f0cd0e54adf65aaa976f5731b7a3f383
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.53.1-py312h41a817b_0.conda
+  sha256: b1d9f95c13b9caa26689875b0af654b7f464e273eea94abdf5b1be1baa6c8870
+  md5: da921c56bcf69a8b97216ecec0cc4015
   depends:
+  - __glibc >=2.17,<3.0.a0
   - brotli
   - libgcc-ng >=12
   - munkres
@@ -4285,17 +4423,17 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools
-  size: 2787769
-  timestamp: 1712344705346
+  - pkg:pypi/fonttools?source=conda-forge-mapping
+  size: 2847552
+  timestamp: 1720359185195
 - kind: conda
   name: fonttools
-  version: 4.51.0
-  build: py312he70551f_0
+  version: 4.53.1
+  build: py312h4389bb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.51.0-py312he70551f_0.conda
-  sha256: c86a5a3483587fac156afe5e1ec9f44aeb91d885b1bf1b753c9f2c1fa2d07229
-  md5: 6820105f0928bb46b99358d45d4f3994
+  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.53.1-py312h4389bb4_0.conda
+  sha256: 508b8443a382eec4a6c389e0ab43543797a99172982d9999df8972bfa42e2829
+  md5: d1d90dc02033f12ab8020dbb653a9fc8
   depends:
   - brotli
   - munkres
@@ -4307,9 +4445,29 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools
-  size: 2363814
-  timestamp: 1712345188022
+  - pkg:pypi/fonttools?source=conda-forge-mapping
+  size: 2412400
+  timestamp: 1720359443784
+- kind: conda
+  name: fonttools
+  version: 4.53.1
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.53.1-py312hbd25219_0.conda
+  sha256: bfb83e8a6e95e7d50880cd4811e2312e315d7e8b95b99a405f4056c3162e6ee2
+  md5: 56b85d2b2f034ed31feaaa0b90c37b7f
+  depends:
+  - __osx >=10.13
+  - brotli
+  - munkres
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/fonttools?source=conda-forge-mapping
+  size: 2714145
+  timestamp: 1720359359694
 - kind: conda
   name: fqdn
   version: 1.5.1
@@ -4325,7 +4483,7 @@ packages:
   license: MPL-2.0
   license_family: MOZILLA
   purls:
-  - pkg:pypi/fqdn
+  - pkg:pypi/fqdn?source=conda-forge-mapping
   size: 14395
   timestamp: 1638810388635
 - kind: conda
@@ -4340,7 +4498,7 @@ packages:
   depends:
   - libgcc-ng >=12
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
   purls: []
   size: 634972
@@ -4356,7 +4514,7 @@ packages:
   md5: 25152fce119320c980e5470e64834b50
   depends:
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: GPL-2.0-only OR FTL
   purls: []
   size: 599300
@@ -4372,7 +4530,7 @@ packages:
   md5: 3761b23693f768dc75a8fd0a73ca053f
   depends:
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -4437,88 +4595,84 @@ packages:
   timestamp: 1694953013560
 - kind: conda
   name: gdal
-  version: 3.8.4
-  build: py312h1be6df0_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.8.4-py312h1be6df0_5.conda
-  sha256: 52dcdd46c5e50458271670666ca41cbf83be06218f72e8feeaf1c922c3423b66
-  md5: e77cb26e60bc7a2f2b9ad4c2d35f024e
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libcxx >=16
-  - libgdal 3.8.4 h2239303_5
-  - libxml2 >=2.12.6,<3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/gdal
-  size: 1644273
-  timestamp: 1711287316869
-- kind: conda
-  name: gdal
-  version: 3.8.4
-  build: py312h257dd4b_5
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.4-py312h257dd4b_5.conda
-  sha256: a11ddb252246e579bed502bff472c4ec7d18aa157adbd349fe9f3de0e4e53e15
-  md5: c5d9279e3e90a439cd7eac621d378d00
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libgcc-ng >=12
-  - libgdal 3.8.4 h7c88fdf_5
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.6,<3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/gdal
-  size: 1663454
-  timestamp: 1711285933784
-- kind: conda
-  name: gdal
-  version: 3.8.4
-  build: py312h36e25a9_5
-  build_number: 5
+  version: 3.9.1
+  build: py312h16ac12d_9
+  build_number: 9
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.8.4-py312h36e25a9_5.conda
-  sha256: 24e6d9f306add64ff976f2ca17c246b83387a6b787d25ee666d48de182bb27c5
-  md5: 45752ae67d53252996b53219071da344
+  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py312h16ac12d_9.conda
+  sha256: d5023e51c49cb214d4ab2b43089c90bbca8c459376f5975f8cd71448f07fcef1
+  md5: 058804ad97618d54637d675344796b18
   depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libgdal 3.8.4 hf83a0e2_5
-  - libxml2 >=2.12.6,<3.0a0
-  - numpy >=1.26.4,<2.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libgdal-core 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/gdal
-  size: 1617688
-  timestamp: 1711287952897
+  - pkg:pypi/gdal?source=conda-forge-mapping
+  size: 1636216
+  timestamp: 1721930672158
+- kind: conda
+  name: gdal
+  version: 3.9.1
+  build: py312h29648be_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py312h29648be_9.conda
+  sha256: 1210cfd0ec5cf8597695c323ac49b3ab532302b368c50e29db643d6e7ebad812
+  md5: 0c0138784f698b701ec799f65a906f65
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/gdal?source=conda-forge-mapping
+  size: 1679631
+  timestamp: 1721929121387
+- kind: conda
+  name: gdal
+  version: 3.9.1
+  build: py312h7eda2e2_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py312h7eda2e2_9.conda
+  sha256: 936ba9bd50395b9c39c6596c5d3caa7eb49b168752ffca5a6bd6d8185186211d
+  md5: d030bd3513bbf7c3900f815da06b76fd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/gdal?source=conda-forge-mapping
+  size: 1693789
+  timestamp: 1721929057689
 - kind: conda
   name: geocube
-  version: 0.5.1
+  version: 0.5.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.1-pyhd8ed1ab_0.conda
-  sha256: cfbd1da7368e59f7635568da3cdbc641f3b47c6265da365848b41318f782babf
-  md5: 2caf80e079028b28c0d6cd0685f67059
+  url: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
+  sha256: e926339ffb33ba2de50c0e29f5871d9eb196f65a3c9807d4aef64b9f067fe57d
+  md5: 2b09edce0b7c79d2da85ae52bd68ca95
   depends:
   - appdirs
   - click >=6.0
@@ -4534,158 +4688,140 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/geocube
-  size: 23078
-  timestamp: 1710863108149
+  - pkg:pypi/geocube?source=conda-forge-mapping
+  size: 23157
+  timestamp: 1713410458393
 - kind: conda
   name: geopandas
-  version: 0.14.3
+  version: 1.0.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
-  sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
-  md5: d8e208e375441bf1404e9693f13f3c25
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
+  sha256: 6d3f8148d88b1f2c100e03fce441f19577f6a4b69e3a2c57d522b48010d84f5f
+  md5: efef4ce75a678216d510d08222845c7f
   depends:
-  - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.3 pyha770c72_0
+  - geopandas-base 1.0.1 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
+  - pyogrio >=0.7.2
+  - pyproj >=3.3.0
   - python >=3.9
-  - rtree
   - xyzservices
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/geopandas?source=conda-forge-mapping
-  size: 7619
-  timestamp: 1706734846170
+  size: 7438
+  timestamp: 1719933423912
 - kind: conda
   name: geopandas-base
-  version: 0.14.3
+  version: 1.0.1
   build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
-  sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
-  md5: fbac4b2194c962b97324a3f5dd7d2696
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_0.conda
+  sha256: b07d76f79cc3b1dc7f5a73aeeb0f7c9977526d73237df7e200582fdff48045d1
+  md5: 1b7d46173c29e14dde41f97cf5aa61df
   depends:
+  - numpy >=1.22
   - packaging
   - pandas >=1.4.0
-  - pyproj >=3.3.0
   - python >=3.9
-  - shapely >=1.8.0
+  - shapely >=2.0.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/geopandas
-  size: 1020461
-  timestamp: 1706734838573
+  - pkg:pypi/geopandas?source=conda-forge-mapping
+  size: 239347
+  timestamp: 1719933418796
 - kind: conda
   name: geos
-  version: 3.12.1
-  build: h1537add_0
+  version: 3.12.2
+  build: h5a68840_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.1-h1537add_0.conda
-  sha256: d7a6bb89063df38b24843e5b4c99da602333ac4e1c1e39c069f2021827d3c98d
-  md5: 02fdccc66ed44a8f9f3731d15f445724
+  url: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.2-h5a68840_1.conda
+  sha256: e8606bbf3ebbaf2817d65d4b48180cc1d828a030061e0a5ef55281f9cc7f1e28
+  md5: 019e3460f99eb7c2198c532c50d08791
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-only
   purls: []
-  size: 1561705
-  timestamp: 1699778438983
+  size: 1561663
+  timestamp: 1721747131206
 - kind: conda
   name: geos
-  version: 3.12.1
-  build: h59595ed_0
+  version: 3.12.2
+  build: he02047a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.1-h59595ed_0.conda
-  sha256: 2593b255cb9c4639d6ea261c47aaed1380216a366546f0468e95c36c2afd1c1a
-  md5: 8c0f4f71f5a59ceb0c6fa9f51501066d
+  url: https://conda.anaconda.org/conda-forge/linux-64/geos-3.12.2-he02047a_1.conda
+  sha256: bc3860e6689be6968ca5bae3660f43dd3e22f4dd61c0bfc99ffd0d0daf4f7a73
+  md5: aab9195bc018b82dc77a84584b36cce9
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: LGPL-2.1-only
   purls: []
-  size: 1736070
-  timestamp: 1699778102442
+  size: 1737633
+  timestamp: 1721746525671
 - kind: conda
   name: geos
-  version: 3.12.1
-  build: h93d8f39_0
+  version: 3.12.2
+  build: hf036a51_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.1-h93d8f39_0.conda
-  sha256: 6feffb0d1999a22c5f94d2168b1af9c5fbdd25c9a963a6825ee32cf05e5c07f5
-  md5: d13f05ed3985f57456b610bab66366db
+  url: https://conda.anaconda.org/conda-forge/osx-64/geos-3.12.2-hf036a51_1.conda
+  sha256: 1d5ec9da8a543885228aa7ca9fabfcacd653b0f14e8d175bb83de60afcffc166
+  md5: fbb2688b537dafd5fb554d0b7ef27397
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
+  - __osx >=10.13
+  - libcxx >=16
   license: LGPL-2.1-only
   purls: []
-  size: 1462098
-  timestamp: 1699778844758
+  size: 1482492
+  timestamp: 1721747118528
 - kind: conda
   name: geotiff
-  version: 1.7.1
-  build: h509af15_15
-  build_number: 15
+  version: 1.7.3
+  build: h4bbec01_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.1-h509af15_15.conda
-  sha256: e6047c9008746788d265ec6b30551387efd204a5a9a599f0f0359956e8513e76
-  md5: 96cb876ae9551821ad4cd6ce860d75f1
+  url: https://conda.anaconda.org/conda-forge/osx-64/geotiff-1.7.3-h4bbec01_1.conda
+  sha256: 7f5c0d021822e12cd64848caa77d43398cea90381f420d6f973877f3eccc2188
+  md5: 94b592c68bb826b1ffee62524b117aa2
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
+  - __osx >=10.13
+  - libcxx >=16
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - proj >=9.3.1,<9.3.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
   - zlib
   license: MIT
   license_family: MIT
   purls: []
-  size: 118949
-  timestamp: 1702091820418
+  size: 116364
+  timestamp: 1717777078423
 - kind: conda
   name: geotiff
-  version: 1.7.1
-  build: h6b2125f_15
-  build_number: 15
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.1-h6b2125f_15.conda
-  sha256: f7dcc865f5522713048397702490ba917abf9d2fbfe89d6b703e0ea333a27b01
-  md5: 218a726155bd9ae1787b26054eed8566
-  depends:
-  - libgcc-ng >=12
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - proj >=9.3.1,<9.3.2.0a0
-  - zlib
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 133164
-  timestamp: 1702091590935
-- kind: conda
-  name: geotiff
-  version: 1.7.1
-  build: hbf5ca3a_15
-  build_number: 15
+  version: 1.7.3
+  build: hd7df778_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.1-hbf5ca3a_15.conda
-  sha256: 7e50e631cf86ebf19e1a25e13b4d778d6166f17a28583c18c3794576b370fbcf
-  md5: b57ca6d86e2f217bf5277e15361e88a8
+  url: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-hd7df778_1.conda
+  sha256: 6e1d97f71644fe2e8c1b69c37c1967aed0b4a545605b7f9d540f1e62c06166cc
+  md5: ebc0058bce6824048891fe3c58bf6acd
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - proj >=9.3.1,<9.3.2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -4693,30 +4829,31 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 125707
-  timestamp: 1702092204962
+  size: 123487
+  timestamp: 1717777636505
 - kind: conda
-  name: gettext
-  version: 0.22.5
-  build: h5728263_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.22.5-h5728263_2.conda
-  sha256: cd4ef93fd052a4fe89a4db963c9d69e60c8a434d41968fc9dc8726db67191582
-  md5: da84216f88a8c89eb943c683ceb34d7d
+  name: geotiff
+  version: 1.7.3
+  build: hf7fa9e8_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.3-hf7fa9e8_1.conda
+  sha256: df00139c22b1b2ab1e1e48bb94c68febcc40a7ca812bd4f228a3e09ac9d2cdf2
+  md5: 8ff4fa3ab0b63dc5b214a68839499e41
   depends:
-  - gettext-tools 0.22.5 h7d00a51_2
-  - libasprintf 0.22.5 h5728263_2
-  - libasprintf-devel 0.22.5 h5728263_2
-  - libgettextpo 0.22.5 h5728263_2
-  - libgettextpo-devel 0.22.5 h5728263_2
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
-  - libintl-devel 0.22.5 h5728263_2
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.0,<9.5.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
   purls: []
-  size: 34028
-  timestamp: 1712517225377
+  size: 131934
+  timestamp: 1717777012441
 - kind: conda
   name: gettext
   version: 0.22.5
@@ -4739,29 +4876,6 @@ packages:
   size: 475058
   timestamp: 1712512357949
 - kind: conda
-  name: gettext
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
-  sha256: ba9a4680b018a4ca517ec20beb25b09c97e293ecd16b931075e689db10291712
-  md5: c09b3dcf2adc5a2a32d11ab90289b8fa
-  depends:
-  - gettext-tools 0.22.5 h5ff76d1_2
-  - libasprintf 0.22.5 h5ff76d1_2
-  - libasprintf-devel 0.22.5 h5ff76d1_2
-  - libcxx >=16
-  - libgettextpo 0.22.5 h5ff76d1_2
-  - libgettextpo-devel 0.22.5 h5ff76d1_2
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  - libintl-devel 0.22.5 h5ff76d1_2
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  purls: []
-  size: 481687
-  timestamp: 1712513003915
-- kind: conda
   name: gettext-tools
   version: 0.22.5
   build: h59595ed_2
@@ -4777,43 +4891,6 @@ packages:
   purls: []
   size: 2728420
   timestamp: 1712512328692
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
-  sha256: 4db71a66340d068c57e16c574c356db6df54ac0147b5b26d3313093f7854ee6d
-  md5: 37e1cb0efeff4d4623a6357e37e0105d
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 2501207
-  timestamp: 1712512940076
-- kind: conda
-  name: gettext-tools
-  version: 0.22.5
-  build: h7d00a51_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gettext-tools-0.22.5-h7d00a51_2.conda
-  sha256: e3621dc3d48399c89bf0dd512a6a398d354429b3b84219473d674aa56e0feef2
-  md5: ef1c3bb48c013099c4872640a5f2096c
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 3415835
-  timestamp: 1712516856107
 - kind: conda
   name: gflags
   version: 2.2.2
@@ -4849,46 +4926,45 @@ packages:
   timestamp: 1594303828933
 - kind: conda
   name: giflib
-  version: 5.2.1
-  build: h0b41bf4_3
-  build_number: 3
+  version: 5.2.2
+  build: h10d778d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
+  sha256: 2c825df829097536314a195ae5cacaa8695209da6b4400135a65d8e23c008ff8
+  md5: 03e8c9b4d3da5f3d6eabdd020c2d63ac
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 74516
+  timestamp: 1712692686914
+- kind: conda
+  name: giflib
+  version: 5.2.2
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
-  sha256: 41ec165704ccce2faa0437f4f53c03c06261a2cc9ff7614828e51427d9261f4b
-  md5: 96f3b11872ef6fad973eac856cd2624f
+  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
   depends:
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 77385
-  timestamp: 1678717794467
-- kind: conda
-  name: giflib
-  version: 5.2.1
-  build: hb7f2c08_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
-  sha256: 47515e0874bcf67e438e1d5d093b074c1781f055067195f0d00a7790a56d446d
-  md5: aca150b0186836f893ebac79019e5498
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 76514
-  timestamp: 1678717973971
+  size: 77248
+  timestamp: 1712692454246
 - kind: conda
   name: glib
-  version: 2.80.0
-  build: h39d0aa6_3
-  build_number: 3
+  version: 2.80.3
+  build: h7025463_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.0-h39d0aa6_3.conda
-  sha256: da3672aafedd8407171b22f30b2106fd334b2d6a96dff0c40870c7a59d6bea7f
-  md5: 53b689f4e44aaa40923441920fc18114
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.3-h7025463_1.conda
+  sha256: 892d784d7a8c7444004109734dcf71d11ded0d1dc06d3dfc14227576993239a5
+  md5: 13ce8fd2eb07f41c7108f7ad7bb0062e
   depends:
-  - glib-tools 2.80.0 h0a98069_3
-  - libglib 2.80.0 h39d0aa6_3
+  - glib-tools 2.80.3 h4394cf3_1
+  - libffi >=3.4,<4.0a0
+  - libglib 2.80.3 h7025463_1
   - libintl >=0.22.5,<1.0a0
   - libintl-devel
   - python *
@@ -4897,86 +4973,87 @@ packages:
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
   purls: []
-  size: 491237
-  timestamp: 1712500408115
+  size: 572358
+  timestamp: 1720335131283
 - kind: conda
   name: glib
-  version: 2.80.0
-  build: hf2295e7_3
-  build_number: 3
+  version: 2.80.3
+  build: h8a4344b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.0-hf2295e7_3.conda
-  sha256: b980a0483acab9012d4771c79ec31f1505ab935f8d7070f215eb1dd3225eadf0
-  md5: 1ade62526144055f05c3eb45ebae3b5b
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.3-h8a4344b_1.conda
+  sha256: 51db16c42f0f07aa9d4f922a629d8f68fe3b2590917b8282b7e8ab5ced45c0f6
+  md5: a3acc4920c9ca19cb6b295028d606477
   depends:
-  - glib-tools 2.80.0 hde27a5a_3
+  - glib-tools 2.80.3 h73ef956_1
+  - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
-  - libglib 2.80.0 hf2295e7_3
+  - libglib 2.80.3 h8a4344b_1
   - python *
   license: LGPL-2.1-or-later
   purls: []
-  size: 504033
-  timestamp: 1712500175549
+  size: 599204
+  timestamp: 1720334967965
 - kind: conda
   name: glib-tools
-  version: 2.80.0
-  build: h0a98069_3
-  build_number: 3
+  version: 2.80.3
+  build: h4394cf3_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.0-h0a98069_3.conda
-  sha256: f059497cd368e07969f027ace75a5f7205a9b05fbaab3809cf5d4d2a353db03d
-  md5: baef876a13714d6b0c86b25b233d410c
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.3-h4394cf3_1.conda
+  sha256: 0bc71e397b49c622a224b4ecdef338ec215d037d0e385a5870afd5a96197399d
+  md5: 12d270a5f8b8ae0a9536c1960f21e0aa
   depends:
-  - libglib 2.80.0 h39d0aa6_3
+  - libglib 2.80.3 h7025463_1
   - libintl >=0.22.5,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.1-or-later
   purls: []
-  size: 94302
-  timestamp: 1712500341235
+  size: 95020
+  timestamp: 1720335074003
 - kind: conda
   name: glib-tools
-  version: 2.80.0
-  build: hde27a5a_3
-  build_number: 3
+  version: 2.80.3
+  build: h73ef956_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.0-hde27a5a_3.conda
-  sha256: 410fdabf991e7755a8201fdc685d79f0494113e818e137a31e265ba2290ff94e
-  md5: d544517494d9008c0b1021213aec4084
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.3-h73ef956_1.conda
+  sha256: 1cbaa71af8ed506c158e345e3f951b4f36506f96e957b9486dea5eaca86252b2
+  md5: 99701cdc9a25a333d15265d1d243b2dc
   depends:
   - libgcc-ng >=12
-  - libglib 2.80.0 hf2295e7_3
+  - libglib 2.80.3 h8a4344b_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 112490
-  timestamp: 1712500134451
+  size: 113361
+  timestamp: 1720334924695
 - kind: conda
   name: glog
-  version: 0.7.0
-  build: h31b1b29_0
+  version: 0.7.1
+  build: h2790a97_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.0-h31b1b29_0.conda
-  sha256: 49d39c6b0c38d9f2badfc37450ea45a40493669561d588ee81d9e5b7ed4478b7
-  md5: bda05f8f4c205124348c764dd82db33a
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
+  sha256: dd56547db8625eb5c91bb0a9fbe8bd6f5c7fbf5b6059d46365e94472c46b24f9
+  md5: 06cf91665775b0da395229cd4331b27d
   depends:
-  - __osx >=10.12
+  - __osx >=10.13
   - gflags >=2.2.2,<2.3.0a0
   - libcxx >=16
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 115506
-  timestamp: 1708261022187
+  size: 117017
+  timestamp: 1718284325443
 - kind: conda
   name: glog
-  version: 0.7.0
-  build: hed5481d_0
+  version: 0.7.1
+  build: hbabe93e_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.0-hed5481d_0.conda
-  sha256: 19f41db8f189ed9caec68ffb9ec97d5518b5ee6b58e0636d185f392f688a84a1
-  md5: a9ea19c48e11754899299f8123070f4e
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+  sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
+  md5: ff862eebdfeb2fd048ae9dc92510baca
   depends:
   - gflags >=2.2.2,<2.3.0a0
   - libgcc-ng >=12
@@ -4984,8 +5061,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 143596
-  timestamp: 1708260910243
+  size: 143452
+  timestamp: 1718284177264
 - kind: conda
   name: graphite2
   version: 1.3.13
@@ -5005,13 +5082,13 @@ packages:
   timestamp: 1711634169756
 - kind: conda
   name: griffe
-  version: 0.42.1
+  version: 0.48.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.42.1-pyhd8ed1ab_0.conda
-  sha256: cdb9afdb4eb66b6c43c6f34ed14da4a4d8686e51f3fafc23e2846e4a166ce700
-  md5: c6adb089706beaef0673bc32953913e8
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+  sha256: 528411c09a2a7bd0a6590601f89ca9a21fe9fb908a67e87d889d2a86205dd850
+  md5: 73aafef908b0b8948d739e11ebf92d32
   depends:
   - astunparse >=1.6
   - colorama >=0.4
@@ -5019,110 +5096,104 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/griffe
-  size: 90936
-  timestamp: 1710874467453
+  - pkg:pypi/griffe?source=conda-forge-mapping
+  size: 101827
+  timestamp: 1721049777473
 - kind: conda
   name: gst-plugins-base
-  version: 1.24.1
-  build: h001b923_1
-  build_number: 1
+  version: 1.24.5
+  build: hb0a98b8_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.1-h001b923_1.conda
-  sha256: 14cdc32e1adf2876d23623cc2047489d7bad122b7020e2b23357bd2416744b80
-  md5: 7900eb39e6203249accb52fb705a2fb0
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.5-hb0a98b8_0.conda
+  sha256: 0958c192be2b1d05aaa7ca2f9df5a479fac8b014780236c0ec1fff361c454ab6
+  md5: b770c056a4d17c9860ffa6464982db70
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.24.1 hb4038d2_1
-  - libglib >=2.78.4,<3.0a0
+  - gstreamer 1.24.5 h5006eae_0
+  - libglib >=2.80.2,<3.0a0
+  - libintl >=0.22.5,<1.0a0
   - libogg >=1.3.4,<1.4.0a0
   - libvorbis >=1.3.7,<1.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
-  size: 2090953
-  timestamp: 1711319124984
+  size: 2063797
+  timestamp: 1718925751976
 - kind: conda
   name: gst-plugins-base
-  version: 1.24.1
-  build: hfa15dee_1
-  build_number: 1
+  version: 1.24.5
+  build: hbaaba92_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.1-hfa15dee_1.conda
-  sha256: 4228bb9b568a09f8e31f0d52d6ccf06e7752dfa1d72af15ee11fd347e6795bca
-  md5: a6dd2bbc684913e2bef0a54ce56fcbfb
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.5-hbaaba92_0.conda
+  sha256: eb9ea3a6b2a3873a379f9b2c86abba510709ae6e0083a7c0c8563c25ed3dc4bd
+  md5: 4a485842570569ba754863b2c083b346
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.24.1 h98fc4e7_1
+  - alsa-lib >=1.2.12,<1.3.0a0
+  - gstreamer 1.24.5 haf2f30d_0
   - libexpat >=2.6.2,<3.0a0
   - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - libglib >=2.80.2,<3.0a0
   - libogg >=1.3.4,<1.4.0a0
   - libopus >=1.3.1,<2.0a0
   - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
   - libvorbis >=1.3.7,<1.4.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xorg-libx11 >=1.8.7,<2.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
-  size: 2789211
-  timestamp: 1711318581613
+  size: 2804833
+  timestamp: 1718924385674
 - kind: conda
   name: gstreamer
-  version: 1.24.1
-  build: h98fc4e7_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.1-h98fc4e7_1.conda
-  sha256: a341496165602c8de4e537e596ba8f5070232d0362a9fe36b3591116a0f0752d
-  md5: b04b5cdf3ba01430db27979250bc5a1d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.80.0,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  purls: []
-  size: 2010273
-  timestamp: 1711318435463
-- kind: conda
-  name: gstreamer
-  version: 1.24.1
-  build: hb4038d2_1
-  build_number: 1
+  version: 1.24.5
+  build: h5006eae_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.1-hb4038d2_1.conda
-  sha256: f2ee66bb1ef3d12f9c2d6784d2c4bf19bb9d4e99c55c96ca4df53c9bd308c084
-  md5: 8a6dfe53ad02a3b151e6383a950043ee
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.24.5-h5006eae_0.conda
+  sha256: 4039dafcfec7a2c0d4c458b403ea652572ef81521bec4b6bd8df704c0cb0b032
+  md5: 5f5d9ef53cd63a2bf341091786d031e5
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.78.4,<3.0a0
-  - libglib >=2.78.4,<3.0a0
+  - glib >=2.80.2,<3.0a0
+  - libglib >=2.80.2,<3.0a0
   - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
-  size: 2069365
-  timestamp: 1711318923388
+  size: 2030810
+  timestamp: 1718925519580
+- kind: conda
+  name: gstreamer
+  version: 1.24.5
+  build: haf2f30d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.5-haf2f30d_0.conda
+  sha256: b824bf5e8b1b2aed4b6cad08caccdb48624a3180a96e7e6b5b978f009a3a7e85
+  md5: c5252c02592373fa8caf5a5327165a89
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glib >=2.80.2,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.2,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 2020578
+  timestamp: 1718924252333
 - kind: conda
   name: h11
   version: 0.14.0
@@ -5138,7 +5209,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/h11
+  - pkg:pypi/h11?source=conda-forge-mapping
   size: 48251
   timestamp: 1664132995560
 - kind: conda
@@ -5157,30 +5228,30 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/h2
+  - pkg:pypi/h2?source=conda-forge-mapping
   size: 46754
   timestamp: 1634280590080
 - kind: conda
   name: harfbuzz
-  version: 8.3.0
-  build: h3d44ed6_0
+  version: 9.0.0
+  build: hfac3d4d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
-  sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
-  md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hfac3d4d_0.conda
+  sha256: 5854e5ac2d3399ef30b59f15045c19fa5f0bab94d116bd75cac4d05181543dc3
+  md5: c7b47c64af53e8ecee01d101eeab2342
   depends:
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - graphite2
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.1,<3.0a0
+  - libglib >=2.80.2,<3.0a0
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 1547473
-  timestamp: 1699925311766
+  size: 1590518
+  timestamp: 1719579998295
 - kind: conda
   name: hdf4
   version: 4.2.15
@@ -5194,7 +5265,7 @@ packages:
   - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5211,7 +5282,7 @@ packages:
   md5: 84344a916a73727c1326841007b52ca8
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -5232,7 +5303,7 @@ packages:
   depends:
   - libcxx >=15.0.7
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5241,72 +5312,72 @@ packages:
 - kind: conda
   name: hdf5
   version: 1.14.3
-  build: nompi_h4f84152_100
-  build_number: 100
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_100.conda
-  sha256: b814f8f9598cc6e50127533ec256725183ba69db5fd8cf5443223627f19e3e59
-  md5: d471a5c3abc984b662d9bae3bb7fd8a5
+  build: nompi_h2b43c12_105
+  build_number: 105
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h2b43c12_105.conda
+  sha256: 56c803607a64b5117a8b4bcfdde722e4fa40970ddc4c61224b0981cbb70fb005
+  md5: 5788de34381caf624b78c4981618dc0a
   depends:
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2039111
+  timestamp: 1717587493910
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h687a608_105
+  build_number: 105
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h687a608_105.conda
+  sha256: 98f8350730d09e8ad7b62ca6d6be38ee2324b11bbcd1a5fe2cac619b12cd68d7
+  md5: 98544299f6bb2ef4d7362506a3dde886
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3733954
+  timestamp: 1717588360008
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_hdf9ad27_105
+  build_number: 105
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_hdf9ad27_105.conda
+  sha256: 2278fa07da6f96e807d402cd55480624d67d2dee202191aaaf278ce5ab23605a
+  md5: 7e1729554e209627636a0f6fabcdd115
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libgcc-ng >=12
   - libgfortran-ng
   - libgfortran5 >=12.3.0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: LicenseRef-HDF5
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3892189
-  timestamp: 1701791599022
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_h691f4bf_100
-  build_number: 100
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_h691f4bf_100.conda
-  sha256: 158dd2ab901659b47e8f7ee0ec1d9e45a1fedc4871391a44a1c8b9e8ba4c9c6b
-  md5: 8e2ac4ae815a8c9743fe37d70f48f075
-  depends:
-  - __osx >=10.9
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libgfortran5 >=13.2.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  license: LicenseRef-HDF5
-  license_family: BSD
-  purls: []
-  size: 3720132
-  timestamp: 1701792909005
-- kind: conda
-  name: hdf5
-  version: 1.14.3
-  build: nompi_h73e8ff5_100
-  build_number: 100
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_100.conda
-  sha256: 89bbb2c878e1b6c6073ef5f1f25eac97ed48393541a4a44a7d182da5ede3dc98
-  md5: 1e91ce0f3a914b0dab762539c0df4ff1
-  depends:
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: LicenseRef-HDF5
-  license_family: BSD
-  purls: []
-  size: 2045774
-  timestamp: 1701791365837
+  size: 3911675
+  timestamp: 1717587866574
 - kind: conda
   name: hpack
   version: 4.0.0
@@ -5321,7 +5392,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/hpack
+  - pkg:pypi/hpack?source=conda-forge-mapping
   size: 25341
   timestamp: 1598856368685
 - kind: conda
@@ -5343,7 +5414,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/httpcore
+  - pkg:pypi/httpcore?source=conda-forge-mapping
   size: 45816
   timestamp: 1711597091407
 - kind: conda
@@ -5365,7 +5436,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/httpx
+  - pkg:pypi/httpx?source=conda-forge-mapping
   size: 64651
   timestamp: 1708531043505
 - kind: pypi
@@ -5392,7 +5463,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/hyperframe
+  - pkg:pypi/hyperframe?source=conda-forge-mapping
   size: 14646
   timestamp: 1619110249723
 - kind: conda
@@ -5430,70 +5501,72 @@ packages:
   timestamp: 1692901469029
 - kind: conda
   name: icu
-  version: '73.2'
-  build: hf5e326d_0
+  version: '75.1'
+  build: h120a0e1_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-  sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
-  md5: 5cc301d759ec03f28328428e28f65591
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-75.1-h120a0e1_0.conda
+  sha256: 2e64307532f482a0929412976c8450c719d558ba20c0962832132fd0d07ba7a7
+  md5: d68d48a3060eb5abdc1cdc8e2a3a5966
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
   purls: []
-  size: 11787527
-  timestamp: 1692901622519
+  size: 11761697
+  timestamp: 1720853679409
 - kind: conda
   name: identify
-  version: 2.5.35
+  version: 2.6.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.5.35-pyhd8ed1ab_0.conda
-  sha256: 971683b13d1b820157bef9993c63dd8b0611d2d60fc4b522da163aee2e70e518
-  md5: 9472bfd206a2b7bb8143835e37667054
+  url: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
+  sha256: 4a2889027df94d51be283536ac235feba77eaa42a0d051f65cd07ba824b324a6
+  md5: f80cc5989f445f23b1622d6c455896d9
   depends:
   - python >=3.6
   - ukkonen
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/identify
-  size: 78364
-  timestamp: 1708283690891
+  - pkg:pypi/identify?source=conda-forge-mapping
+  size: 78197
+  timestamp: 1720413864262
 - kind: conda
   name: idna
-  version: '3.6'
+  version: '3.7'
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.6-pyhd8ed1ab_0.conda
-  sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
-  md5: 1a76f09108576397c41c0b0c5bd84134
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
+  sha256: 9687ee909ed46169395d4f99a0ee94b80a52f87bed69cd454bb6d37ffeb0ec7b
+  md5: c0cc1420498b17414d8617d0b9f506ca
   depends:
   - python >=3.6
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/idna
-  size: 50124
-  timestamp: 1701027126206
+  - pkg:pypi/idna?source=conda-forge-mapping
+  size: 52718
+  timestamp: 1713279497047
 - kind: conda
   name: importlib-metadata
-  version: 7.1.0
+  version: 8.2.0
   build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.1.0-pyha770c72_0.conda
-  sha256: cc2e7d1f7f01cede30feafc1118b7aefa244d0a12224513734e24165ae12ba49
-  md5: 0896606848b2dc5cebdf111b6543aa04
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
+  sha256: 15dd2beba1c6f780fec6c5351bbce815d27a29561f422fe830133c995ef90b8a
+  md5: c261d14fc7f49cdd403868998a18c318
   depends:
   - python >=3.8
   - zipp >=0.5
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/importlib-metadata
-  size: 27043
-  timestamp: 1710971498183
+  - pkg:pypi/importlib-metadata?source=conda-forge-mapping
+  size: 28110
+  timestamp: 1721856614564
 - kind: conda
   name: importlib-resources
   version: 6.4.0
@@ -5514,21 +5587,21 @@ packages:
   timestamp: 1711041029062
 - kind: conda
   name: importlib_metadata
-  version: 7.1.0
+  version: 8.2.0
   build: hd8ed1ab_0
   subdir: noarch
   noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.1.0-hd8ed1ab_0.conda
-  sha256: 01dc057a45dedcc742a71599f67c7383ae2bf873be6018ebcbd06ac8d994dedb
-  md5: 6ef2b72d291b39e479d7694efa2b2b98
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
+  sha256: 4a0eacc41786d97176fb53c19d25c4f9b8ab4c9a0ee1fd6f09bc13ca197c21d9
+  md5: 0fd030dce707a6654472cf7619b0b01b
   depends:
-  - importlib-metadata >=7.1.0,<7.1.1.0a0
+  - importlib-metadata >=8.2.0,<8.2.1.0a0
   license: Apache-2.0
   license_family: APACHE
   purls:
   - pkg:pypi/importlib-metadata?source=conda-forge-mapping
-  size: 9444
-  timestamp: 1710971502542
+  size: 9330
+  timestamp: 1721856618848
 - kind: conda
   name: importlib_resources
   version: 6.4.0
@@ -5546,7 +5619,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/importlib-resources
+  - pkg:pypi/importlib-resources?source=conda-forge-mapping
   size: 33056
   timestamp: 1711041009039
 - kind: conda
@@ -5563,32 +5636,92 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/iniconfig
+  - pkg:pypi/iniconfig?source=conda-forge-mapping
   size: 11101
   timestamp: 1673103208955
 - kind: conda
   name: intel-openmp
-  version: 2024.1.0
-  build: h57928b3_964
-  build_number: 964
+  version: 2024.2.0
+  build: h57928b3_980
+  build_number: 980
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.1.0-h57928b3_964.conda
-  sha256: bea54e995cd79b0961ded5f0d6d1b8a55513283ccda74cedb3421a3764f7d679
-  md5: 30ebb9fd99666d8b8675fcee541a09f3
-  license: LicenseRef-ProprietaryIntel
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+  sha256: e3ddfb67e0a922868e68f83d0b56755ff1c280ffa959a0c5ee6a922aaf7022b0
+  md5: 9c28c39e64871a0adef7d1195bd58655
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   purls: []
-  size: 1616281
-  timestamp: 1712153179165
+  size: 1860328
+  timestamp: 1721088141110
 - kind: conda
   name: ipykernel
-  version: 6.29.3
-  build: pyh3cd1d5f_0
+  version: 6.29.5
+  build: pyh3099207_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyh3cd1d5f_0.conda
-  sha256: ef2f9c1d83afd693db3793c368c5c6afcd37a416958ece490a2e1fbcd85012eb
-  md5: 28e74fca8d8abf09c1ed0d190a17e307
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
+  sha256: 33cfd339bb4efac56edf93474b37ddc049e08b1b4930cf036c893cc1f5a1f32a
+  md5: b40131ab6a36ac2c09b7c57d4d3fbf99
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/ipykernel?source=conda-forge-mapping
+  size: 119084
+  timestamp: 1719845605084
+- kind: conda
+  name: ipykernel
+  version: 6.29.5
+  build: pyh4bbf305_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
+  sha256: dc569094125127c0078aa536f78733f383dd7e09507277ef8bcd1789786e7086
+  md5: 18df5fc4944a679e085e0e8f31775fc8
+  depends:
+  - __win
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio
+  - packaging
+  - psutil
+  - python >=3.8
+  - pyzmq >=24
+  - tornado >=6.1
+  - traitlets >=5.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/ipykernel?source=conda-forge-mapping
+  size: 119853
+  timestamp: 1719845858082
+- kind: conda
+  name: ipykernel
+  version: 6.29.5
+  build: pyh57ce528_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
+  sha256: 072534d4d379225b2c3a4e38bc7730b65ae171ac7f0c2d401141043336e97980
+  md5: 9eb15d654daa0ef5a98802f586bb4ffc
   depends:
   - __osx
   - appnope
@@ -5608,78 +5741,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipykernel
-  size: 119602
-  timestamp: 1708996878886
-- kind: conda
-  name: ipykernel
-  version: 6.29.3
-  build: pyha63f2e9_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyha63f2e9_0.conda
-  sha256: 93ff46322a2512e9fb4ba456b1f0120d2f628a4b851f3102561a351e528d24d0
-  md5: d86f243bdd45a8019050e7326ed7bb2e
-  depends:
-  - __win
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - python >=3.8
-  - pyzmq >=24
-  - tornado >=6.1
-  - traitlets >=5.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/ipykernel
-  size: 119670
-  timestamp: 1708996955969
-- kind: conda
-  name: ipykernel
-  version: 6.29.3
-  build: pyhd33586a_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.3-pyhd33586a_0.conda
-  sha256: 0314f15e666fd9a4fb653aae37d2cf4dc6bc3a18c0d9c2671a6a0783146adcfa
-  md5: e0deff12c601ce5cb7476f93718f3168
-  depends:
-  - __linux
-  - comm >=0.1.1
-  - debugpy >=1.6.5
-  - ipython >=7.23.1
-  - jupyter_client >=6.1.12
-  - jupyter_core >=4.12,!=5.0.*
-  - matplotlib-inline >=0.1
-  - nest-asyncio
-  - packaging
-  - psutil
-  - python >=3.8
-  - pyzmq >=24
-  - tornado >=6.1
-  - traitlets >=5.4.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/ipykernel
-  size: 119050
-  timestamp: 1708996727913
+  - pkg:pypi/ipykernel?source=conda-forge-mapping
+  size: 119568
+  timestamp: 1719845667420
 - kind: conda
   name: ipython
-  version: 8.22.2
+  version: 8.26.0
   build: pyh707e725_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh707e725_0.conda
-  sha256: 7740505317669f094c881537a643ed26977e209510965164d84942799c997d42
-  md5: f0abe827c8a7c6d91bccdf90cb1fbee3
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
+  sha256: a40c2859a055d98ba234d67b233fb1ba55d86cbe632ec96eecb7c5019c16478b
+  md5: f64d3520d5d00321c10f4dabb5b903f3
   depends:
   - __unix
   - decorator
@@ -5693,22 +5766,22 @@ packages:
   - python >=3.10
   - stack_data
   - traitlets >=5.13.0
-  - typing_extensions
+  - typing_extensions >=4.6
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython
-  size: 593746
-  timestamp: 1709559868257
+  - pkg:pypi/ipython?source=conda-forge-mapping
+  size: 599279
+  timestamp: 1719582627972
 - kind: conda
   name: ipython
-  version: 8.22.2
+  version: 8.26.0
   build: pyh7428d3b_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.22.2-pyh7428d3b_0.conda
-  sha256: f7196ab6d5251505fd5b9c6ff63694eff09be7959a0a3421b8c2336638de9aaf
-  md5: f803d121b60dff8f4d8f9264b7c6e8bf
+  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
+  sha256: b0fd9f89ef87c4b968ae8aae01c4ff8969eb4463f1fb28c77ff0b33b444d9cef
+  md5: f5047e2bc6a82dcdf2f169fdb0bbed99
   depends:
   - __win
   - colorama
@@ -5722,13 +5795,13 @@ packages:
   - python >=3.10
   - stack_data
   - traitlets >=5.13.0
-  - typing_extensions
+  - typing_extensions >=4.6
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython
-  size: 593699
-  timestamp: 1709560407504
+  - pkg:pypi/ipython?source=conda-forge-mapping
+  size: 600345
+  timestamp: 1719583103556
 - kind: conda
   name: isoduration
   version: 20.11.0
@@ -5744,7 +5817,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/isoduration
+  - pkg:pypi/isoduration?source=conda-forge-mapping
   size: 17189
   timestamp: 1638811664194
 - kind: conda
@@ -5762,153 +5835,155 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/jedi
+  - pkg:pypi/jedi?source=conda-forge-mapping
   size: 841312
   timestamp: 1696326218364
 - kind: conda
   name: jinja2
-  version: 3.1.3
+  version: 3.1.4
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.3-pyhd8ed1ab_0.conda
-  sha256: fd517b7dd3a61eca34f8a6f9f92f306397149cae1204fce72ac3d227107dafdc
-  md5: e7d8df6509ba635247ff9aea31134262
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+  sha256: 27380d870d42d00350d2d52598cddaf02f9505fb24be09488da0c9b8d1428f2d
+  md5: 7b86ecb7d3557821c649b3c31e3eb9f2
   depends:
   - markupsafe >=2.0
   - python >=3.7
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jinja2
-  size: 111589
-  timestamp: 1704967140287
+  - pkg:pypi/jinja2?source=conda-forge-mapping
+  size: 111565
+  timestamp: 1715127275924
 - kind: conda
   name: joblib
-  version: 1.3.2
+  version: 1.4.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.3.2-pyhd8ed1ab_0.conda
-  sha256: 31e05d47970d956206188480b038829d24ac11fe8216409d8584d93d40233878
-  md5: 4da50d410f553db77e62ab62ffaa1abc
+  url: https://conda.anaconda.org/conda-forge/noarch/joblib-1.4.2-pyhd8ed1ab_0.conda
+  sha256: 8ad719524b1039510fcbd75eb776123189d75e2c09228189257ddbcab86f5b64
+  md5: 25df261d4523d9f9783bcdb7208d872f
   depends:
-  - python >=3.7
+  - python >=3.8
   - setuptools
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/joblib
-  size: 221200
-  timestamp: 1691577306309
+  - pkg:pypi/joblib?source=conda-forge-mapping
+  size: 219731
+  timestamp: 1714665585214
 - kind: conda
   name: json-c
   version: '0.17'
-  build: h7ab15ed_0
+  build: h1220068_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h7ab15ed_0.conda
-  sha256: 5646496ca07dfa1486d27ed07282967007811dfc63d6394652e87f94166ecae3
-  md5: 9961b1f100c3b6852bd97c9233d06979
+  url: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.17-h1220068_1.conda
+  sha256: 0caf06ccfbd6f9a7b3a1e09fa83e318c9e84f2d1c1003a9e486f2600f4096720
+  md5: f8f0f0c4338bad5c34a4e9e11460481d
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 83050
-  timestamp: 1691933952501
+  size: 83682
+  timestamp: 1720812978049
 - kind: conda
   name: json-c
   version: '0.17'
-  build: h8e11ae5_0
+  build: h6253ea5_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h8e11ae5_0.conda
-  sha256: 2a493095fe1292108ff1799a1b47ababe82d844bfa3abcf2252676c1017a1e04
-  md5: 266d2e4ebbf37091c8322937392bb540
+  url: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.17-h6253ea5_1.conda
+  sha256: 66ddd1a4d643c7c800a1bb8e61f5f4198ec102be37db9a6d2e037004442eff8d
+  md5: fb72a2ef514c2df4ba035187945a6dcf
+  depends:
+  - __osx >=10.13
   license: MIT
   license_family: MIT
   purls: []
-  size: 71671
-  timestamp: 1691934144512
+  size: 72163
+  timestamp: 1720813111542
 - kind: conda
   name: json5
-  version: 0.9.24
+  version: 0.9.25
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.24-pyhd8ed1ab_0.conda
-  sha256: 148a427d4867ecd367b2bb9c2ef11ae7795abeabc8454f802f28ff692b3ce1aa
-  md5: fc9780a517b51ea3798fc011c17ffd51
+  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.25-pyhd8ed1ab_0.conda
+  sha256: 0c75e428970e8bb72ba1dd3a6dc32b8d68f6534b4fe16b38e53364963fdc8e38
+  md5: 5d8c241a9261e720a34a07a3e1ac4109
   depends:
   - python >=3.7,<4.0
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/json5
-  size: 27927
-  timestamp: 1710632397456
+  - pkg:pypi/json5?source=conda-forge-mapping
+  size: 27995
+  timestamp: 1712986338874
 - kind: conda
   name: jsonpointer
-  version: '2.4'
-  build: py312h2e8e312_3
-  build_number: 3
+  version: 3.0.0
+  build: py312h2e8e312_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py312h2e8e312_3.conda
-  sha256: 98d86d5ccb3a95da2cd96b394c157aa6fef0d4908b8878c3e2b5931f6bc5fd57
-  md5: 9d9572e257bf4559f20629efb0d3511d
+  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py312h2e8e312_0.conda
+  sha256: 74d440e8250ff2ca05013b959de954bc85d84ff14a3b60c9e3dc7e071cddfa42
+  md5: 6509bc42d9d26be656db3332da504913
   depends:
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jsonpointer
-  size: 34602
-  timestamp: 1695397923441
+  - pkg:pypi/jsonpointer?source=conda-forge-mapping
+  size: 42461
+  timestamp: 1718283943216
 - kind: conda
   name: jsonpointer
-  version: '2.4'
-  build: py312h7900ff3_3
-  build_number: 3
+  version: 3.0.0
+  build: py312h7900ff3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py312h7900ff3_3.conda
-  sha256: c211a79cff8aa001a6e14e923c37278231dca7f0970d8db155c4b9e48ac87a5a
-  md5: 50f62bdb9b60b13c2f6ae69957342e4d
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py312h7900ff3_0.conda
+  sha256: b5d17c5db3c7306d3625745a27359f806a6dd94707d76d74cba541fc1daa2ae3
+  md5: 320338762418ae59539ae368d4386085
   depends:
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jsonpointer
-  size: 18033
-  timestamp: 1695397448370
+  - pkg:pypi/jsonpointer?source=conda-forge-mapping
+  size: 17497
+  timestamp: 1718283512438
 - kind: conda
   name: jsonpointer
-  version: '2.4'
-  build: py312hb401068_3
-  build_number: 3
+  version: 3.0.0
+  build: py312hb401068_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py312hb401068_3.conda
-  sha256: 883f6d635e58f49359f393e853e4e0043731fb0ce671283a2024db02a1ebc8f6
-  md5: 637aa8f6c1c61f659f1496e9b2dc7552
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py312hb401068_0.conda
+  sha256: c28d5ee8ddc58858c711f0a4874916ed7d1306fa8b12bb95e3e8bb7183f2e287
+  md5: 7d360dce2fa56d1701773d26ecccb038
   depends:
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jsonpointer
-  size: 18184
-  timestamp: 1695397820416
+  - pkg:pypi/jsonpointer?source=conda-forge-mapping
+  size: 17704
+  timestamp: 1718283533709
 - kind: conda
   name: jsonschema
-  version: 4.21.1
+  version: 4.23.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
-  sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
-  md5: 8a3a3d01629da20befa340919e3dd2c4
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.23.0-pyhd8ed1ab_0.conda
+  sha256: 7d0c4c0346b26be9f220682b7c5c0d84606d48c6dbc36fc238e4452dda733aff
+  md5: da304c192ad59975202859b367d0f6a2
   depends:
   - attrs >=22.2.0
   - importlib_resources >=1.4.0
@@ -5920,9 +5995,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/jsonschema
-  size: 72817
-  timestamp: 1705707712082
+  - pkg:pypi/jsonschema?source=conda-forge-mapping
+  size: 74323
+  timestamp: 1720529611305
 - kind: conda
   name: jsonschema-specifications
   version: 2023.12.1
@@ -5939,43 +6014,42 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/jsonschema-specifications
+  - pkg:pypi/jsonschema-specifications?source=conda-forge-mapping
   size: 16431
   timestamp: 1703778502971
 - kind: conda
   name: jsonschema-with-format-nongpl
-  version: 4.21.1
-  build: pyhd8ed1ab_0
+  version: 4.23.0
+  build: hd8ed1ab_0
   subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-  sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
-  md5: 26bce4b5405738c09304d4f4796b2c2a
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.23.0-hd8ed1ab_0.conda
+  sha256: 007a0a506a0d1805b099629cb0ee743ad0afe7d9749e57339f32c168119e0139
+  md5: 16b37612b3a2fd77f409329e213b530c
   depends:
   - fqdn
   - idna
   - isoduration
   - jsonpointer >1.13
-  - jsonschema >=4.21.1,<4.21.2.0a0
-  - python
+  - jsonschema >=4.23.0,<4.23.1.0a0
   - rfc3339-validator
   - rfc3986-validator >0.1.0
   - uri-template
-  - webcolors >=1.11
+  - webcolors >=24.6.0
   license: MIT
   license_family: MIT
   purls: []
-  size: 7452
-  timestamp: 1705707742938
+  size: 7143
+  timestamp: 1720529619500
 - kind: conda
   name: jupyter-lsp
-  version: 2.2.4
+  version: 2.2.5
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.4-pyhd8ed1ab_0.conda
-  sha256: 8000b1904a2a10cf039b46305781128e1a93da4c2fd857445b4924ecf3535bdb
-  md5: 91f93e1ebf6535be518715432d89fd92
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.5-pyhd8ed1ab_0.conda
+  sha256: 2151c2c63e0442a4c69ee0ad8a634195eedab10b7b74c0ec8266471842239a93
+  md5: 885867f6adab3d7ecdf8ab6ca0785f51
   depends:
   - importlib-metadata >=4.8.3
   - jupyter_server >=1.1.2
@@ -5983,18 +6057,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-lsp
-  size: 55303
-  timestamp: 1709672683901
+  - pkg:pypi/jupyter-lsp?source=conda-forge-mapping
+  size: 55539
+  timestamp: 1712707521811
 - kind: conda
   name: jupyter_client
-  version: 8.6.1
+  version: 8.6.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.1-pyhd8ed1ab_0.conda
-  sha256: c7d10d7941fd2e61480e49d3b2b21a530af4ae4b0d449a1746a72a38bacb63e2
-  md5: c03972cfce69ad913d520c652e5ed908
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.2-pyhd8ed1ab_0.conda
+  sha256: 634f065cdd1d0aacd4bb6848ebf240dcebc8578135d65f4ad4aa42b2276c4e0c
+  md5: 3cdbb2fa84490e5fd44c9f9806c0d292
   depends:
   - importlib_metadata >=4.8.3
   - jupyter_core >=4.12,!=5.0.*
@@ -6006,9 +6080,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-client
-  size: 106042
-  timestamp: 1710255955150
+  - pkg:pypi/jupyter-client?source=conda-forge-mapping
+  size: 106248
+  timestamp: 1716472312833
 - kind: conda
   name: jupyter_core
   version: 5.7.2
@@ -6026,7 +6100,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-core
+  - pkg:pypi/jupyter-core?source=conda-forge-mapping
   size: 109880
   timestamp: 1710257719549
 - kind: conda
@@ -6045,7 +6119,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-core
+  - pkg:pypi/jupyter-core?source=conda-forge-mapping
   size: 92843
   timestamp: 1710257533875
 - kind: conda
@@ -6064,7 +6138,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-core
+  - pkg:pypi/jupyter-core?source=conda-forge-mapping
   size: 92679
   timestamp: 1710257658978
 - kind: conda
@@ -6088,44 +6162,44 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-events
+  - pkg:pypi/jupyter-events?source=conda-forge-mapping
   size: 21475
   timestamp: 1710805759187
 - kind: conda
   name: jupyter_server
-  version: 2.13.0
+  version: 2.14.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.13.0-pyhd8ed1ab_0.conda
-  sha256: 7e3259506b1b8500ebac4b4b097629ca8c32ee70d1c1df122052fea65c7cbae0
-  md5: e242df505f194c4932fbb840a99207e2
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.14.2-pyhd8ed1ab_0.conda
+  sha256: edab71a05feceac54bdb90e755a257545af7832b9911607c1a70f09be44ba985
+  md5: ca23c71f70a7c7935b3d03f0f1a5801d
   depends:
   - anyio >=3.1.0
-  - argon2-cffi
-  - jinja2
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
   - jupyter_client >=7.4.4
   - jupyter_core >=4.12,!=5.0.*
   - jupyter_events >=0.9.0
-  - jupyter_server_terminals
+  - jupyter_server_terminals >=0.4.4
   - nbconvert-core >=6.4.4
   - nbformat >=5.3.0
-  - overrides
-  - packaging
-  - prometheus_client
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
   - python >=3.8
   - pyzmq >=24
   - send2trash >=1.8.2
   - terminado >=0.8.3
   - tornado >=6.2.0
   - traitlets >=5.6.0
-  - websocket-client
+  - websocket-client >=1.7
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-server
-  size: 324502
-  timestamp: 1709563426862
+  - pkg:pypi/jupyter-server?source=conda-forge-mapping
+  size: 323978
+  timestamp: 1720816754998
 - kind: conda
   name: jupyter_server_terminals
   version: 0.5.3
@@ -6141,41 +6215,42 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-server-terminals
+  - pkg:pypi/jupyter-server-terminals?source=conda-forge-mapping
   size: 19818
   timestamp: 1710262791393
 - kind: conda
   name: jupyterlab
-  version: 4.1.5
+  version: 4.2.4
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.5-pyhd8ed1ab_0.conda
-  sha256: b098b79ef34d5c6a9ef7fc482bd2373072820006757ed7db33328af88fb91496
-  md5: 04b1ca9d7ac414b3f5c3fb16066c6861
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.2.4-pyhd8ed1ab_0.conda
+  sha256: e3b585b55634da48871ed3082c429652a62bf0cf7733641b1382b9c314f1c901
+  md5: 28f3334e97c39de2b7ac15743b041784
   depends:
   - async-lru >=1.0.0
   - httpx >=0.25.0
   - importlib_metadata >=4.8.3
   - importlib_resources >=1.4
-  - ipykernel
+  - ipykernel >=6.5.0
   - jinja2 >=3.0.3
   - jupyter-lsp >=2.0.0
   - jupyter_core
   - jupyter_server >=2.4.0,<3
-  - jupyterlab_server >=2.19.0,<3
+  - jupyterlab_server >=2.27.1,<3
   - notebook-shim >=0.2
   - packaging
   - python >=3.8
-  - tomli
+  - setuptools >=40.1.0
+  - tomli >=1.2.2
   - tornado >=6.2.0
   - traitlets
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyterlab
-  size: 7062018
-  timestamp: 1710450498940
+  - pkg:pypi/jupyterlab?source=conda-forge-mapping
+  size: 8187486
+  timestamp: 1721396667021
 - kind: conda
   name: jupyterlab_pygments
   version: 0.3.0
@@ -6194,18 +6269,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyterlab-pygments
+  - pkg:pypi/jupyterlab-pygments?source=conda-forge-mapping
   size: 18776
   timestamp: 1707149279640
 - kind: conda
   name: jupyterlab_server
-  version: 2.25.4
+  version: 2.27.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.4-pyhd8ed1ab_0.conda
-  sha256: d0336d0c0223a66d648b24cfd1512fd7aebc85550d47f55ad5edbd53f482e7e5
-  md5: ffd61670ae09d2d3c637f6afd29db443
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
+  sha256: a23b26d1a35bccdb91b9232119e5f402624e1e1a252b0e64cc20c6eb5b87cefb
+  md5: af8239bf1ba7e8c69b689f780f653488
   depends:
   - babel >=2.10
   - importlib-metadata >=4.8.3
@@ -6221,50 +6296,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyterlab-server
-  size: 48821
-  timestamp: 1710189875931
+  - pkg:pypi/jupyterlab-server?source=conda-forge-mapping
+  size: 49355
+  timestamp: 1721163412436
 - kind: conda
   name: kealib
   version: 1.5.3
-  build: h2f55d51_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-h2f55d51_0.conda
-  sha256: ee0934ff426d3cab015055808bed33eb9d20f635ec14bc421c596f4b70927102
-  md5: f7e7077802927590efc8bf7328208f12
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 172990
-  timestamp: 1703115976887
-- kind: conda
-  name: kealib
-  version: 1.5.3
-  build: h5f07ac3_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-h5f07ac3_0.conda
-  sha256: 54a847faf2d2aea83c149d98634646edb8e7f346faefc6af1aa52106200b43aa
-  md5: 7a0924f6214e4c17b6062b21d1240253
-  depends:
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libcxx >=15
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 149513
-  timestamp: 1703116284587
-- kind: conda
-  name: kealib
-  version: 1.5.3
-  build: hd248416_0
+  build: h6c43f9b_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-hd248416_0.conda
-  sha256: 833a9f8acc1982a174267f8cd12d161cbafc42fdaeb7beb075975977b5ee56f5
-  md5: b65b0092dade29117f6e87c8d11a2394
+  url: https://conda.anaconda.org/conda-forge/win-64/kealib-1.5.3-h6c43f9b_1.conda
+  sha256: b4b2cee0ad62ae1f8e4a541d34074c575df935682c023fdf1c21c9c5c9995fa9
+  md5: a20c9e3598a55ca3e61cad90ef33ada3
   depends:
   - hdf5 >=1.14.3,<1.14.4.0a0
   - ucrt >=10.0.20348.0
@@ -6273,8 +6316,44 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 133421
-  timestamp: 1703116732437
+  size: 133355
+  timestamp: 1716158947179
+- kind: conda
+  name: kealib
+  version: 1.5.3
+  build: hb2b617a_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/kealib-1.5.3-hb2b617a_1.conda
+  sha256: 3150dedf047284e8b808a169dfe630d818d8513b79d08a5404b90973c61c6914
+  md5: e24e1fa559fd29c34593d6a47b459443
+  depends:
+  - __osx >=10.13
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 152270
+  timestamp: 1716158359765
+- kind: conda
+  name: kealib
+  version: 1.5.3
+  build: hee9dde6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.5.3-hee9dde6_1.conda
+  sha256: d607ddb5906a335cb3665dd81f3adec4af248cf398147693b470b65d887408e7
+  md5: c5b7b29e2b66107553d0366538257a51
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 170709
+  timestamp: 1716158265533
 - kind: conda
   name: keyutils
   version: 1.6.1
@@ -6307,7 +6386,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/kiwisolver
+  - pkg:pypi/kiwisolver?source=conda-forge-mapping
   size: 55576
   timestamp: 1695380565733
 - kind: conda
@@ -6326,7 +6405,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/kiwisolver
+  - pkg:pypi/kiwisolver?source=conda-forge-mapping
   size: 60227
   timestamp: 1695380392812
 - kind: conda
@@ -6346,65 +6425,66 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/kiwisolver
+  - pkg:pypi/kiwisolver?source=conda-forge-mapping
   size: 72099
   timestamp: 1695380122482
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: h659d440_0
+  version: 1.21.3
+  build: h37d8d59_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.3-h37d8d59_0.conda
+  sha256: 83b52685a4ce542772f0892a0f05764ac69d57187975579a0835ff255ae3ef9c
+  md5: d4765c524b1d91567886bde656fb514b
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libedit >=3.1.20191231,<3.2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1185323
+  timestamp: 1719463492984
+- kind: conda
+  name: krb5
+  version: 1.21.3
+  build: h659f571_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
-  sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  md5: cd95826dbd331ed1be26bdf401432844
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
+  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
   depends:
   - keyutils >=1.6.1,<2.0a0
   - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 1371181
-  timestamp: 1692097755782
+  size: 1370023
+  timestamp: 1719463201255
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: hb884880_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
-  sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
-  md5: 80505a68783f01dc8d7308c075261b2f
-  depends:
-  - libcxx >=15.0.7
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.1.2,<4.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 1183568
-  timestamp: 1692098004387
-- kind: conda
-  name: krb5
-  version: 1.21.2
-  build: heb0366b_0
+  version: 1.21.3
+  build: hdf4eb48_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
-  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
   depends:
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 710894
-  timestamp: 1692098129546
+  size: 712034
+  timestamp: 1719463874284
 - kind: conda
   name: lame
   version: '3.100'
@@ -6476,18 +6556,19 @@ packages:
 - kind: conda
   name: ld_impl_linux-64
   version: '2.40'
-  build: h41732ed_0
+  build: hf3520f5_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
-  sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  md5: 7aca3059a1729aa76c597603f10b0dd3
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
+  sha256: 764b6950aceaaad0c67ef925417594dd14cd2e22fff864aeef455ac259263d15
+  md5: b80f2f396ca2c28b8c14c437a4ed1e74
   constrains:
   - binutils_impl_linux-64 2.40
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 704696
-  timestamp: 1674833944779
+  size: 707602
+  timestamp: 1718625640445
 - kind: conda
   name: lerc
   version: 4.0.0
@@ -6537,65 +6618,66 @@ packages:
   timestamp: 1657977526749
 - kind: conda
   name: libabseil
-  version: '20240116.1'
-  build: cxx17_h59595ed_2
-  build_number: 2
+  version: '20240116.2'
+  build: cxx17_he02047a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
-  sha256: 9951421311285dd4335ad3aceffb223a4d3bc90fb804245508cd27aceb184a29
-  md5: 75648bc5dd3b8eab22406876c24d81ec
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
+  sha256: 945396726cadae174a661ce006e3f74d71dbd719219faf7cc74696b267f7b0b5
+  md5: c48fc56ec03229f294176923c3265c05
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   constrains:
-  - libabseil-static =20240116.1=cxx17*
-  - abseil-cpp =20240116.1
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1266503
-  timestamp: 1709159756788
+  size: 1264712
+  timestamp: 1720857377573
 - kind: conda
   name: libabseil
-  version: '20240116.1'
-  build: cxx17_h63175ca_2
-  build_number: 2
+  version: '20240116.2'
+  build: cxx17_he0c23c2_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
-  sha256: 565071112e6339051b037bb9c5dae3f4bbc3b45c6f7b8ee598d0ec9056346c93
-  md5: bda6bc65300c4188933d8c68abc97923
+  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
+  sha256: aafa7993698420ef786c145f660e6822139c02cf9230fbad43efff6d4828defc
+  md5: 19725e54b7f996e0a5748ec5e9e37ae9
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - libabseil-static =20240116.1=cxx17*
-  - abseil-cpp =20240116.1
+  - libabseil-static =20240116.2=cxx17*
+  - abseil-cpp =20240116.2
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1737645
-  timestamp: 1709160246325
+  size: 1802886
+  timestamp: 1720857653184
 - kind: conda
   name: libabseil
-  version: '20240116.1'
-  build: cxx17_hc1bcbd7_2
-  build_number: 2
+  version: '20240116.2'
+  build: cxx17_hf036a51_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
-  sha256: 30c0f569949a2fa0c5fd9aae3416e3f6623b9dd6fccdaa8d3437f143b67cca2a
-  md5: 819934a15bc13a0d30778bf18446ada6
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
+  sha256: 396d18f39d5207ecae06fddcbc6e5f20865718939bc4e0ea9729e13952833aac
+  md5: d6c78ca84abed3fea5f308ac83b8f54e
   depends:
+  - __osx >=10.13
   - libcxx >=16
   constrains:
-  - libabseil-static =20240116.1=cxx17*
-  - __osx >=10.13
-  - abseil-cpp =20240116.1
+  - abseil-cpp =20240116.2
+  - libabseil-static =20240116.2=cxx17*
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1133225
-  timestamp: 1709160179404
+  size: 1124364
+  timestamp: 1720857589333
 - kind: conda
   name: libaec
   version: 1.1.3
@@ -6646,610 +6728,382 @@ packages:
   timestamp: 1711021419744
 - kind: conda
   name: libarchive
-  version: 3.7.2
-  build: h2aa1ff5_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.2-h2aa1ff5_1.conda
-  sha256: 340ed0bb02fe26a2b2e29cedf6559e2999b820f434e745c108e788d629ae4b17
-  md5: 3bf887827d1968275978361a6e405e4f
+  version: 3.7.4
+  build: h20e244c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
+  sha256: 9e46db25e976630e6738b351d76d9b79047ae232638b82f9f45eba774caaef8a
+  md5: 82a85fa38e83366009b7f4b2cef4deb8
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libxml2 >=2.12.2,<2.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - lzo >=2.10,<3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 866168
-  timestamp: 1701994227275
+  size: 742682
+  timestamp: 1716394747351
 - kind: conda
   name: libarchive
-  version: 3.7.2
-  build: h313118b_1
-  build_number: 1
+  version: 3.7.4
+  build: haf234dc_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.2-h313118b_1.conda
-  sha256: 8dd608299e8bc56e0337c6653028e552fea8b952af10fbcc2f4008274add11a1
-  md5: 4b84938cdb30e9cc2dc413208e917e11
+  url: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
+  sha256: 3ab13c269949874c4538b22eeb83a36d2c55b4a4ea6628bef1bab4c724ee5a1b
+  md5: 86de12ebf8d7fffeba4ca9dbf13e9733
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libxml2 >=2.12.2,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - lzo >=2.10,<3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 964623
-  timestamp: 1701994828221
+  size: 957632
+  timestamp: 1716395481752
 - kind: conda
   name: libarchive
-  version: 3.7.2
-  build: hd35d340_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.2-hd35d340_1.conda
-  sha256: f458515a49c56e117e05fe607493b7683a7bf06d2a625b59e378dbbf7f308895
-  md5: 8c7b79b20a67287a87b39df8a8c8dcc4
+  version: 3.7.4
+  build: hfca40fe_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
+  sha256: c30970e5e6515c662d00bb74e7c1b09ebe0c8c92c772b952a41a5725e2dcc936
+  md5: 32ddb97f897740641d8d46a829ce1704
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libiconv >=1.17,<2.0a0
-  - libxml2 >=2.12.2,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgcc-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - lzo >=2.10,<3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 745686
-  timestamp: 1701994485309
+  size: 871853
+  timestamp: 1716394516418
 - kind: conda
   name: libarrow
-  version: 15.0.2
-  build: h878f99b_1_cpu
-  build_number: 1
+  version: 17.0.0
+  build: h11e6a32_2_cpu
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-15.0.2-h878f99b_1_cpu.conda
-  sha256: b2a67b9ef9526da159b9fb64d225c4f4121cde176bcd1fc38617fd7935c0a9b5
-  md5: a22f43ca465278c992639603c2b8e48c
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h11e6a32_2_cpu.conda
+  sha256: 829e49849d6fc98728c7f9212a76af9a057342b649ac85486a1bd7f9fbf8bbc5
+  md5: 987cc5f7abb9e8041b427ed55774aff4
   depends:
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
   - bzip2 >=1.0.8,<2.0a0
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
+  - libabseil >=20240116.2,<20240117.0a0
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.6.0,<9.0a0
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
+  - libcurl >=8.9.0,<9.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
   - libre2-11 >=2023.9.1,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.1,<4.0a0
-  - orc >=2.0.0,<2.0.1.0a0
+  - orc >=2.0.1,<2.0.2.0a0
   - re2
-  - snappy >=1.1.10,<2.0a0
+  - snappy >=1.2.1,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
+  - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 5083581
-  timestamp: 1711178993402
+  size: 5145540
+  timestamp: 1721955719293
 - kind: conda
   name: libarrow
-  version: 15.0.2
-  build: h8d4fe2c_1_cpu
-  build_number: 1
+  version: 17.0.0
+  build: h130fc27_2_cpu
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.2-h8d4fe2c_1_cpu.conda
-  sha256: 0c00897262e54c54f3769384518792f4dda43e384111cfedb2fc6c85ad8e1fb9
-  md5: 0dfd8ebfe7557c521e195b40375735e7
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h130fc27_2_cpu.conda
+  sha256: f5e4fc5e4b94b86e31986c7344ca47124ab76b9f697b5f32942ac6a404eb3783
+  md5: d54f6230b476eb2d72cf4504a50d77df
   depends:
   - __osx >=10.13
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-files-datalake-cpp >=12.11.0,<12.11.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.0,<0.8.0a0
+  - glog >=0.7.1,<0.8.0a0
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
+  - libabseil >=20240116.2,<20240117.0a0
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
   - libcxx >=16
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
   - libre2-11 >=2023.9.1,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.0,<2.0.1.0a0
+  - orc >=2.0.1,<2.0.2.0a0
   - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - arrow-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 5711851
-  timestamp: 1711266383556
+  size: 5914438
+  timestamp: 1721954847558
 - kind: conda
   name: libarrow
-  version: 15.0.2
-  build: hb86450c_1_cpu
-  build_number: 1
+  version: 17.0.0
+  build: h4b47046_2_cpu
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.2-hb86450c_1_cpu.conda
-  sha256: f99e523a0dea433fcc79caf18057ef83621fd28da6f1b3e42096c4deaa485416
-  md5: b68f648f3e2f60755adaa5bfb93287d0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h4b47046_2_cpu.conda
+  sha256: b40f6d34408b191ca68699d45ac3bbfae7775f0f535166092b69734b30dc0043
+  md5: 715b8afa678fd8ef0c2a1a2f5d575d9b
   depends:
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-files-datalake-cpp >=12.11.0,<12.11.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.0,<0.8.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.7.1,<0.8.0a0
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
+  - libabseil >=20240116.2,<20240117.0a0
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
   - libgcc-ng >=12
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
   - libre2-11 >=2023.9.1,<2024.0a0
   - libstdcxx-ng >=12
   - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.0,<2.0.1.0a0
+  - orc >=2.0.1,<2.0.2.0a0
   - re2
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 8179378
-  timestamp: 1711178447850
+  size: 8392931
+  timestamp: 1721955073249
 - kind: conda
   name: libarrow-acero
-  version: 15.0.2
-  build: h59595ed_1_cpu
-  build_number: 1
+  version: 17.0.0
+  build: he02047a_2_cpu
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.2-h59595ed_1_cpu.conda
-  sha256: 6bf96851b6451f5d3ede688d454a23e40e53bbceb1e56e6d30a538be451d126d
-  md5: b9423f0ec36b99f729aa890b6fb3c98d
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_2_cpu.conda
+  sha256: c710601c8fad60f422c4597e73f176753b69c4d4ef1bd3f0de5615a2ab6a28a2
+  md5: 43cee94a84bbe6e2d7c123af27140578
   depends:
-  - libarrow 15.0.2 hb86450c_1_cpu
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0 h4b47046_2_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 597414
-  timestamp: 1711178497118
+  size: 598162
+  timestamp: 1721955111941
 - kind: conda
   name: libarrow-acero
-  version: 15.0.2
-  build: h63175ca_1_cpu
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-15.0.2-h63175ca_1_cpu.conda
-  sha256: bb9a0f2585dd122ac9d4150215cbdc4a835cee0595aa8f4d094cb98b6a0b903f
-  md5: 1760e0c37e7b61989f3a23067721f84e
-  depends:
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 445679
-  timestamp: 1711179087147
-- kind: conda
-  name: libarrow-acero
-  version: 15.0.2
-  build: hd427752_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.2-hd427752_1_cpu.conda
-  sha256: 35a25a398c21791d8a7806be09b5d02b505081839d7ae5f9dc888d60f3c0d205
-  md5: c0ebc15c626587f686000bd92be0700f
-  depends:
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 522140
-  timestamp: 1711266483945
-- kind: conda
-  name: libarrow-dataset
-  version: 15.0.2
-  build: h59595ed_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.2-h59595ed_1_cpu.conda
-  sha256: 41610da5423d6f167791b9dcf670151d53dbe545092e95efafd68dbf4437e6b1
-  md5: a921e87ad731a7cde36a016233c1b80b
-  depends:
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libarrow-acero 15.0.2 h59595ed_1_cpu
-  - libgcc-ng >=12
-  - libparquet 15.0.2 h352af49_1_cpu
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 583806
-  timestamp: 1711178621744
-- kind: conda
-  name: libarrow-dataset
-  version: 15.0.2
-  build: h63175ca_1_cpu
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-15.0.2-h63175ca_1_cpu.conda
-  sha256: 68c8d5e01b3d404bd7c9b12d66cff1b03f8353c76d09c99e2a2f8ceecfcc094e
-  md5: e794000b8e1137d5cacbeba3811ecf3d
-  depends:
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - libarrow-acero 15.0.2 h63175ca_1_cpu
-  - libparquet 15.0.2 h7ec3a38_1_cpu
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 431252
-  timestamp: 1711179443216
-- kind: conda
-  name: libarrow-dataset
-  version: 15.0.2
-  build: hd427752_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.2-hd427752_1_cpu.conda
-  sha256: 4b0ea6e2c18c6add7e276447b751e09b20289d4bc672857abc05a525c138b532
-  md5: afb8fa396c1963637ab416acccf9c833
-  depends:
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libarrow-acero 15.0.2 hd427752_1_cpu
-  - libcxx >=16
-  - libparquet 15.0.2 h089a9f7_1_cpu
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 512287
-  timestamp: 1711266804210
-- kind: conda
-  name: libarrow-flight
-  version: 15.0.2
-  build: h02312f3_1_cpu
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-15.0.2-h02312f3_1_cpu.conda
-  sha256: 9e5f73153ed5ee20431943a11e5aee79674bded2584b614d4e4d5962c7a35a64
-  md5: 8bc6c812f84251b654b3db070d9b72ad
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 289403
-  timestamp: 1711179180265
-- kind: conda
-  name: libarrow-flight
-  version: 15.0.2
-  build: h39e3226_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.2-h39e3226_1_cpu.conda
-  sha256: 6b12aca956d1c300a03fc3e25bd5b741a84f516dc2fe8d765350555d05126bd7
-  md5: 4c10ac4396926e3b262a07fe7a4b85e6
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libcxx >=16
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 323015
-  timestamp: 1711266565593
-- kind: conda
-  name: libarrow-flight
-  version: 15.0.2
-  build: hc6145d9_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.2-hc6145d9_1_cpu.conda
-  sha256: 0524b7b92b6d3ab5b043f5e3ea57291aec8fe69813191819bfd9e74bdcedfa1d
-  md5: a8166c3e9ff1222307cdd86af0234dbe
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libgcc-ng >=12
-  - libgrpc >=1.62.1,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - ucx >=1.15.0,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 503481
-  timestamp: 1711178527272
-- kind: conda
-  name: libarrow-flight-sql
-  version: 15.0.2
-  build: h1a3ed6a_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.2-h1a3ed6a_1_cpu.conda
-  sha256: ab67e0202ca0565561eedf5c16d61b8bdf4302034bfad78b385574a74406fa7e
-  md5: fa369c66520f1ada8738fbf15ef0ee50
-  depends:
-  - __osx >=10.13
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libarrow-flight 15.0.2 h39e3226_1_cpu
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 154416
-  timestamp: 1711266892717
-- kind: conda
-  name: libarrow-flight-sql
-  version: 15.0.2
-  build: h55b4db4_1_cpu
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-15.0.2-h55b4db4_1_cpu.conda
-  sha256: 7954820f6e8d924419a372d90db68c1aa707101dbf9dc0204497597f831adab8
-  md5: 19d5af0b9e0adbb702969a5f75f9596f
-  depends:
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - libarrow-flight 15.0.2 h02312f3_1_cpu
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 235286
-  timestamp: 1711179521999
-- kind: conda
-  name: libarrow-flight-sql
-  version: 15.0.2
-  build: h757c851_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.2-h757c851_1_cpu.conda
-  sha256: 5d2910012453c698657a2129c9d3337d4569d79a23cf93b40ada013777a04798
-  md5: b59b90d6c8d2e072890f5d289f9ba36f
-  depends:
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libarrow-flight 15.0.2 hc6145d9_1_cpu
-  - libgcc-ng >=12
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 194476
-  timestamp: 1711178653236
-- kind: conda
-  name: libarrow-gandiva
-  version: 15.0.2
-  build: h3f2ff47_1_cpu
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.2-h3f2ff47_1_cpu.conda
-  sha256: ff32757e31319f82b059be869b9e6fad1a65ccaa644263f8a30d5cf4ac0d20e2
-  md5: 68d3eaa519881658b9a8fbdddb1b3a0d
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 10716092
-  timestamp: 1711179268859
-- kind: conda
-  name: libarrow-gandiva
-  version: 15.0.2
-  build: h43798cf_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.2-h43798cf_1_cpu.conda
-  sha256: 95f3ea92b602de66fe03b09ad8718659503cadf3e424fd7e40a5949d9573f9ea
-  md5: bc579bbc786f9c0a58b249e2adb0b26e
-  depends:
-  - __osx >=10.13
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libcxx >=16
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 700923
-  timestamp: 1711266648558
-- kind: conda
-  name: libarrow-gandiva
-  version: 15.0.2
-  build: hb016d2e_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.2-hb016d2e_1_cpu.conda
-  sha256: 1e528b63285fd1918495e9b2ba83ece291ef0d53060b9120bb2af3591b53ffdd
-  md5: c595407620b1688599908bdc1c17fd74
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libgcc-ng >=12
-  - libllvm16 >=16.0.6,<16.1.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libstdcxx-ng >=12
-  - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - re2
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 896830
-  timestamp: 1711178560814
-- kind: conda
-  name: libarrow-substrait
-  version: 15.0.2
-  build: h1a3ed6a_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.2-h1a3ed6a_1_cpu.conda
-  sha256: 6cf5535189e7bd3bf20ebef56381ab8bd161543228a851f5285ead9736477f33
-  md5: e3c034db160f4604bd11028c3d825fa6
-  depends:
-  - __osx >=10.13
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libarrow-acero 15.0.2 hd427752_1_cpu
-  - libarrow-dataset 15.0.2 hd427752_1_cpu
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 449725
-  timestamp: 1711266974219
-- kind: conda
-  name: libarrow-substrait
-  version: 15.0.2
-  build: h757c851_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.2-h757c851_1_cpu.conda
-  sha256: c4d7e0e2753eb193144b18ca78699d92da2a76011c3441952393ee672d1b9e32
-  md5: 802e115e2c489e1c76c0fe809e766ccd
-  depends:
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libarrow-acero 15.0.2 h59595ed_1_cpu
-  - libarrow-dataset 15.0.2 h59595ed_1_cpu
-  - libgcc-ng >=12
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 519390
-  timestamp: 1711178682023
-- kind: conda
-  name: libarrow-substrait
-  version: 15.0.2
-  build: h89268de_1_cpu
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.2-h89268de_1_cpu.conda
-  sha256: fd0c01546dec8d2cc8bfd6f88d80c961ca92f04872bda0441c4320cd4df6ed20
-  md5: 99a787c11d708974eb7adde145591136
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - libarrow-acero 15.0.2 h63175ca_1_cpu
-  - libarrow-dataset 15.0.2 h63175ca_1_cpu
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 361715
-  timestamp: 1711179599839
-- kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h5728263_2
+  version: 17.0.0
+  build: he0c23c2_2_cpu
   build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-0.22.5-h5728263_2.conda
-  sha256: 5722a4a260355c9233680a3424a977433f25826ca0a1c05af403d62b805681bc
-  md5: 75a6982b9ff0a8db0f53303527b07af8
-  license: LGPL-2.1-or-later
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_2_cpu.conda
+  sha256: 463c846a4a0f76056c03b44dd6a45530cf45ccd72d09d9b5b85a7e8065afdab8
+  md5: ea763696096132652646082db0c1b5b7
+  depends:
+  - libarrow 17.0.0 h11e6a32_2_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
   purls: []
-  size: 49778
-  timestamp: 1712515968238
+  size: 445813
+  timestamp: 1721955798599
 - kind: conda
-  name: libasprintf
-  version: 0.22.5
-  build: h5ff76d1_2
+  name: libarrow-acero
+  version: 17.0.0
+  build: hf036a51_2_cpu
   build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
-  sha256: 4babb29b8d39ae8b341c094c134a1917c595846e5f974c9d0cb64d3f734b46b1
-  md5: ad803793d7168331f1395685cbdae212
-  license: LGPL-2.1-or-later
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hf036a51_2_cpu.conda
+  sha256: 4309d8b0324687f97b692ca5221a104dc2343d013c7849f030c0759f83e40138
+  md5: 535d428745f06bdf966de4acf55f5ade
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0 h130fc27_2_cpu
+  - libcxx >=16
+  license: Apache-2.0
   purls: []
-  size: 40438
-  timestamp: 1712512749697
+  size: 522450
+  timestamp: 1721954942117
+- kind: conda
+  name: libarrow-dataset
+  version: 17.0.0
+  build: he02047a_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_2_cpu.conda
+  sha256: 6fe4d93d43f53d173c2d2b77bba7aaffd134b1de9ecd3382dc8f0d89d3eb4f2b
+  md5: 241bbbd938197304409716fa9510b5f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0 h4b47046_2_cpu
+  - libarrow-acero 17.0.0 he02047a_2_cpu
+  - libgcc-ng >=12
+  - libparquet 17.0.0 h9e5060d_2_cpu
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  purls: []
+  size: 579424
+  timestamp: 1721955184653
+- kind: conda
+  name: libarrow-dataset
+  version: 17.0.0
+  build: he0c23c2_2_cpu
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_2_cpu.conda
+  sha256: d448cc14b48bd03968f8bcccc7a42a6ab945bbdf389587a213ddf66cadad31cf
+  md5: e415db627f83cba18f36847eb0314237
+  depends:
+  - libarrow 17.0.0 h11e6a32_2_cpu
+  - libarrow-acero 17.0.0 he0c23c2_2_cpu
+  - libparquet 17.0.0 h178134c_2_cpu
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  purls: []
+  size: 427106
+  timestamp: 1721956034070
+- kind: conda
+  name: libarrow-dataset
+  version: 17.0.0
+  build: hf036a51_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hf036a51_2_cpu.conda
+  sha256: 989a014cb32e91e64ec208530da88e0c727a8bd56a039a956744049eb03ad23b
+  md5: e97592b6b66519baf1f8c22cb47ee8ec
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0 h130fc27_2_cpu
+  - libarrow-acero 17.0.0 hf036a51_2_cpu
+  - libcxx >=16
+  - libparquet 17.0.0 h904a336_2_cpu
+  license: Apache-2.0
+  purls: []
+  size: 509346
+  timestamp: 1721955570511
+- kind: conda
+  name: libarrow-substrait
+  version: 17.0.0
+  build: h1f0e801_2_cpu
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_2_cpu.conda
+  sha256: e6ff913d34f9c5766acf378a8f0956d9f7060122f6d3a7daf9aa90d8a6589e63
+  md5: 903453f0ae8f782747ce04ff5bcb15cc
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 17.0.0 h11e6a32_2_cpu
+  - libarrow-acero 17.0.0 he0c23c2_2_cpu
+  - libarrow-dataset 17.0.0 he0c23c2_2_cpu
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  purls: []
+  size: 383187
+  timestamp: 1721956139856
+- kind: conda
+  name: libarrow-substrait
+  version: 17.0.0
+  build: h85bc590_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-h85bc590_2_cpu.conda
+  sha256: 978cc5306585601c51f354661c33ab86ceca0cf298221060514755b2fc03f6b6
+  md5: e6a41720db57e512468cdab8c6bd160f
+  depends:
+  - __osx >=10.13
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 17.0.0 h130fc27_2_cpu
+  - libarrow-acero 17.0.0 hf036a51_2_cpu
+  - libarrow-dataset 17.0.0 hf036a51_2_cpu
+  - libcxx >=16
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  license: Apache-2.0
+  purls: []
+  size: 480979
+  timestamp: 1721955767582
+- kind: conda
+  name: libarrow-substrait
+  version: 17.0.0
+  build: hc9a23c6_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_2_cpu.conda
+  sha256: 29c0670577e2a6a298b9119a28dfb6e1b11649587c5abd9e31d89d6b52da8f24
+  md5: 7c6bbc213f37b593c6a90a36b371e48d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libarrow 17.0.0 h4b47046_2_cpu
+  - libarrow-acero 17.0.0 he02047a_2_cpu
+  - libarrow-dataset 17.0.0 he02047a_2_cpu
+  - libgcc-ng >=12
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  purls: []
+  size: 548676
+  timestamp: 1721955219102
 - kind: conda
   name: libasprintf
   version: 0.22.5
@@ -7269,36 +7123,6 @@ packages:
 - kind: conda
   name: libasprintf-devel
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libasprintf-devel-0.22.5-h5728263_2.conda
-  sha256: d5c711d9da4e35d29f4f2191664075c64cbf8cd481a35bf7ef3a527018eb0184
-  md5: 8377da2cc31200d7181d2e48d60e4c7b
-  depends:
-  - libasprintf 0.22.5 h5728263_2
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 36272
-  timestamp: 1712516175913
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
-  sha256: 39fa757378b49993142013c1f69dd56248cc3703c2f04c5bcf4cc4acdc644ae3
-  md5: c7182eda3bc727384e2f98f4d680fa7d
-  depends:
-  - libasprintf 0.22.5 h5ff76d1_2
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 34702
-  timestamp: 1712512806211
-- kind: conda
-  name: libasprintf-devel
-  version: 0.22.5
   build: h661eb56_2
   build_number: 2
   subdir: linux-64
@@ -7312,28 +7136,6 @@ packages:
   purls: []
   size: 34225
   timestamp: 1712512295117
-- kind: conda
-  name: libblas
-  version: 3.9.0
-  build: 22_linux64_openblas
-  build_number: 22
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-22_linux64_openblas.conda
-  sha256: 082b8ac20d43a7bbcdc28b3b1cd40e4df3a8b5daf0a2d23d68953a44d2d12c1b
-  md5: 1a2a0cd3153464fee6646f3dd6dad9b8
-  depends:
-  - libopenblas >=0.3.27,<0.3.28.0a0
-  - libopenblas >=0.3.27,<1.0a0
-  constrains:
-  - libcblas 3.9.0 22_linux64_openblas
-  - blas * openblas
-  - liblapacke 3.9.0 22_linux64_openblas
-  - liblapack 3.9.0 22_linux64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 14537
-  timestamp: 1712542250081
 - kind: conda
   name: libblas
   version: 3.9.0
@@ -7359,69 +7161,46 @@ packages:
 - kind: conda
   name: libblas
   version: 3.9.0
-  build: 22_win64_mkl
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-22_win64_mkl.conda
-  sha256: 4faab445cbd9a13736a206b98fde962d0a9fa80dcbd38300951a8b2863e7c35c
-  md5: 65c56ecdeceffd6c32d3d54db7e02c6e
+  build: 23_linux64_openblas
+  build_number: 23
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
+  sha256: edb1cee5da3ac4936940052dcab6969673ba3874564f90f5110f8c11eed789c2
+  md5: 96c8450a40aa2b9733073a9460de972c
   depends:
-  - mkl 2024.1.0 h66d3029_692
+  - libopenblas >=0.3.27,<0.3.28.0a0
+  - libopenblas >=0.3.27,<1.0a0
   constrains:
-  - liblapacke 3.9.0 22_win64_mkl
-  - blas * mkl
-  - libcblas 3.9.0 22_win64_mkl
-  - liblapack 3.9.0 22_win64_mkl
+  - liblapacke 3.9.0 23_linux64_openblas
+  - libcblas 3.9.0 23_linux64_openblas
+  - liblapack 3.9.0 23_linux64_openblas
+  - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 5182602
-  timestamp: 1712542984136
+  size: 14880
+  timestamp: 1721688759937
 - kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: h57928b3_2
-  build_number: 2
+  name: libblas
+  version: 3.9.0
+  build: 23_win64_mkl
+  build_number: 23
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_2.conda
-  sha256: 9acabbc9bf68f89ff60aa06e622b1bdf20edc7b3f53bfc782135f0ea9882291f
-  md5: 01d545c5fbafd05719fa31148cbd1989
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-23_win64_mkl.conda
+  sha256: fd52eb0ec4d0ca5727317dd608c41dacc8ccfc7e21d943b7aafbbf10ae28c97c
+  md5: 693407a31c27e70c750b5ae153251d9a
+  depends:
+  - mkl 2024.1.0 h66d3029_694
   constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
+  - blas * mkl
+  - liblapack 3.9.0 23_win64_mkl
+  - libcblas 3.9.0 23_win64_mkl
+  - liblapacke 3.9.0 23_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
   purls: []
-  size: 13853504
-  timestamp: 1711405828125
-- kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: h694c41f_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_2.conda
-  sha256: e51f3b877ab4a7a68bf1e1f95e9b007d716e85547078bfd5f6f7f114545dc26e
-  md5: 37678c6938655e8862e121b48101365a
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  purls: []
-  size: 13810365
-  timestamp: 1711406234038
-- kind: conda
-  name: libboost-headers
-  version: 1.84.0
-  build: ha770c72_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_2.conda
-  sha256: 5a7843db33422d043256af27f288836f51530b058653bdb074704eb72282f601
-  md5: 85d30a3fcc0f1cfc252776208af546a1
-  constrains:
-  - boost-cpp =1.84.0
-  license: BSL-1.0
-  purls: []
-  size: 13730884
-  timestamp: 1711404167604
+  size: 5192100
+  timestamp: 1721689573083
 - kind: conda
   name: libbrotlicommon
   version: 1.1.0
@@ -7593,26 +7372,6 @@ packages:
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 22_linux64_openblas
-  build_number: 22
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-22_linux64_openblas.conda
-  sha256: da1b2faa017663c8f5555c1c5518e96ac4cd8e0be2a673c1c9e2cb8507c8fe46
-  md5: 4b31699e0ec5de64d5896e580389c9a1
-  depends:
-  - libblas 3.9.0 22_linux64_openblas
-  constrains:
-  - liblapack 3.9.0 22_linux64_openblas
-  - blas * openblas
-  - liblapacke 3.9.0 22_linux64_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 14438
-  timestamp: 1712542270166
-- kind: conda
-  name: libcblas
-  version: 3.9.0
   build: 22_osx64_openblas
   build_number: 22
   subdir: osx-64
@@ -7633,23 +7392,43 @@ packages:
 - kind: conda
   name: libcblas
   version: 3.9.0
-  build: 22_win64_mkl
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-22_win64_mkl.conda
-  sha256: 5503273924650330dc03edd1eb01ec4020b9967b5a4cafc377ba20b976d15590
-  md5: 336c93ab102846c6131cf68e722a68f1
+  build: 23_linux64_openblas
+  build_number: 23
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-23_linux64_openblas.conda
+  sha256: 3e7a3236e7e03e308e1667d91d0aa70edd0cba96b4b5563ef4adde088e0881a5
+  md5: eede29b40efa878cbe5bdcb767e97310
   depends:
-  - libblas 3.9.0 22_win64_mkl
+  - libblas 3.9.0 23_linux64_openblas
   constrains:
-  - liblapacke 3.9.0 22_win64_mkl
-  - blas * mkl
-  - liblapack 3.9.0 22_win64_mkl
+  - liblapacke 3.9.0 23_linux64_openblas
+  - liblapack 3.9.0 23_linux64_openblas
+  - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 5191513
-  timestamp: 1712543043641
+  size: 14798
+  timestamp: 1721688767584
+- kind: conda
+  name: libcblas
+  version: 3.9.0
+  build: 23_win64_mkl
+  build_number: 23
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-23_win64_mkl.conda
+  sha256: 80b471a22affadc322006399209e1d12eb4ab4e3125ed6d01b4031e09de16753
+  md5: 7ffb5b336cefd2e6d1e00ac1f7c9f2c9
+  depends:
+  - libblas 3.9.0 23_win64_mkl
+  constrains:
+  - blas * mkl
+  - liblapack 3.9.0 23_win64_mkl
+  - liblapacke 3.9.0 23_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 5191981
+  timestamp: 1721689628480
 - kind: conda
   name: libclang-cpp15
   version: 15.0.7
@@ -7670,40 +7449,43 @@ packages:
   timestamp: 1711063711931
 - kind: conda
   name: libclang13
-  version: 18.1.3
-  build: default_h5d6823c_0
+  version: 18.1.8
+  build: default_h9def88c_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.3-default_h5d6823c_0.conda
-  sha256: 8490f8ca051e80d0f79279d75dabb93e0cadf046984b96bfaeb4c9d6146857fb
-  md5: 5fff487759736b275dc3e4a263cac666
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-18.1.8-default_h9def88c_1.conda
+  sha256: ec9a672623c5d485e48bd14f36353ec0b5c14f516440dfbb6674b1c784289eb4
+  md5: 04c8c481b30c3fe62bec148fa4a75857
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  - libllvm18 >=18.1.3,<18.2.0a0
+  - libllvm18 >=18.1.8,<18.2.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 11054286
-  timestamp: 1712569057776
+  size: 11016960
+  timestamp: 1721479548831
 - kind: conda
   name: libclang13
-  version: 18.1.3
-  build: default_hf64faad_0
+  version: 18.1.8
+  build: default_ha5278ca_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.3-default_hf64faad_0.conda
-  sha256: 7ccb5fefe1ca2c8341e402fa726e5b9cea1939feb87b5335b3c4581589ba86d5
-  md5: 9217c37b478ec601af909aafc954a6fc
+  url: https://conda.anaconda.org/conda-forge/win-64/libclang13-18.1.8-default_ha5278ca_1.conda
+  sha256: b9c47c6124d4fa0ce9bf6925744897319bbcc77356e1b3ac464a26649acc3381
+  md5: 30a167d5b69555fbf39192a23e40df52
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 25293651
-  timestamp: 1712568643856
+  size: 25327749
+  timestamp: 1721486985259
 - kind: conda
   name: libcrc32c
   version: 1.1.2
@@ -7764,7 +7546,7 @@ packages:
   - krb5 >=1.21.1,<1.22.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
@@ -7772,78 +7554,81 @@ packages:
   timestamp: 1689195353551
 - kind: conda
   name: libcurl
-  version: 8.7.1
-  build: h726d00d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
-  sha256: 06cb1bd3bbaf905213777d6ade190ac4c7fb7a20dfe0cf901c977dbbc6cec265
-  md5: fa58e5eaa12006bc3289a71357bef167
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  purls: []
-  size: 378176
-  timestamp: 1711548390530
-- kind: conda
-  name: libcurl
-  version: 8.7.1
-  build: hca28451_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
-  sha256: 82a75e9a5d9ee5b2f487d850ec5d4edc18a56eb9527608a95a916c40baae3843
-  md5: 755c7f876815003337d2c61ff5d047e5
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  purls: []
-  size: 398293
-  timestamp: 1711548114077
-- kind: conda
-  name: libcurl
-  version: 8.7.1
-  build: hd5e4a3a_0
+  version: 8.9.0
+  build: h18fefc2_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
-  sha256: 8dd272362e2aeb1d4f49333ff57e07eb4da2bbabce20110a2416df9152ba03e0
-  md5: 3396aff340d0903e8814c2852d631e4e
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.9.0-h18fefc2_0.conda
+  sha256: ccf4c2088bb89c88841eb87264050a8c26767222e0b97afb2dbc41a46e0017e0
+  md5: 8ae225681b7041c1dccdcd713c9d7424
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
+  - krb5 >=1.21.3,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: curl
   license_family: MIT
   purls: []
-  size: 331262
-  timestamp: 1711548608132
+  size: 340202
+  timestamp: 1721822102198
+- kind: conda
+  name: libcurl
+  version: 8.9.0
+  build: hdb1bdb2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.9.0-hdb1bdb2_0.conda
+  sha256: ff97a3160117385649e1b7e8b84fefb3561fceae09bb48d2bfdf37bc2b6bfdc9
+  md5: 5badfbdb2688d8aaca7bd3c98d557b97
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 415655
+  timestamp: 1721821481248
+- kind: conda
+  name: libcurl
+  version: 8.9.0
+  build: hfcf2730_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.9.0-hfcf2730_0.conda
+  sha256: 1e2c6482eb7753589d66dfe9997e1916611bcce387dfde55cd7d9f595fe84b72
+  md5: 861e66c46985b6eadd97c73ac77d1a07
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  size: 396435
+  timestamp: 1721821921421
 - kind: conda
   name: libcxx
-  version: 16.0.6
-  build: hd57cbcb_0
+  version: 18.1.8
+  build: hef8daea_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
-  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
-  md5: 7d6972792161077908b62971802f289a
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hef8daea_1.conda
+  sha256: 92611f996ee339e1e5d2988d5e5d7ac9be2b7c2b5ce7ace1961ef4697558b644
+  md5: 8309952890f89dbd4283a18633ecdfe3
+  depends:
+  - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 1142172
-  timestamp: 1686896907750
+  size: 1223927
+  timestamp: 1722131562936
 - kind: conda
   name: libdeflate
   version: '1.20'
@@ -8119,224 +7904,991 @@ packages:
   timestamp: 1687765514062
 - kind: conda
   name: libgcc-ng
-  version: 13.2.0
-  build: h807b86a_5
-  build_number: 5
+  version: 14.1.0
+  build: h77fa898_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_5.conda
-  sha256: d32f78bfaac282cfe5205f46d558704ad737b8dbf71f9227788a5ca80facaba4
-  md5: d4ff227c46917d3b4565302a2bbb276b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
+  sha256: b8e869ac96591cda2704bf7e77a301025e405227791a0bddf14a3dac65125538
+  md5: ca0fad6a41ddaef54a153b78eccb5037
   depends:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
   constrains:
-  - libgomp 13.2.0 h807b86a_5
+  - libgomp 14.1.0 h77fa898_0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 770506
-  timestamp: 1706819192021
+  size: 842109
+  timestamp: 1719538896937
 - kind: conda
   name: libgcrypt
-  version: 1.10.3
-  build: hd590300_0
+  version: 1.11.0
+  build: h4ab18f5_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
-  sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
-  md5: 32d16ad533c59bb0a3c5ffaf16110829
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.11.0-h4ab18f5_1.conda
+  sha256: 9e97e4a753d2ee238cfc7375f0882830f0d8c1667431bc9d070a0f6718355570
+  md5: 14858a47d4cc995892e79f2b340682d7
   depends:
   - libgcc-ng >=12
-  - libgpg-error >=1.47,<2.0a0
+  - libgpg-error >=1.50,<2.0a0
   license: LGPL-2.1-or-later AND GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 634887
-  timestamp: 1701383493365
+  size: 684307
+  timestamp: 1721392291497
 - kind: conda
   name: libgdal
-  version: 3.8.4
-  build: h2239303_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.4-h2239303_5.conda
-  sha256: 0840390bd7b68eb2eb2f4e0dd67730d4ed20709a56f7c0e338442faee8603ed6
-  md5: d38e6517611a9666774554c5124cfa44
+  version: 3.9.1
+  build: h57928b3_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_9.conda
+  sha256: bddbbfd112bd6dd436c79a82d4bd1925dfff293ba42c35ee7df82140921563ed
+  md5: 674aee42ac3a4a338cf19c7924007672
   depends:
-  - blosc >=1.21.5,<2.0a0
-  - cfitsio >=4.4.0,<4.4.1.0a0
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.12.1,<3.12.2.0a0
-  - geotiff >=1.7.1,<1.8.0a0
-  - giflib >=5.2.1,<5.3.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgdal-core 3.9.1.*
+  - libgdal-fits 3.9.1.*
+  - libgdal-grib 3.9.1.*
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libgdal-jp2openjpeg 3.9.1.*
+  - libgdal-kea 3.9.1.*
+  - libgdal-netcdf 3.9.1.*
+  - libgdal-pdf 3.9.1.*
+  - libgdal-pg 3.9.1.*
+  - libgdal-postgisraster 3.9.1.*
+  - libgdal-tiledb 3.9.1.*
+  - libgdal-xls 3.9.1.*
+  license: MIT
+  purls: []
+  size: 422131
+  timestamp: 1721934666296
+- kind: conda
+  name: libgdal
+  version: 3.9.1
+  build: h694c41f_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-h694c41f_9.conda
+  sha256: 21828cb096378d618253006e0237d5f6f5551ebcd6889868bb80ae613b3cf59c
+  md5: d70cdc88a3fc3589c38b6d0cdfe371cd
+  depends:
+  - libgdal-core 3.9.1.*
+  - libgdal-fits 3.9.1.*
+  - libgdal-grib 3.9.1.*
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libgdal-jp2openjpeg 3.9.1.*
+  - libgdal-kea 3.9.1.*
+  - libgdal-netcdf 3.9.1.*
+  - libgdal-pdf 3.9.1.*
+  - libgdal-pg 3.9.1.*
+  - libgdal-postgisraster 3.9.1.*
+  - libgdal-tiledb 3.9.1.*
+  - libgdal-xls 3.9.1.*
+  license: MIT
+  purls: []
+  size: 421928
+  timestamp: 1721932378899
+- kind: conda
+  name: libgdal
+  version: 3.9.1
+  build: ha770c72_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_9.conda
+  sha256: 5a57d2785bbb78d4ae7aa337cccb8f75143645031966508dc4d3b4c3bf3cc0af
+  md5: b3e68a21c23d726ad0317eab502515b7
+  depends:
+  - libgdal-core 3.9.1.*
+  - libgdal-fits 3.9.1.*
+  - libgdal-grib 3.9.1.*
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libgdal-jp2openjpeg 3.9.1.*
+  - libgdal-kea 3.9.1.*
+  - libgdal-netcdf 3.9.1.*
+  - libgdal-pdf 3.9.1.*
+  - libgdal-pg 3.9.1.*
+  - libgdal-postgisraster 3.9.1.*
+  - libgdal-tiledb 3.9.1.*
+  - libgdal-xls 3.9.1.*
+  license: MIT
+  purls: []
+  size: 421418
+  timestamp: 1721930692503
+- kind: conda
+  name: libgdal-core
+  version: 3.9.1
+  build: h858dd01_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.1-h858dd01_9.conda
+  sha256: e07ec4a6a527796033bd8762c57e080b787c0398f54aeca9240e3083bf22b1de
+  md5: 4db73daccf169b94e35e0ce64415d598
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - json-c >=0.17,<0.18.0a0
-  - kealib >=1.5.3,<1.6.0a0
   - lerc >=4.0.0,<5.0a0
-  - libaec >=1.1.3,<2.0a0
-  - libarchive >=3.7.2,<3.8.0a0
-  - libcurl >=8.6.0,<9.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.9.0,<9.0a0
   - libcxx >=16
   - libdeflate >=1.20,<1.21.0a0
   - libexpat >=2.6.2,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.45.2,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  - poppler >=24.3.0,<24.4.0a0
-  - postgresql
-  - proj >=9.3.1,<9.3.2.0a0
-  - tiledb >=2.21.1,<2.22.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.4.1,<9.5.0a0
   - xerces-c >=3.2.5,<3.3.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.9.1.*
   license: MIT
-  license_family: MIT
   purls: []
-  size: 9376293
-  timestamp: 1711286692389
+  size: 8920802
+  timestamp: 1721928962863
 - kind: conda
-  name: libgdal
-  version: 3.8.4
-  build: h7c88fdf_5
-  build_number: 5
+  name: libgdal-core
+  version: 3.9.1
+  build: h8f9377d_9
+  build_number: 9
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.4-h7c88fdf_5.conda
-  sha256: caad3fbd31a1572a5688d27bcf863acc36866eeaf73c4af67e5e40480e87772e
-  md5: 750bfb344a8690e7089c8c2b303f252a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-h8f9377d_9.conda
+  sha256: c9987f3ed507f038f16c30ff792a608d2385390cff113148b159cfb5754d708b
+  md5: b536cac25257f7647432d366c223d0f3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - blosc >=1.21.5,<2.0a0
-  - cfitsio >=4.4.0,<4.4.1.0a0
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.12.1,<3.12.2.0a0
-  - geotiff >=1.7.1,<1.8.0a0
-  - giflib >=5.2.1,<5.3.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - geotiff >=1.7.3,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - json-c >=0.17,<0.18.0a0
-  - kealib >=1.5.3,<1.6.0a0
   - lerc >=4.0.0,<5.0a0
-  - libaec >=1.1.3,<2.0a0
-  - libarchive >=3.7.2,<3.8.0a0
-  - libcurl >=8.6.0,<9.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.9.0,<9.0a0
   - libdeflate >=1.20,<1.21.0a0
   - libexpat >=2.6.2,<3.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.45.2,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.7.0a0
   - libuuid >=2.38.1,<3.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  - poppler >=24.3.0,<24.4.0a0
-  - postgresql
-  - proj >=9.3.1,<9.3.2.0a0
-  - tiledb >=2.21.1,<2.22.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.4.1,<9.5.0a0
   - xerces-c >=3.2.5,<3.3.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.9.1.*
   license: MIT
-  license_family: MIT
   purls: []
-  size: 11113700
-  timestamp: 1711285696664
+  size: 10206466
+  timestamp: 1721928872226
 - kind: conda
-  name: libgdal
-  version: 3.8.4
-  build: hf83a0e2_5
-  build_number: 5
+  name: libgdal-core
+  version: 3.9.1
+  build: hcff673a_9
+  build_number: 9
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.4-hf83a0e2_5.conda
-  sha256: 98e0e290f8cc76e66a386283240e35158bd22960b18301a7ca281a2aecaba01b
-  md5: 0efb428de61baca5231bdf6ef0a4de2d
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-hcff673a_9.conda
+  sha256: 04fd489dde644aaaa0c1e000677cc71277c545d5356402bd1006fbfe236f50d3
+  md5: b493554a2a9df2f308b75312ff651c6a
   depends:
-  - blosc >=1.21.5,<2.0a0
-  - cfitsio >=4.4.0,<4.4.1.0a0
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.12.1,<3.12.2.0a0
-  - geotiff >=1.7.1,<1.8.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - kealib >=1.5.3,<1.6.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - geotiff >=1.7.3,<1.8.0a0
   - lerc >=4.0.0,<5.0a0
-  - libaec >=1.1.3,<2.0a0
-  - libarchive >=3.7.2,<3.8.0a0
-  - libcurl >=8.6.0,<9.0a0
+  - libarchive >=3.7.4,<3.8.0a0
+  - libcurl >=8.9.0,<9.0a0
   - libdeflate >=1.20,<1.21.0a0
   - libexpat >=2.6.2,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.45.2,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - pcre2 >=10.43,<10.44.0a0
-  - poppler >=24.3.0,<24.4.0a0
-  - postgresql
-  - proj >=9.3.1,<9.3.2.0a0
-  - tiledb >=2.21.1,<2.22.0a0
+  - openssl >=3.3.1,<4.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  - proj >=9.4.1,<9.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xerces-c >=3.2.5,<3.3.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - libgdal 3.9.1.*
   license: MIT
-  license_family: MIT
   purls: []
-  size: 8622989
-  timestamp: 1711286830900
+  size: 8029377
+  timestamp: 1721929811207
 - kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  name: libgdal-fits
+  version: 3.9.1
+  build: h0a0b71e_9
+  build_number: 9
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-0.22.5-h5728263_2.conda
-  sha256: 445ecfc4bf5b474c2ac79f716dcb8459a08a532ab13a785744665f086ef94c95
-  md5: f4c826b19bf1ccee2a63a2c685039728
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_9.conda
+  sha256: 8141b9d549ad4aa97a5c766bdea6e2d2aea9d8eef12209587cce8e8e86a9fd88
+  md5: d90baa93f4b57f897f7f05143d35f8fd
   depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
-  license: GPL-3.0-or-later
-  license_family: GPL
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
   purls: []
-  size: 171210
-  timestamp: 1712516290149
+  size: 496342
+  timestamp: 1721932482602
+- kind: conda
+  name: libgdal-fits
+  version: 3.9.1
+  build: h5d197d2_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.1-h5d197d2_9.conda
+  sha256: 03bd6ea2ae364a3e943247bbd0b03ea7e88428cf71914181f8f6308ef16e96aa
+  md5: b01fc850cdd3f8645f95f7934e9edd25
+  depends:
+  - __osx >=10.13
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  purls: []
+  size: 467683
+  timestamp: 1721930794819
+- kind: conda
+  name: libgdal-fits
+  version: 3.9.1
+  build: hdd6600c_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_9.conda
+  sha256: 5e53b3f39ac1707b37f267e6dfbb5d3815343782b3f2e985c409309db4398488
+  md5: b8eeb61976527c946b8c9bc79b676703
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cfitsio >=4.4.1,<4.4.2.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 475258
+  timestamp: 1721929922448
+- kind: conda
+  name: libgdal-grib
+  version: 3.9.1
+  build: h385febf_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.1-h385febf_9.conda
+  sha256: 04e888511ba03da0cf159857bb95048e33399efa611d60add72addcd8663fca8
+  md5: c1f210b114fed9e0da7206495d03f622
+  depends:
+  - __osx >=10.13
+  - libaec >=1.1.3,<2.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  purls: []
+  size: 662000
+  timestamp: 1721930928060
+- kind: conda
+  name: libgdal-grib
+  version: 3.9.1
+  build: h5f34788_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_9.conda
+  sha256: e232c4c7af008426918a41257449ce7a41f2c34d043969b0126f2494e205605a
+  md5: a20357dc3edd20ead013bd79d38f521a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.3,<2.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 720672
+  timestamp: 1721929987392
+- kind: conda
+  name: libgdal-grib
+  version: 3.9.1
+  build: hd2a089b_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_9.conda
+  sha256: 5ed1454b0e11426fc300df32edc3fa1219d0808452f7af485971fdc1878b0d27
+  md5: c6fb0c82acbc38ca0fd444858a55bd39
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 676930
+  timestamp: 1721932676878
+- kind: conda
+  name: libgdal-hdf4
+  version: 3.9.1
+  build: h430f241_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_9.conda
+  sha256: dcd1fba90f613b85677804796fba2f621b1345b665d5b0fb9b7207366a3d8722
+  md5: ae616088398bb53c9d67f89efeba85fc
+  depends:
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 561434
+  timestamp: 1721932857065
+- kind: conda
+  name: libgdal-hdf4
+  version: 3.9.1
+  build: h86719f3_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.1-h86719f3_9.conda
+  sha256: b3b7ec74998b2e88dac62e7487e1265484883ec30dbb333afbe9027a9b1a25c2
+  md5: e231e49e7d34fb10d1dd315dc57f957d
+  depends:
+  - __osx >=10.13
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  purls: []
+  size: 589980
+  timestamp: 1721931060623
+- kind: conda
+  name: libgdal-hdf4
+  version: 3.9.1
+  build: ha39a594_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_9.conda
+  sha256: 223639f510d27d52ac6fd14c2399bdbc20ff0999d7f0712c5f8e82d035608e64
+  md5: c1a1f4de69b3ffa9328c2bbf54fdd474
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 575663
+  timestamp: 1721930053760
+- kind: conda
+  name: libgdal-hdf5
+  version: 3.9.1
+  build: h513f0eb_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.1-h513f0eb_9.conda
+  sha256: ddc284be5efd075ee65e04e9f0e485d5b8cb97b82a8626b48dc940fd0aeb00de
+  md5: 554634455c70448922c7349c1f74cd93
+  depends:
+  - __osx >=10.13
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  purls: []
+  size: 600408
+  timestamp: 1721931224044
+- kind: conda
+  name: libgdal-hdf5
+  version: 3.9.1
+  build: ha2ed5f0_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_9.conda
+  sha256: b78dcf6cba0711d885b053557bddb9dc084176c12c6b8c1465bbadbcb2c3c800
+  md5: f7b8b185e85152fdac4370362c8be0ad
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 638576
+  timestamp: 1721930129990
+- kind: conda
+  name: libgdal-hdf5
+  version: 3.9.1
+  build: had131a1_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_9.conda
+  sha256: 4a29e3439eb821f34b61187defc7afc353a987763c96b8d17ac1a314ab0e383d
+  md5: e3fd61f73e44d872ca6ef3264446ea20
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 612448
+  timestamp: 1721933061166
+- kind: conda
+  name: libgdal-jp2openjpeg
+  version: 3.9.1
+  build: h2ebfdf0_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_9.conda
+  sha256: a3685778085a57ee294c9e6fcaf05d6bb0093b45334508a1e9e355de62918488
+  md5: f83e97638c3cddb96afe499e55322558
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - openjpeg >=2.5.2,<3.0a0
+  license: MIT
+  purls: []
+  size: 466781
+  timestamp: 1721930184529
+- kind: conda
+  name: libgdal-jp2openjpeg
+  version: 3.9.1
+  build: hc5f35ca_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.1-hc5f35ca_9.conda
+  sha256: e14fc68c671e30415f29960101824fb3b1c60e397d595269f8e46a2756dedb63
+  md5: 09bd074c0ea856c7b17bd31d63d9d9c3
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  license: MIT
+  purls: []
+  size: 462790
+  timestamp: 1721931345154
+- kind: conda
+  name: libgdal-jp2openjpeg
+  version: 3.9.1
+  build: hed4c6cb_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_9.conda
+  sha256: f7b923980a7ffd414af4e0c400f8bbdd2ef75ae7467ddfa64df3ed0dc15aa5fe
+  md5: 5905a3a17d8247258a52d8b45b00d8b3
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 496792
+  timestamp: 1721933228305
+- kind: conda
+  name: libgdal-kea
+  version: 3.9.1
+  build: h2b45729_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_9.conda
+  sha256: 9b995c9bb7289151155ae16741066e6163c3e418367ad9e513798b8a2416ceb9
+  md5: 3faa1b29f298e88e8abd0ed851e375fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 479282
+  timestamp: 1721930603930
+- kind: conda
+  name: libgdal-kea
+  version: 3.9.1
+  build: h3b8d0bf_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.1-h3b8d0bf_9.conda
+  sha256: d03f0e184a15a5bc7d63c8ea560d07573582bcfeb22577c728cf68cd42717cd6
+  md5: 30cd6c4b9da5bbe830f9014758f2eea2
+  depends:
+  - __osx >=10.13
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  purls: []
+  size: 474748
+  timestamp: 1721932156288
+- kind: conda
+  name: libgdal-kea
+  version: 3.9.1
+  build: h95b1a77_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_9.conda
+  sha256: b90525c3a2654b6eec3e5121a709bdd0b4571bd698879662ada4396c59d83609
+  md5: 6319a77d91a84935535cce429e5c06cb
+  depends:
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - kealib >=1.5.3,<1.6.0a0
+  - libgdal-core >=3.9
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 517242
+  timestamp: 1721934467008
+- kind: conda
+  name: libgdal-netcdf
+  version: 3.9.1
+  build: h3127c03_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.1-h3127c03_9.conda
+  sha256: 89573a2c901ba0ec152c6b2a91b189097518411525c2feaf19f2af4a2971786e
+  md5: 7ab3df8dec1c4aa16635d4e1a5845518
+  depends:
+  - __osx >=10.13
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  license: MIT
+  purls: []
+  size: 687060
+  timestamp: 1721932360293
+- kind: conda
+  name: libgdal-netcdf
+  version: 3.9.1
+  build: h55e78d3_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_9.conda
+  sha256: 22c98d1274e29bdf1e13f3d1fdf244b3cb747e0edc2ed47a355c08b48d58fc08
+  md5: 3b64d848d0a6f07f62f5eaf20f2806bc
+  depends:
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgdal-core >=3.9
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 665753
+  timestamp: 1721934657618
+- kind: conda
+  name: libgdal-netcdf
+  version: 3.9.1
+  build: h94e7027_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_9.conda
+  sha256: 19fb3880436fc3f445fa4ff8a1be3bc6161300a5c4d3e26a4f8f029fe5563b21
+  md5: 25728b5ba8ad503953ab19989c5ea2a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libgdal-hdf4 3.9.1.*
+  - libgdal-hdf5 3.9.1.*
+  - libkml >=1.3.0,<1.4.0a0
+  - libnetcdf >=4.9.2,<4.9.3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 730600
+  timestamp: 1721930686158
+- kind: conda
+  name: libgdal-pdf
+  version: 3.9.1
+  build: h0da0525_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.1-h0da0525_9.conda
+  sha256: a6c36fd502078c64211e1f178eca3c4c79b575779de735d1309db2ef8bf720a3
+  md5: ee16c9e9347b3a3649791b26244b1528
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - poppler >=24.7.0,<24.8.0a0
+  license: MIT
+  purls: []
+  size: 608490
+  timestamp: 1721931490785
+- kind: conda
+  name: libgdal-pdf
+  version: 3.9.1
+  build: h261eb30_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_9.conda
+  sha256: b9b6f8a922124024592aaa4e374717e274117abf80b67ea1f553a00057ada455
+  md5: 45f79e30830951a25fb2377a46fea5c5
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - poppler >=24.7.0,<24.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 624639
+  timestamp: 1721933464817
+- kind: conda
+  name: libgdal-pdf
+  version: 3.9.1
+  build: h562c687_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_9.conda
+  sha256: 24af3451f2ed7c132ea89cd7b617bb9ab56da14c8ff0d3d4525c25d3c22c69b6
+  md5: b5e0329808d5b7135c7c19bba68a82c8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - poppler >=24.7.0,<24.8.0a0
+  license: MIT
+  purls: []
+  size: 662940
+  timestamp: 1721930269098
+- kind: conda
+  name: libgdal-pg
+  version: 3.9.1
+  build: h1b48671_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.1-h1b48671_9.conda
+  sha256: aa21e59229758c089f015b00b56de0d8c97b43c4fe1b51e6cf6de4a08c6f7859
+  md5: 55bdf44a2f0fdea45d4255b8c6fe5ae2
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  license: MIT
+  purls: []
+  size: 506122
+  timestamp: 1721931617588
+- kind: conda
+  name: libgdal-pg
+  version: 3.9.1
+  build: ha693a0f_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_9.conda
+  sha256: 2597f5738fa42165982b734bba0c5b2135ca6210b8507631ef8565edfc121009
+  md5: 072dd55f196e4dea96997c6bbc21e66d
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 532025
+  timestamp: 1721933661573
+- kind: conda
+  name: libgdal-pg
+  version: 3.9.1
+  build: he047751_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_9.conda
+  sha256: 287957a49b179add435b08c86cf5969c4c41d3bbf43cc6258d79322fd0e9cf81
+  md5: b30538950cf78efea609fe6ba1afae98
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - libstdcxx-ng >=12
+  - postgresql
+  license: MIT
+  purls: []
+  size: 523844
+  timestamp: 1721930333274
+- kind: conda
+  name: libgdal-postgisraster
+  version: 3.9.1
+  build: h1b48671_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.1-h1b48671_9.conda
+  sha256: 537f4b3a2ec2e0319eec4a99b2771eb4f792f95c41c10d19e1b099308c8215fb
+  md5: a6162fa1d296de2cee4fbb298d8f3b0f
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  license: MIT
+  purls: []
+  size: 468018
+  timestamp: 1721931745768
+- kind: conda
+  name: libgdal-postgisraster
+  version: 3.9.1
+  build: ha693a0f_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_9.conda
+  sha256: 48e1504a6249c30768d5e4b9bfdbbb711162237b86d04affd62423775d351d71
+  md5: cecd2de662e620c898920c8b27be396b
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 503936
+  timestamp: 1721933858295
+- kind: conda
+  name: libgdal-postgisraster
+  version: 3.9.1
+  build: he047751_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_9.conda
+  sha256: 34d0d56adc76c95544dd0b9339c6a072ffe1c7c62f8602be18659d4eb059ff22
+  md5: 67bc90420754a372cbf8004ec926a99b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.3,<17.0a0
+  - libstdcxx-ng >=12
+  - postgresql
+  license: MIT
+  purls: []
+  size: 477916
+  timestamp: 1721930394804
+- kind: conda
+  name: libgdal-tiledb
+  version: 3.9.1
+  build: h9d8aadb_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-h9d8aadb_9.conda
+  sha256: f652da9210ac91700f66e0e788837a04659f59d2a89fdbf39b86075b208bc8ae
+  md5: cdc1c1b305f64384595e495d0d660ecb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  - tiledb >=2.25.0,<2.26.0a0
+  license: MIT
+  purls: []
+  size: 670373
+  timestamp: 1721930488549
+- kind: conda
+  name: libgdal-tiledb
+  version: 3.9.1
+  build: ha63beff_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.1-ha63beff_9.conda
+  sha256: 86c7b33457cda439aab51a116f46e7652c25bea948a8cbd915baf3a269884b0c
+  md5: b5693b447076da3f41ed9f025222e7be
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - tiledb >=2.25.0,<2.26.0a0
+  license: MIT
+  purls: []
+  size: 629454
+  timestamp: 1721931898811
+- kind: conda
+  name: libgdal-tiledb
+  version: 3.9.1
+  build: hefbb53f_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-hefbb53f_9.conda
+  sha256: 578d1b53b683e969d8e186bdc2f8ab477e37b16961ccb8f9e823d6bf810e4192
+  md5: e471886edf3400a53cc3a86af32172ba
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - tiledb >=2.25.0,<2.26.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 627221
+  timestamp: 1721934109236
+- kind: conda
+  name: libgdal-xls
+  version: 3.9.1
+  build: h062f1c4_9
+  build_number: 9
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_9.conda
+  sha256: 33add4b46dc20d65d7aec1310fe51fff2683588898bd4649f552387937affe9a
+  md5: 3077e6393e8d84a349c3ff4cb1f1525f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freexl >=2.0.0,<3.0a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  purls: []
+  size: 432993
+  timestamp: 1721930543024
+- kind: conda
+  name: libgdal-xls
+  version: 3.9.1
+  build: h597966e_9
+  build_number: 9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.1-h597966e_9.conda
+  sha256: 866bb05b780535ea583e96cb347d2269e2dc4312942e1c3af8c9f509cc7ce4d4
+  md5: 33f3742cea1c01fb882ce336883c4d59
+  depends:
+  - __osx >=10.13
+  - freexl >=2.0.0,<3.0a0
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  license: MIT
+  purls: []
+  size: 430433
+  timestamp: 1721932018864
+- kind: conda
+  name: libgdal-xls
+  version: 3.9.1
+  build: hd0e23a6_9
+  build_number: 9
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_9.conda
+  sha256: d2b09392ecfc2cb4c6b695267b87395aa43e99912445780c3929530b845de369
+  md5: 3e4dd91409f74011df62e83cbc7925bd
+  depends:
+  - freexl >=2.0.0,<3.0a0
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  purls: []
+  size: 465209
+  timestamp: 1721934275968
 - kind: conda
   name: libgettextpo
   version: 0.22.5
@@ -8353,41 +8905,6 @@ packages:
   purls: []
   size: 170582
   timestamp: 1712512286907
-- kind: conda
-  name: libgettextpo
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
-  sha256: 139d1861e21c41b950ebf9e395db2492839337a3b481ad2901a4a6800c555e37
-  md5: 54cc9d12c29c2f0516f2ef4987de53ae
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 172506
-  timestamp: 1712512827340
-- kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: h5728263_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgettextpo-devel-0.22.5-h5728263_2.conda
-  sha256: bcee730b2be23ba9aa5de3471b78c4644d3b17d5a71e7fdc59bb40e252edb2f7
-  md5: 6f42ec61abc6d52a4079800a640319c5
-  depends:
-  - libgettextpo 0.22.5 h5728263_2
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5728263_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 40312
-  timestamp: 1712516436925
 - kind: conda
   name: libgettextpo-devel
   version: 0.22.5
@@ -8406,24 +8923,6 @@ packages:
   size: 36758
   timestamp: 1712512303244
 - kind: conda
-  name: libgettextpo-devel
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
-  sha256: 57940f6a872ffcf5a3406e96bdbd9d25854943e4dd84acee56178ffb728a9671
-  md5: 1e0384c52cd8b54812912e7234e66056
-  depends:
-  - libgettextpo 0.22.5 h5ff76d1_2
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: GPL-3.0-or-later
-  license_family: GPL
-  purls: []
-  size: 37189
-  timestamp: 1712512859854
-- kind: conda
   name: libgfortran
   version: 5.0.0
   build: 13_2_0_h97931a8_3
@@ -8441,20 +8940,19 @@ packages:
   timestamp: 1707328956438
 - kind: conda
   name: libgfortran-ng
-  version: 13.2.0
-  build: h69a702a_5
-  build_number: 5
+  version: 14.1.0
+  build: h69a702a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_5.conda
-  sha256: 238c16c84124d58307376715839aa152bd4a1bf5a043052938ad6c3137d30245
-  md5: e73e9cfd1191783392131e6238bdb3e9
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
+  sha256: ef624dacacf97b2b0af39110b36e2fd3e39e358a1a6b7b21b85c9ac22d8ffed9
+  md5: f4ca84fbd6d06b0a052fb2d5b96dde41
   depends:
-  - libgfortran5 13.2.0 ha4646dd_5
+  - libgfortran5 14.1.0 hc5f4f2c_0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 23829
-  timestamp: 1706819413770
+  size: 49893
+  timestamp: 1719538933879
 - kind: conda
   name: libgfortran5
   version: 13.2.0
@@ -8475,356 +8973,352 @@ packages:
   timestamp: 1707328880361
 - kind: conda
   name: libgfortran5
-  version: 13.2.0
-  build: ha4646dd_5
-  build_number: 5
+  version: 14.1.0
+  build: hc5f4f2c_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_5.conda
-  sha256: ba8d94e8493222ce155bb264d9de4200e41498a458e866fedf444de809bde8b6
-  md5: 7a6bd7a12a4bd359e2afe6c0fa1acace
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
+  sha256: a67d66b1e60a8a9a9e4440cee627c959acb4810cb182e089a4b0729bfdfbdf90
+  md5: 6456c2620c990cd8dde2428a27ba0bc5
   depends:
-  - libgcc-ng >=13.2.0
+  - libgcc-ng >=14.1.0
   constrains:
-  - libgfortran-ng 13.2.0
+  - libgfortran-ng 14.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 1442769
-  timestamp: 1706819209473
+  size: 1457561
+  timestamp: 1719538909168
 - kind: conda
   name: libglib
-  version: 2.80.0
-  build: h39d0aa6_3
-  build_number: 3
+  version: 2.80.3
+  build: h7025463_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_3.conda
-  sha256: 01b8e650ecc2581c9d95b2b0fbe861f19f9a55d87c5952a3d30d6ca53e6552ee
-  md5: 6ed359e5ae622059d4d2306328314bf5
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.3-h7025463_1.conda
+  sha256: cae4f5ab6c64512aa6ae9f5c808f9b0aaea19496ddeab3720c118ad0809f7733
+  md5: 53c80e0ed9a3905ca7047c03756a5caa
   depends:
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
   - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - glib 2.80.0 *_3
+  - glib 2.80.3 *_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 2760042
-  timestamp: 1712500246841
+  size: 3743922
+  timestamp: 1720334986136
 - kind: conda
   name: libglib
-  version: 2.80.0
-  build: h81c1438_3
-  build_number: 3
+  version: 2.80.3
+  build: h736d271_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_3.conda
-  sha256: 0da6453549cc49d7258f3db76adc7ffb8e5fec524fb3c3af14a2ba1842bee0f7
-  md5: de78445096d2846df7f4f5fa5c252560
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_1.conda
+  sha256: bfd5a28140d31f9310efcdfd1136f36d7ca718a297690a1a8869b3a1966675ae
+  md5: 0919d467624606fbc05c38c458f3f42a
   depends:
+  - __osx >=10.13
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
   - libintl >=0.22.5,<1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
   constrains:
-  - glib 2.80.0 *_3
+  - glib 2.80.3 *_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 2654530
-  timestamp: 1712500156886
+  size: 3655643
+  timestamp: 1720335043559
 - kind: conda
   name: libglib
-  version: 2.80.0
-  build: hf2295e7_3
-  build_number: 3
+  version: 2.80.3
+  build: h8a4344b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_3.conda
-  sha256: 2779b2d967f0d5732943c20dd60101a55f8f139f46d9c68deb7b19d3e732e752
-  md5: 569d25ad54594080778abff56a611dc7
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h8a4344b_1.conda
+  sha256: 5f5854a7cee117d115009d8f22a70d5f9e28f09cb6e453e8f1dd712e354ecec9
+  md5: 6ea440297aacee4893f02ad759e6ffbc
   depends:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.43,<10.44.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
   constrains:
-  - glib 2.80.0 *_3
+  - glib 2.80.3 *_1
   license: LGPL-2.1-or-later
   purls: []
-  size: 2878044
-  timestamp: 1712500070893
+  size: 3886207
+  timestamp: 1720334852370
 - kind: conda
   name: libgomp
-  version: 13.2.0
-  build: h807b86a_5
-  build_number: 5
+  version: 14.1.0
+  build: h77fa898_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_5.conda
-  sha256: 0d3d4b1b0134283ea02d58e8eb5accf3655464cf7159abf098cc694002f8d34e
-  md5: d211c42b9ce49aee3734fdc828731689
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_0.conda
+  sha256: 7699df61a1f6c644b3576a40f54791561f2845983120477a16116b951c9cdb05
+  md5: ae061a5ed5f05818acdf9adab72c146d
   depends:
   - _libgcc_mutex 0.1 conda_forge
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 419751
-  timestamp: 1706819107383
+  size: 456925
+  timestamp: 1719538796073
 - kind: conda
   name: libgoogle-cloud
-  version: 2.22.0
-  build: h651e89d_1
-  build_number: 1
+  version: 2.26.0
+  build: h26d7fe4_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.26.0-h26d7fe4_0.conda
+  sha256: c6caa2d4c375c6c5718e6223bb20ccf6305313c0fef2a66499b4f6cdaa299635
+  md5: 7b9d4c93870fb2d644168071d4d76afb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  constrains:
+  - libgoogle-cloud 2.26.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1223584
+  timestamp: 1719889637602
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.26.0
+  build: h5e7cea3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.26.0-h5e7cea3_0.conda
+  sha256: 31e0abd909dce9b0223471383e5f561c802da0abfe7d6f28eb0317c806879c41
+  md5: 641d850ed6a3d2bffb546868eb7cb4db
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgrpc >=1.62.2,<1.63.0a0
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libgoogle-cloud 2.26.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 14356
+  timestamp: 1719889580338
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.26.0
+  build: h721cda5_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.22.0-h651e89d_1.conda
-  sha256: 39f2f50202e50e41ee8581c99a0b3023c2c21cab80ba597f8c5be7c8c8c6a059
-  md5: 3f2faf53ecb3b51b92b3eee155b50233
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.26.0-h721cda5_0.conda
+  sha256: f514519dc7a48cfd81e5c2dd436223b221f80c03f224253739e22d60d896f632
+  md5: 7f7f4537746da4470385ec3a496730a4
   depends:
   - __osx >=10.13
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libcxx >=16
-  - libgrpc >=1.62.0,<1.63.0a0
+  - libgrpc >=1.62.2,<1.63.0a0
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   constrains:
-  - libgoogle-cloud 2.22.0 *_1
+  - libgoogle-cloud 2.26.0 *_0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 849198
-  timestamp: 1709738549021
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.22.0
-  build: h9be4e54_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.22.0-h9be4e54_1.conda
-  sha256: b9980209438b22113f4352df2b260bf43b2eb63a7b6325192ec5ae3a562872ed
-  md5: 4b4e36a91e7dabf7345b82d85767a7c3
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libgrpc >=1.62.0,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  constrains:
-  - libgoogle-cloud 2.22.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 1209816
-  timestamp: 1709737846418
-- kind: conda
-  name: libgoogle-cloud
-  version: 2.22.0
-  build: h9cad5c0_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.22.0-h9cad5c0_1.conda
-  sha256: f76e892d13e1db405777c968787678d8ba912b7e4eef7f950fcdcca185e06e71
-  md5: 63cd44a71f00d4e72844bf0e8be56be4
-  depends:
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgrpc >=1.62.0,<1.63.0a0
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - openssl >=3.2.1,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libgoogle-cloud 2.22.0 *_1
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 14420
-  timestamp: 1709737037941
+  size: 875432
+  timestamp: 1719889038115
 - kind: conda
   name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: ha67e85c_1
-  build_number: 1
+  version: 2.26.0
+  build: h9e84e37_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.22.0-ha67e85c_1.conda
-  sha256: e4f351e55fe7c0656cb608eba8690063e3b407d25a855c9d1fd832486d4a1244
-  md5: 0c25180c34b1a58d309b28386698fb6e
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.26.0-h9e84e37_0.conda
+  sha256: d2081318e2962225c7b00fee355f66737553828eac42ddfbab968f59b039213a
+  md5: b1e5017003917b69d5c046fc7ac0dcc3
   depends:
+  - __osx >=10.13
   - libabseil
   - libcrc32c >=1.1.2,<1.2.0a0
   - libcurl
   - libcxx >=16
-  - libgoogle-cloud 2.22.0 h651e89d_1
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgoogle-cloud 2.26.0 h721cda5_0
+  - libzlib >=1.3.1,<2.0a0
   - openssl
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 523045
-  timestamp: 1709739227970
+  size: 549363
+  timestamp: 1719890135847
 - kind: conda
   name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: hb581fae_1
-  build_number: 1
+  version: 2.26.0
+  build: ha262f82_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.26.0-ha262f82_0.conda
+  sha256: 7c16bf2e5aa6b5e42450c218fdfa7d5ff1da952c5a5c821c001ab3fd940c2aed
+  md5: 89b53708fd67762b26c38c8ecc5d323d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc-ng >=12
+  - libgoogle-cloud 2.26.0 h26d7fe4_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 764005
+  timestamp: 1719889827732
+- kind: conda
+  name: libgoogle-cloud-storage
+  version: 2.26.0
+  build: he5eb982_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.22.0-hb581fae_1.conda
-  sha256: 5ee34f168948211db14874f521e6edf9b4032d533c61fd429caaa282be1d0e7b
-  md5: f63348292dea55cf834e631cf26e2669
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.26.0-he5eb982_0.conda
+  sha256: cfe666f4e205148661249a87587335a1dae58f7bf530fb08dcc2ffcd1bc6adb9
+  md5: 31d875f47c82afb1c9bbe3beb3bd8d6e
   depends:
   - libabseil
   - libcrc32c >=1.1.2,<1.2.0a0
   - libcurl
-  - libgoogle-cloud 2.22.0 h9cad5c0_1
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl
+  - libgoogle-cloud 2.26.0 h5e7cea3_0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 14330
-  timestamp: 1709737542249
-- kind: conda
-  name: libgoogle-cloud-storage
-  version: 2.22.0
-  build: hc7a4891_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.22.0-hc7a4891_1.conda
-  sha256: 0e00e1ca2a981db1c96071edf266bc29fd6f13ac484225de1736fc4dac5c64a8
-  md5: 7811f043944e010e54640918ea82cecd
-  depends:
-  - libabseil
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl
-  - libgcc-ng >=12
-  - libgoogle-cloud 2.22.0 h9be4e54_1
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 748818
-  timestamp: 1709738181078
+  size: 14267
+  timestamp: 1719889928831
 - kind: conda
   name: libgpg-error
-  version: '1.48'
-  build: h71f35ed_0
+  version: '1.50'
+  build: h4f305b6_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.48-h71f35ed_0.conda
-  sha256: c448c6d86d27e10b9e844172000540e9cbfe9c28f968db87f949ba05add9bd50
-  md5: 4d18d86916705d352d5f4adfb7f0edd3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.50-h4f305b6_0.conda
+  sha256: c60969d5c315f33fee90a1f2dd5d169e2834ace5a55f5a6f822aa7485a3a84cc
+  md5: 0d7ff1a8e69565ca3add6925e18e708f
   depends:
-  - gettext >=0.21.1,<1.0a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
   - libgcc-ng >=12
+  - libgettextpo >=0.22.5,<1.0a0
   - libstdcxx-ng >=12
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 266447
-  timestamp: 1708702470365
+  size: 273774
+  timestamp: 1719390736440
 - kind: conda
   name: libgrpc
-  version: 1.62.1
+  version: 1.62.2
   build: h15f2491_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
-  sha256: 1d4ece94dfef73d904dcba0fd9d56098796f5fdc62ea5f9edff60c71be7a3d63
-  md5: 564517a8cbd095cff75eb996d33d2b7e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
+  sha256: 28241ed89335871db33cb6010e9ccb2d9e9b6bb444ddf6884f02f0857363c06a
+  md5: 8dabe607748cb3d7002ad73cd06f1325
   depends:
-  - c-ares >=1.27.0,<2.0a0
+  - c-ares >=1.28.1,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libprotobuf >=4.25.3,<4.25.4.0a0
   - libre2-11 >=2023.9.1,<2024.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.2.1,<4.0a0
   - re2
   constrains:
-  - grpc-cpp =1.62.1
+  - grpc-cpp =1.62.2
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 7667664
-  timestamp: 1709938059287
+  size: 7316832
+  timestamp: 1713390645548
 - kind: conda
   name: libgrpc
-  version: 1.62.1
+  version: 1.62.2
   build: h384b2fc_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.1-h384b2fc_0.conda
-  sha256: 8c9898d259e2343df52259b599ec342c386679e1c420df603cba6f06078fcdd6
-  md5: 2ac05daca7276a4d6ca4465707670380
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
+  sha256: 7c228040e7dac4e5e7e6935a4decf6bc2155cc05fcfb0811d25ccb242d0036ba
+  md5: 9421f67cf8b4bc976fe5d0c3ab42de18
   depends:
   - __osx >=10.13
-  - c-ares >=1.27.0,<2.0a0
+  - c-ares >=1.28.1,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20240116.1,<20240117.0a0
   - libcxx >=16
   - libprotobuf >=4.25.3,<4.25.4.0a0
   - libre2-11 >=2023.9.1,<2024.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.2.1,<4.0a0
   - re2
   constrains:
-  - grpc-cpp =1.62.1
+  - grpc-cpp =1.62.2
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 4432823
-  timestamp: 1709938959215
+  size: 5189573
+  timestamp: 1713392887258
 - kind: conda
   name: libgrpc
-  version: 1.62.1
+  version: 1.62.2
   build: h5273850_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.1-h5273850_0.conda
-  sha256: 338cb58d1095ee651acd168af9636834b41908f7a94e613088e284dc53d2947c
-  md5: 99ac2f772591801641ec692fee843796
+  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
+  sha256: 08794bf5ea0e19ac23ed47d0f8699b5c05c46f14334b41f075e53bac9bbf97d8
+  md5: 2939e4b5baecfeac1e8dee5c4f579f1a
   depends:
-  - c-ares >=1.27.0,<2.0a0
+  - c-ares >=1.28.1,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20240116.1,<20240117.0a0
   - libprotobuf >=4.25.3,<4.25.4.0a0
   - libre2-11 >=2023.9.1,<2024.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.2.1,<4.0a0
   - re2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - grpc-cpp =1.62.1
+  - grpc-cpp =1.62.2
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 15963245
-  timestamp: 1709939262816
+  size: 16097674
+  timestamp: 1713392821679
 - kind: conda
   name: libhwloc
-  version: 2.9.3
-  build: default_haede6df_1009
-  build_number: 1009
+  version: 2.11.1
+  build: default_h8125262_1000
+  build_number: 1000
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
-  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  md5: 87da045f6d26ce9fe20ad76a18f6a18a
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
+  sha256: 92728e292640186759d6dddae3334a1bc0b139740b736ffaeccb825fb8c07a2e
+  md5: 933bad6e4658157f1aec9b171374fde2
   depends:
-  - libxml2 >=2.11.5,<3.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
   - pthreads-win32
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -8832,8 +9326,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 2578462
-  timestamp: 1694533393675
+  size: 2379689
+  timestamp: 1720461835526
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -8926,22 +9420,6 @@ packages:
   size: 40772
   timestamp: 1712516363413
 - kind: conda
-  name: libintl-devel
-  version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
-  sha256: e3f15a85c6e63633a5ff503d56366bab31cd2e07ea21559889bc7eb19564106d
-  md5: ea0a07e556d6b238db685cae6e3585d0
-  depends:
-  - libiconv >=1.17,<2.0a0
-  - libintl 0.22.5 h5ff76d1_2
-  license: LGPL-2.1-or-later
-  purls: []
-  size: 38422
-  timestamp: 1712512843420
-- kind: conda
   name: libjpeg-turbo
   version: 3.0.0
   build: h0dc2134_1
@@ -8995,86 +9473,65 @@ packages:
 - kind: conda
   name: libkml
   version: 1.3.0
-  build: h01aab08_1018
-  build_number: 1018
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-h01aab08_1018.conda
-  sha256: f67fc0be886c7eac14dbce858bfcffbc90a55b598e897e513f0979dd2caad750
-  md5: 3eb5f16bcc8a02892199aa63555c731f
-  depends:
-  - libboost-headers
-  - libexpat >=2.5.0,<3.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - uriparser >=0.9.7,<1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 513804
-  timestamp: 1696451330826
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: hab3ca0e_1018
-  build_number: 1018
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hab3ca0e_1018.conda
-  sha256: f546750a59b85a4b721f69e34e797ceddb93c438ee384db285e3344490d6a9b5
-  md5: 535b1bb4896b113c14dfa64141370a12
-  depends:
-  - libboost-headers
-  - libcxx >=15.0.7
-  - libexpat >=2.5.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - uriparser >=0.9.7,<1.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 398649
-  timestamp: 1696452291278
-- kind: conda
-  name: libkml
-  version: 1.3.0
-  build: haf3e7a6_1018
-  build_number: 1018
+  build: h538826c_1020
+  build_number: 1020
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-haf3e7a6_1018.conda
-  sha256: 74117fe100d9aa3aaab25eb705c44165f8ff6feec2e7c058212a3f5434f85d5f
-  md5: 950e8765b20b79ecbd296543f848b4ec
+  url: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
+  sha256: 2f20949d50302bddfd4b6c9bb2cd91a02c97ce5a36fab552f2eacad53a71c113
+  md5: fddbd8a22ee5700bc07e978e25c10ef1
   depends:
-  - libboost-headers
-  - libexpat >=2.5.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - uriparser >=0.9.7,<1.0a0
+  - uriparser >=0.9.8,<1.0a0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1764160
-  timestamp: 1696451646350
+  size: 1655764
+  timestamp: 1720690303546
 - kind: conda
-  name: liblapack
-  version: 3.9.0
-  build: 22_linux64_openblas
-  build_number: 22
+  name: libkml
+  version: 1.3.0
+  build: hbbc8833_1020
+  build_number: 1020
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-22_linux64_openblas.conda
-  sha256: db246341d42f9100d45adeb1a7ba8b1ef5b51ceb9056fd643e98046a3259fde6
-  md5: b083767b6c877e24ee597d93b87ab838
+  url: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hbbc8833_1020.conda
+  sha256: 5bd19933cb3790ec8632c11fa67c25d82654bea6c2bc4f51f8bcd8b122ae96c8
+  md5: 6d76c5822cb38bc1ab5a06565c6cf626
   depends:
-  - libblas 3.9.0 22_linux64_openblas
-  constrains:
-  - libcblas 3.9.0 22_linux64_openblas
-  - blas * openblas
-  - liblapacke 3.9.0 22_linux64_openblas
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.6.2,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 14471
-  timestamp: 1712542277696
+  size: 395723
+  timestamp: 1720690222714
+- kind: conda
+  name: libkml
+  version: 1.3.0
+  build: hfcbc525_1020
+  build_number: 1020
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
+  sha256: 20dec455f668ab2527d6a20204599253ac0b2d4d0325e4a1ce2316850128cc3e
+  md5: 055d429f351b79c0a7b7d7e39ff45b28
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libexpat >=2.6.2,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - uriparser >=0.9.8,<1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 285823
+  timestamp: 1720690426491
 - kind: conda
   name: liblapack
   version: 3.9.0
@@ -9098,23 +9555,43 @@ packages:
 - kind: conda
   name: liblapack
   version: 3.9.0
-  build: 22_win64_mkl
-  build_number: 22
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-22_win64_mkl.conda
-  sha256: 8b28b361a13819ed83a67d3bfdde750a13bc8b50b9af26d94fd61616d0f2d703
-  md5: c752cc2af9f3d8d7b2fdebb915a33ef7
+  build: 23_linux64_openblas
+  build_number: 23
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-23_linux64_openblas.conda
+  sha256: 25c7aef86c8a1d9db0e8ee61aa7462ba3b46b482027a65d66eb83e3e6f949043
+  md5: 2af0879961951987e464722fd00ec1e0
   depends:
-  - libblas 3.9.0 22_win64_mkl
+  - libblas 3.9.0 23_linux64_openblas
   constrains:
-  - liblapacke 3.9.0 22_win64_mkl
-  - blas * mkl
-  - libcblas 3.9.0 22_win64_mkl
+  - liblapacke 3.9.0 23_linux64_openblas
+  - libcblas 3.9.0 23_linux64_openblas
+  - blas * openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 5182500
-  timestamp: 1712543085027
+  size: 14823
+  timestamp: 1721688775172
+- kind: conda
+  name: liblapack
+  version: 3.9.0
+  build: 23_win64_mkl
+  build_number: 23
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-23_win64_mkl.conda
+  sha256: 4f4738602d26935f4d4b0154fb23d48c276c87413c3a5e05274809abfcbe1273
+  md5: 3580796ab7b7d68143f45d4d94d866b7
+  depends:
+  - libblas 3.9.0 23_win64_mkl
+  constrains:
+  - blas * mkl
+  - libcblas 3.9.0 23_win64_mkl
+  - liblapacke 3.9.0 23_win64_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 5191980
+  timestamp: 1721689666180
 - kind: conda
   name: libllvm15
   version: 15.0.7
@@ -9127,8 +9604,8 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.1,<2.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
@@ -9136,150 +9613,113 @@ packages:
   size: 33321457
   timestamp: 1701375836233
 - kind: conda
-  name: libllvm16
-  version: 16.0.6
-  build: hb3ce162_3
-  build_number: 3
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-hb3ce162_3.conda
-  sha256: 624fa4012397bc5a8c9269247bf9baa7d907eb59079aefc6f6fa6a40f10fd0ba
-  md5: a4d48c40dd5c60edbab7fd69c9a88967
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.1,<2.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 35359734
-  timestamp: 1701375139881
-- kind: conda
-  name: libllvm16
-  version: 16.0.6
-  build: hbedff68_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
-  sha256: ad848dc0bb02b1dbe54324ee5700b050a2e5f63c095f5229b2de58249a3e268e
-  md5: 8fd56c0adc07a37f93bd44aa61a97c90
-  depends:
-  - libcxx >=16
-  - libxml2 >=2.12.1,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 25196932
-  timestamp: 1701379796962
-- kind: conda
   name: libllvm18
-  version: 18.1.3
-  build: h2448989_0
+  version: 18.1.8
+  build: h8b73ec9_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.3-h2448989_0.conda
-  sha256: 4f213da12c893451b21db33ab9eb7637378b79da3747e4ba70db482f7310c5ae
-  md5: 927b6d6e80b2c0d4405a58b61ca248a3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm18-18.1.8-h8b73ec9_1.conda
+  sha256: 8a04961ef1ef88a5af6632441580f607cf20c02d0f413bd11354929331cbe729
+  md5: 16d94b3586ef3558e5a583598524deb4
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 38422113
-  timestamp: 1712517638355
+  size: 38233630
+  timestamp: 1721183903221
 - kind: conda
   name: libnetcdf
   version: 4.9.2
-  build: nompi_h07c049d_113
-  build_number: 113
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h07c049d_113.conda
-  sha256: 4b06a7aa1fcfb3406e3eab9368089d612ea014402edd5deefb2f02b73cf3673d
-  md5: 2aa431a5a05e3679eea4faad0f47b119
+  build: nompi_h135f659_114
+  build_number: 114
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h135f659_114.conda
+  sha256: 055572a4c8a1c3f9ac60071ee678f5ea49cfd7ac60a636d817988a6f9d6de6ae
+  md5: a908e463c710bd6b10a9eaa89fdf003c
   depends:
   - blosc >=1.21.5,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libxml2 >=2.12.2,<3.0.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.12.7,<3.0a0
   - libzip >=1.10.1,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 849172
+  timestamp: 1717671645362
+- kind: conda
+  name: libnetcdf
+  version: 4.9.2
+  build: nompi_h7334405_114
+  build_number: 114
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
+  sha256: a4af96274a6c72d97e84dfc728ecc765af300de805d962a835c0841bb6a8f331
+  md5: 32ffbe5b0b0134e49f6347f4de8c5dcc
+  depends:
+  - __osx >=10.13
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libxml2 >=2.12.7,<3.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - zlib
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 726205
+  timestamp: 1717671847032
+- kind: conda
+  name: libnetcdf
+  version: 4.9.2
+  build: nompi_h92078aa_114
+  build_number: 114
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
+  sha256: 111fb98bf02e717c69eb78388a5b03dc7af05bfa840ac51c2b31beb70bf42318
+  md5: 819507db3802d9a179de4d161285c22f
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=1.14.3,<1.14.4.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzip >=1.10.1,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zlib
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 625091
-  timestamp: 1702229854053
-- kind: conda
-  name: libnetcdf
-  version: 4.9.2
-  build: nompi_h7760872_113
-  build_number: 113
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7760872_113.conda
-  sha256: 3d6a950d82a8dfb9fa51c263e543cfa9c113703add20646ec85401e7b557da49
-  md5: bce76ace6497221c2a2a02840aaceac5
-  depends:
-  - __osx >=10.9
-  - blosc >=1.21.5,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=16.0.6
-  - libxml2 >=2.12.2,<3.0.0a0
-  - libzip >=1.10.1,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zlib
-  - zstd >=1.5.5,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 724322
-  timestamp: 1702229765562
-- kind: conda
-  name: libnetcdf
-  version: 4.9.2
-  build: nompi_h9612171_113
-  build_number: 113
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h9612171_113.conda
-  sha256: 0b4d984c7be21531e9254ce742e04101f7f7e77c0bbb7074855c0806c28323b0
-  md5: b2414908e43c442ddc68e6148774a304
-  depends:
-  - blosc >=1.21.5,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.3,<1.14.4.0a0
-  - libaec >=1.1.2,<2.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxml2 >=2.12.2,<2.13.0a0
-  - libzip >=1.10.1,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zlib
-  - zstd >=1.5.5,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 849037
-  timestamp: 1702229195031
+  size: 624793
+  timestamp: 1717672198533
 - kind: conda
   name: libnghttp2
   version: 1.58.0
@@ -9295,7 +9735,7 @@ packages:
   - libev >=4.33,<5.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
@@ -9317,28 +9757,13 @@ packages:
   - libcxx >=16.0.6
   - libev >=4.33,<4.34.0a0
   - libev >=4.33,<5.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.2.0,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
   size: 599736
   timestamp: 1702130398536
-- kind: conda
-  name: libnl
-  version: 3.9.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
-  sha256: aae03117811e704c3f3666e8374dd2e632f1d78bef0c27330e7298b24004819e
-  md5: d27c451db4f1d3c983c78167d2fdabc2
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  purls: []
-  size: 732866
-  timestamp: 1702657849946
 - kind: conda
   name: libnsl
   version: 2.0.1
@@ -9356,46 +9781,47 @@ packages:
   timestamp: 1697359010159
 - kind: conda
   name: libogg
-  version: 1.3.4
-  build: h7f98852_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
-  sha256: b88afeb30620b11bed54dac4295aa57252321446ba4e6babd7dce4b9ffde9b25
-  md5: 6e8cc2173440d77708196c5b93771680
+  version: 1.3.5
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_0.conda
+  sha256: fcffdf32c620569738b85c98ddd25e1c84c8add80cd732743d90d469b7b532bb
+  md5: 44a4d173e62c5ed6d715f18ae7c46b7a
   depends:
-  - libgcc-ng >=9.3.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 210550
-  timestamp: 1610382007814
+  size: 35459
+  timestamp: 1719302192495
 - kind: conda
   name: libogg
-  version: 1.3.4
-  build: h8ffe710_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
-  sha256: ef20f04ad2121a07e074b34bfc211587df18180e680963f5c02c54d1951b9ee6
-  md5: 04286d905a0dcb7f7d4a12bdfe02516d
+  version: 1.3.5
+  build: h4ab18f5_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-h4ab18f5_0.conda
+  sha256: 5eda3fe92b99b25dd4737226a9485078ab405672d9f621be75edcb68f1e9026d
+  md5: 601bfb4b3c6f0b844443bb81a56651e0
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
+  - libgcc-ng >=12
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 35187
-  timestamp: 1610382533961
+  size: 205914
+  timestamp: 1719301575771
 - kind: conda
   name: libopenblas
   version: 0.3.27
-  build: openmp_hfef2a42_0
+  build: openmp_h8869122_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_hfef2a42_0.conda
-  sha256: 45519189c0295296268cb7eabeeaa03ef54d780416c9a24be1d2a21db63a7848
-  md5: 00237c9c7f2cb6725fe2960680a6e225
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
+  sha256: 83b0b9d3d09889b3648a81d2c18a2d78c405b03b115107941f0496a8b358ce6d
+  md5: c0798ad76ddd730dade6ff4dff66e0b5
   depends:
+  - __osx >=10.13
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
   - llvm-openmp >=16.0.6
@@ -9404,16 +9830,17 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 6047531
-  timestamp: 1712366254156
+  size: 6047513
+  timestamp: 1720426759731
 - kind: conda
   name: libopenblas
   version: 0.3.27
-  build: pthreads_h413a1c8_0
+  build: pthreads_hac2b453_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
-  sha256: 2ae7559aed0705deb3f716c7b247c74fd1b5e35b64e39834ce8b95f7564d4a3e
-  md5: a356024784da6dfd4683dc5ecf45b155
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
+  sha256: 714cb82d7c4620ea2635a92d3df263ab841676c9b183d0c01992767bb2451c39
+  md5: ae05ece66d3924ac3d48b4aa3fa96cec
   depends:
   - libgcc-ng >=12
   - libgfortran-ng
@@ -9423,8 +9850,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 5598747
-  timestamp: 1712364444346
+  size: 5563053
+  timestamp: 1720426334043
 - kind: conda
   name: libopus
   version: 1.3.1
@@ -9443,64 +9870,63 @@ packages:
   timestamp: 1606823578035
 - kind: conda
   name: libparquet
-  version: 15.0.2
-  build: h089a9f7_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.2-h089a9f7_1_cpu.conda
-  sha256: c018302a1cb5a7d499ee48639264970acbdb6046367a53d533fdd3dad6b9de11
-  md5: 1b06e76579f69227a285a574611f01d1
-  depends:
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libcxx >=16
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 922029
-  timestamp: 1711266728694
-- kind: conda
-  name: libparquet
-  version: 15.0.2
-  build: h352af49_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.2-h352af49_1_cpu.conda
-  sha256: 3561887d5cecd273ca4a40c7263b0b81b9fcb7d14c54fe83c1f691b86c1c6b6f
-  md5: 9c9171bf3a477a585d08a7979f84c3b8
-  depends:
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 1179311
-  timestamp: 1711178591018
-- kind: conda
-  name: libparquet
-  version: 15.0.2
-  build: h7ec3a38_1_cpu
-  build_number: 1
+  version: 17.0.0
+  build: h178134c_2_cpu
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.2-h7ec3a38_1_cpu.conda
-  sha256: 44b5242d76e63fff53deded142ebe762a05a1f6beb3392e267ba30688e3bea1f
-  md5: ed2a8225a571cecb51eb0a3e68edc8dc
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-h178134c_2_cpu.conda
+  sha256: 62c914f0c504168088021ba1f239a954f8dc11d0b5c3f367d968e4cecb146994
+  md5: 63cc400150806d15f51eb6e72bca4602
   depends:
-  - libarrow 15.0.2 h878f99b_1_cpu
+  - libarrow 17.0.0 h11e6a32_2_cpu
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
-  license_family: APACHE
   purls: []
-  size: 792091
-  timestamp: 1711179365149
+  size: 806090
+  timestamp: 1721955978790
+- kind: conda
+  name: libparquet
+  version: 17.0.0
+  build: h904a336_2_cpu
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-h904a336_2_cpu.conda
+  sha256: 2051ef8d7518aff32cee6ce32a6e08db174099cd20c3a358df9c3bebfd2b8888
+  md5: 49feaeea725d9e5f909997f318d6d878
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0 h130fc27_2_cpu
+  - libcxx >=16
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  purls: []
+  size: 925839
+  timestamp: 1721955467435
+- kind: conda
+  name: libparquet
+  version: 17.0.0
+  build: h9e5060d_2_cpu
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-h9e5060d_2_cpu.conda
+  sha256: d7283a8bf46b6203b600fa87dc94505fc54ac893071a5e8a44024b75e1c2f82f
+  md5: e4a82f087e5b915a7ee4cd199a7678df
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0 h4b47046_2_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  purls: []
+  size: 1173349
+  timestamp: 1721955166629
 - kind: conda
   name: libpng
   version: 1.6.43
@@ -9510,7 +9936,7 @@ packages:
   sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
   md5: 77e398acc32617a0384553aea29e866b
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -9528,7 +9954,7 @@ packages:
   md5: 009981dd9cfcaa4dbfa25ffaed86bcae
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
   purls: []
   size: 288221
@@ -9542,63 +9968,61 @@ packages:
   sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
   md5: 65dcddb15965c9de2c0365cb14910532
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: zlib-acknowledgement
   purls: []
   size: 268524
   timestamp: 1708780496420
 - kind: conda
   name: libpq
-  version: '16.2'
-  build: h33b98f1_1
-  build_number: 1
+  version: '16.3'
+  build: h4501773_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.3-h4501773_0.conda
+  sha256: 039da003586fdcdb40b8c8ffa25d5ded33316ba3a32ec79afde098a68b8a3acc
+  md5: 74f18d32d7cc71584c8b05fd1ee555a0
+  depends:
+  - __osx >=10.13
+  - krb5 >=1.21.2,<1.22.0a0
+  - openssl >=3.3.0,<4.0a0
+  license: PostgreSQL
+  purls: []
+  size: 2398885
+  timestamp: 1715267344306
+- kind: conda
+  name: libpq
+  version: '16.3'
+  build: ha72fbe1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
-  sha256: e03a8439b79e013840c44c957d37dbce10316888b2b5dc7dcfcfc0cfe3a3b128
-  md5: 9e49ec2a61d02623b379dc332eb6889d
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+  sha256: 117ba1e11f07b1ca0671641bd6d1f2e7fc6e27db1c317a0cdb4799ffa69f47db
+  md5: bac737ae28b79cfbafd515258d97d29e
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   license: PostgreSQL
   purls: []
-  size: 2601973
-  timestamp: 1710863646063
+  size: 2500439
+  timestamp: 1715266400833
 - kind: conda
   name: libpq
-  version: '16.2'
-  build: ha925e61_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
-  sha256: bfb252cb14b88a75ba4af930c16dccae265dce0afdf5abde7de1718181aa2cea
-  md5: a10ef466bbc68a8e74112a8e26028d66
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - openssl >=3.2.1,<4.0a0
-  license: PostgreSQL
-  purls: []
-  size: 2333894
-  timestamp: 1710864725862
-- kind: conda
-  name: libpq
-  version: '16.2'
-  build: hdb24f17_1
-  build_number: 1
+  version: '16.3'
+  build: hab9416b_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpq-16.2-hdb24f17_1.conda
-  sha256: b217f10336ca02bcffd2adf474fecf4bc917d8fbd26ab027b96e0d05257e5537
-  md5: a347334764562545270c6acc4b852ccf
+  url: https://conda.anaconda.org/conda-forge/win-64/libpq-16.3-hab9416b_0.conda
+  sha256: 5cb998386c86fcbf5c3b929c0ec252e80b56d3f2ef4bc857496f5d06d3b28af1
+  md5: 84d2332f3110845bbafbfd7d5311354f
   depends:
   - krb5 >=1.21.2,<1.22.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: PostgreSQL
   purls: []
-  size: 3642690
-  timestamp: 1710864431449
+  size: 3456937
+  timestamp: 1715267132646
 - kind: conda
   name: libprotobuf
   version: 4.25.3
@@ -9612,7 +10036,7 @@ packages:
   - libabseil >=20240116.1,<20240117.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -9631,7 +10055,7 @@ packages:
   - libabseil * cxx17*
   - libabseil >=20240116.1,<20240117.0a0
   - libcxx >=16
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -9648,7 +10072,7 @@ packages:
   depends:
   - libabseil * cxx17*
   - libabseil >=20240116.1,<20240117.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -9724,58 +10148,59 @@ packages:
 - kind: conda
   name: librttopo
   version: 1.1.0
-  build: h8917695_15
-  build_number: 15
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h8917695_15.conda
-  sha256: 03e248787162a1804683c614c0681c2488fa6d9f353cb32e2f8c1158157165ea
-  md5: 20c3c14bc491f30daecaa6f73e2223ae
-  depends:
-  - geos >=3.12.1,<3.12.2.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL
-  purls: []
-  size: 233194
-  timestamp: 1700766491991
-- kind: conda
-  name: librttopo
-  version: 1.1.0
-  build: h94c4f80_15
-  build_number: 15
+  build: h6c42fcb_16
+  build_number: 16
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h94c4f80_15.conda
-  sha256: 1a85091ebed8272b0c9b9e5aacba1d423c6411bfa91d7777c1ede8c7a42c933b
-  md5: 3c2a870012ae8f6ffcc7735715f197b1
+  url: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-h6c42fcb_16.conda
+  sha256: 417d468a42860bee6d487a39603740c3650fb7eae03b694a9bddada9ef5d1017
+  md5: 4476d717f460b45f5033206bbb84f3f5
   depends:
-  - geos >=3.12.1,<3.12.2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 402764
-  timestamp: 1700767022424
+  size: 407420
+  timestamp: 1720347953921
 - kind: conda
   name: librttopo
   version: 1.1.0
-  build: hf05f67e_15
-  build_number: 15
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-hf05f67e_15.conda
-  sha256: 10c46efefda5cc77143832a186f517e401098907cf9c3ec7406a5c242bb34e33
-  md5: e65bedc9d9779a161cf26b6d12305246
+  build: hc670b87_16
+  build_number: 16
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hc670b87_16.conda
+  sha256: 65bfd9f8915b1fc2523c58bf556dc2b9ed6127b7c6877ed2841c67b717f6f924
+  md5: 3d9f3a2e5d7213c34997e4464d2f938c
   depends:
-  - __osx >=10.9
-  - geos >=3.12.1,<3.12.2.0a0
-  - libcxx >=16.0.6
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 213839
-  timestamp: 1700766697471
+  size: 231637
+  timestamp: 1720347750456
+- kind: conda
+  name: librttopo
+  version: 1.1.0
+  build: he2ba7a0_16
+  build_number: 16
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-he2ba7a0_16.conda
+  sha256: 907f602ad39172a98e3062c0d6616535075f5227435753fe2c843eb10891403c
+  md5: 80cc407788999eb3cd5a3651981e55fd
+  depends:
+  - __osx >=10.13
+  - geos >=3.12.2,<3.12.3.0a0
+  - libcxx >=16
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 213675
+  timestamp: 1720347819147
 - kind: conda
   name: libsndfile
   version: 1.2.2
@@ -9844,183 +10269,135 @@ packages:
   size: 528765
   timestamp: 1605135849110
 - kind: conda
-  name: libspatialindex
-  version: 1.9.3
-  build: h39d44d4_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libspatialindex-1.9.3-h39d44d4_4.tar.bz2
-  sha256: 88af7e2c9c5fc38be7cecd6ed41abbbb9cf5924dedb9c31f9c5426cb715753bb
-  md5: 51c172496e828258d04eba9971f2af1a
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 447231
-  timestamp: 1626973005831
-- kind: conda
-  name: libspatialindex
-  version: 1.9.3
-  build: h9c3ff4c_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialindex-1.9.3-h9c3ff4c_4.tar.bz2
-  sha256: 588fbd0c11bc44e354365d5f836183216a4ed17d680b565ff416a93b839f1a8b
-  md5: d87fbe9c0ff589e802ff13872980bfd9
-  depends:
-  - libgcc-ng >=9.3.0
-  - libstdcxx-ng >=9.3.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 4838937
-  timestamp: 1626972731590
-- kind: conda
-  name: libspatialindex
-  version: 1.9.3
-  build: he49afe7_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialindex-1.9.3-he49afe7_4.tar.bz2
-  sha256: 443db45215e08fbf134a019486c20540d9903c1d9b14ac28ba299f8a730069da
-  md5: b1c13764417c32fa87fac733caa82a64
-  depends:
-  - libcxx >=11.1.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 410011
-  timestamp: 1626973076121
-- kind: conda
   name: libspatialite
   version: 5.1.0
-  build: h7bd4643_4
-  build_number: 4
+  build: h15fa968_8
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h7bd4643_4.conda
-  sha256: 2d07badb81296f42dd0c59b02dbf7d64ca2c78c086226327c1e11e11f71effbd
-  md5: 127d36f9ee392fa81b45e81867ce30ab
+  url: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h15fa968_8.conda
+  sha256: ba7a298eb6e101ad4c3769c84f0d635c34e677a1879064f41e82598f0a0f5696
+  md5: 48502f34f5ba86c1ce192cb30f959dc9
   depends:
+  - __glibc >=2.17,<3.0.a0
   - freexl >=2
   - freexl >=2.0.0,<3.0a0
-  - geos >=3.12.1,<3.12.2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
   - libgcc-ng >=12
   - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.2,<2.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - proj >=9.3.1,<9.3.2.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.1,<9.5.0a0
   - sqlite
   - zlib
   license: MPL-1.1
   license_family: MOZILLA
   purls: []
-  size: 4066136
-  timestamp: 1702008260311
+  size: 3494258
+  timestamp: 1720363665050
 - kind: conda
   name: libspatialite
   version: 5.1.0
-  build: hebe6af1_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hebe6af1_4.conda
-  sha256: 48ff63495ed9ed86db1fb62ea51e1053747e76481200fb33aa164f7bdb1bec93
-  md5: 9e8f3012e1b4460819395357cc7c4371
+  build: hcb35769_8
+  build_number: 8
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hcb35769_8.conda
+  sha256: 98ab122b2a48b70b0845d81cda0f96df11bb89240b17583091b9f39022ad9dab
+  md5: 68253306f07e185a8420488465cc1c32
   depends:
-  - __osx >=10.9
   - freexl >=2
   - freexl >=2.0.0,<3.0a0
-  - geos >=3.12.1,<3.12.2.0a0
-  - libcxx >=16.0.6
+  - geos >=3.12.2,<3.12.3.0a0
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.1,<9.5.0a0
+  - sqlite
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  purls: []
+  size: 8799088
+  timestamp: 1720363415346
+- kind: conda
+  name: libspatialite
+  version: 5.1.0
+  build: hdc25a2c_8
+  build_number: 8
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-hdc25a2c_8.conda
+  sha256: 860aa6eae736e7f280fcded14541512a98def5f49e9206042b452428d9913509
+  md5: 51fd57e4f726cea701188184c036c341
+  depends:
+  - __osx >=10.13
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - libcxx >=16
   - libiconv >=1.17,<2.0a0
   - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.44.2,<4.0a0
-  - libxml2 >=2.12.2,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - proj >=9.3.1,<9.3.2.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.4.1,<9.5.0a0
   - sqlite
   - zlib
   license: MPL-1.1
   license_family: MOZILLA
   purls: []
-  size: 3145354
-  timestamp: 1702008546896
+  size: 3147316
+  timestamp: 1720363598519
 - kind: conda
-  name: libspatialite
-  version: 5.1.0
-  build: hf2f0abc_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-hf2f0abc_4.conda
-  sha256: 30356fe967052feb909ae8b6011637ffe57aaaf6add65399400fca04a97189b7
-  md5: 15d5d74335f53b34f05e6ee83c2e6119
+  name: libsqlite
+  version: 3.46.0
+  build: h1b8f9f3_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+  sha256: 63af1a9e3284c7e4952364bafe7267e41e2d9d8bcc0e85a4ea4b0ec02d3693f6
+  md5: 5dadfbc1a567fe6e475df4ce3148be09
   depends:
-  - freexl >=2
-  - freexl >=2.0.0,<3.0a0
-  - geos >=3.12.1,<3.12.2.0a0
-  - librttopo >=1.1.0,<1.2.0a0
-  - libsqlite >=3.44.2,<4.0a0
-  - libxml2 >=2.12.2,<3.0.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - proj >=9.3.1,<9.3.2.0a0
-  - sqlite
+  - __osx >=10.13
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 908643
+  timestamp: 1718050720117
+- kind: conda
+  name: libsqlite
+  version: 3.46.0
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.0-h2466b09_0.conda
+  sha256: 662bd7e0d63c5b8c31cca19b91649e798319b93568a2ba8d1375efb91eeb251b
+  md5: 951b0a3a463932e17414cd9f047fa03d
+  depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zlib
-  license: MPL-1.1
-  license_family: MOZILLA
+  license: Unlicense
   purls: []
-  size: 8606085
-  timestamp: 1702008651881
+  size: 876677
+  timestamp: 1718051113874
 - kind: conda
   name: libsqlite
-  version: 3.45.2
-  build: h2797004_0
+  version: 3.46.0
+  build: hde9e2c9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
-  sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
-  md5: 866983a220e27a80cb75e85cb30466a1
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
+  md5: 18aa975d2094c34aef978060ae7da7d8
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0a0
   license: Unlicense
   purls: []
-  size: 857489
-  timestamp: 1710254744982
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h92b6c6a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
-  sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
-  md5: 086f56e13a96a6cfb1bf640505ae6b70
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  purls: []
-  size: 902355
-  timestamp: 1710254991672
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
-  sha256: 4bb24b986550275a6d02835150d943c4c675808d05c0efc5c2a22154d007a69f
-  md5: f95359f8dc5abf7da7776ece9ef10bc5
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Unlicense
-  purls: []
-  size: 869606
-  timestamp: 1710255095740
+  size: 865346
+  timestamp: 1718050628718
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -10031,7 +10408,7 @@ packages:
   md5: 1f5a58e686b13bcfde88b93f547d23fe
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10047,7 +10424,7 @@ packages:
   sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
   md5: dc262d03aae04fe26825062879141a41
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -10066,7 +10443,7 @@ packages:
   sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
   md5: ca3a72efba692c59a90d4b9fc0dfe774
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10075,18 +10452,19 @@ packages:
   timestamp: 1685837820566
 - kind: conda
   name: libstdcxx-ng
-  version: 13.2.0
-  build: h7e041cc_5
-  build_number: 5
+  version: 14.1.0
+  build: hc0a3c3a_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_5.conda
-  sha256: a56c5b11f1e73a86e120e6141a42d9e935a99a2098491ac9e15347a1476ce777
-  md5: f6f6600d18a4047b54f803cf708b868a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-14.1.0-hc0a3c3a_0.conda
+  sha256: 88c42b388202ffe16adaa337e36cf5022c63cf09b0405cf06fc6aeacccbe6146
+  md5: 1cb187a157136398ddbaae90713e2498
+  depends:
+  - libgcc-ng 14.1.0 h77fa898_0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 3834139
-  timestamp: 1706819252496
+  size: 3881307
+  timestamp: 1719538923443
 - kind: conda
   name: libsystemd0
   version: '255'
@@ -10120,7 +10498,7 @@ packages:
   depends:
   - libcxx >=15.0.7
   - libevent >=2.1.12,<2.1.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.3,<4.0a0
   license: Apache-2.0
   license_family: APACHE
@@ -10138,7 +10516,7 @@ packages:
   md5: d3432b9d4950e91d2fdf3bed91248ee0
   depends:
   - libevent >=2.1.12,<2.1.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.3,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -10161,7 +10539,7 @@ packages:
   - libevent >=2.1.12,<2.1.13.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.3,<4.0a0
   license: Apache-2.0
   license_family: APACHE
@@ -10183,7 +10561,7 @@ packages:
   - libdeflate >=1.20,<1.21.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: HPND
@@ -10206,7 +10584,7 @@ packages:
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libstdcxx-ng >=12
   - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: HPND
@@ -10226,7 +10604,7 @@ packages:
   - lerc >=4.0.0,<5.0a0
   - libdeflate >=1.20,<1.21.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -10332,109 +10710,109 @@ packages:
   timestamp: 1610609811627
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
-  build: h0dc2134_0
+  version: 1.4.0
+  build: h10d778d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
-  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
-  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 346599
-  timestamp: 1694709233836
+  size: 355099
+  timestamp: 1713200298965
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
-  md5: dcde8820959e64378d4e06147ffecfdd
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 268870
-  timestamp: 1694709461733
+  size: 274359
+  timestamp: 1713200524021
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
-  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
   depends:
   - libgcc-ng >=12
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 401830
-  timestamp: 1694709121323
+  size: 438953
+  timestamp: 1713199854503
 - kind: conda
   name: libxcb
-  version: '1.15'
-  build: h0b41bf4_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
-  sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
-  md5: 33277193f5b92bad9fdd230eb700929c
-  depends:
-  - libgcc-ng >=12
-  - pthread-stubs
-  - xorg-libxau
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 384238
-  timestamp: 1682082368177
-- kind: conda
-  name: libxcb
-  version: '1.15'
-  build: hb7f2c08_0
+  version: '1.16'
+  build: h0dc2134_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
-  sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
-  md5: 5513f57e0238c87c12dffedbcc9c1a4a
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.16-h0dc2134_0.conda
+  sha256: c64277f586b716d5c34947e7f2783ef0d24f239a136bc6a024e854bede0389a9
+  md5: 07e80289d4ba724f37b4b6f001f88fbe
   depends:
   - pthread-stubs
-  - xorg-libxau
+  - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
   purls: []
-  size: 313793
-  timestamp: 1682083036825
+  size: 322676
+  timestamp: 1693089168477
 - kind: conda
   name: libxcb
-  version: '1.15'
+  version: '1.16'
   build: hcd874cb_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
-  sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
-  md5: 090d91b69396f14afef450c285f9758c
+  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-hcd874cb_0.conda
+  sha256: 3b1f3b04baa370cfb1c350cfa829e6236519df5f03e3f57ea2cb2eb044eb8616
+  md5: 7c1217d3b075f195ab17370f2d550f5d
   depends:
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
   - pthread-stubs
-  - xorg-libxau
+  - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxdmcp
   license: MIT
   license_family: MIT
   purls: []
-  size: 969788
-  timestamp: 1682083087243
+  size: 989932
+  timestamp: 1693089470750
+- kind: conda
+  name: libxcb
+  version: '1.16'
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.16-hd590300_0.conda
+  sha256: 7180375f37fd264bb50672a63da94536d4abd81ccec059e932728ae056324b3a
+  md5: 151cba22b85a989c2d6ef9633ffee1e4
+  depends:
+  - libgcc-ng >=12
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 394932
+  timestamp: 1693088990429
 - kind: conda
   name: libxcrypt
   version: 4.4.36
@@ -10453,82 +10831,85 @@ packages:
 - kind: conda
   name: libxkbcommon
   version: 1.7.0
-  build: h662e7e4_0
+  build: h2c5496b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h662e7e4_0.conda
-  sha256: 3d97d7f964237f42452295d461afdbc51e93f72e2c80be516f56de80e3bb6621
-  md5: b32c0da42b1f24a98577bb3d7fc0b995
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.7.0-h2c5496b_1.conda
+  sha256: 6804c2a7062d10de6f159f7106dc45ebccc8d42bfb925f7919e26e567fa6da6b
+  md5: e2eaefa4de2b7237af7c907b8bbc760a
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.6,<3.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libxml2 >=2.12.7,<3.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
   license: MIT/X11 Derivative
   license_family: MIT
   purls: []
-  size: 593534
-  timestamp: 1711303445595
+  size: 593336
+  timestamp: 1718819935698
 - kind: conda
   name: libxml2
-  version: 2.12.6
-  build: h232c23b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
-  sha256: c0bd693bb1a7e5aba388a0c79be16ff92e2411e03aaa920f94b4b33bf099e254
-  md5: 6853448e9ca1cfd5f15382afd2a6d123
-  depends:
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 705994
-  timestamp: 1711318087106
-- kind: conda
-  name: libxml2
-  version: 2.12.6
-  build: hc0ae0f7_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_1.conda
-  sha256: 07a5dc7316d4c1ff3d924df6a76e6a13380d702fa5b3b1889e56d0672e5b8201
-  md5: bd85e0ca9e1ffaadc3b56079fd956035
-  depends:
-  - icu >=73.2,<74.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 620164
-  timestamp: 1711318305209
-- kind: conda
-  name: libxml2
-  version: 2.12.6
-  build: hc3477c8_1
-  build_number: 1
+  version: 2.12.7
+  build: h0f24e4e_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_1.conda
-  sha256: 1846c1318a5987e7315ca3648b55b38e5cfd9853370803a0f5159bc0071609c1
-  md5: eb9f59dd51f50f5aa369813fa63ba569
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h0f24e4e_4.conda
+  sha256: ae78197961b09b0eef4ee194a44e4adc4555c0f2f20c348086b0cd8aaf2f7731
+  md5: ed4d301f0d2149b34deb9c4fecafd836
   depends:
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 1640801
-  timestamp: 1711318467301
+  size: 1682090
+  timestamp: 1721031296951
+- kind: conda
+  name: libxml2
+  version: 2.12.7
+  build: h4c95cb1_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.7-h4c95cb1_3.conda
+  sha256: 11a346aed187405a7d3710a79b815fd66ff80fec3b9b7f840a24531324742acf
+  md5: 0ac9aff6010a7751961c8e4b863a40e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 705701
+  timestamp: 1720772684071
+- kind: conda
+  name: libxml2
+  version: 2.12.7
+  build: heaf3512_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
+  sha256: ed18a2d8d428c0b88d47751ebcc7cc4e6202f99c3948fffd776cba83c4f0dad3
+  md5: ea1be6ecfe814da889e882c8b6ead79d
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 619901
+  timestamp: 1721031175411
 - kind: conda
   name: libzip
   version: 1.10.1
@@ -10540,7 +10921,7 @@ packages:
   md5: 5c629cd12d89e2856c17b1dc5fcf44a4
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.2,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -10562,7 +10943,7 @@ packages:
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.2,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10580,7 +10961,7 @@ packages:
   md5: 6112b3173f3aa2f12a8f40d07a77cc35
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.2,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
@@ -10589,73 +10970,77 @@ packages:
   timestamp: 1694416738467
 - kind: conda
   name: libzlib
-  version: 1.2.13
-  build: h8a1eda9_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-  sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
-  md5: 4a3ad23f6e16f99c04e166767193d700
-  constrains:
-  - zlib 1.2.13 *_5
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 59404
-  timestamp: 1686575566695
-- kind: conda
-  name: libzlib
-  version: 1.2.13
-  build: hcfcfb64_5
-  build_number: 5
+  version: 1.3.1
+  build: h2466b09_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
-  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_1.conda
+  sha256: b13846a54a15243e15f96fec06b526d8155adc6a1ac2b6ed47a88f6a71a94b68
+  md5: d4483ca8afc57ddf1f6dded53b36c17f
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - zlib 1.2.13 *_5
+  - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
   purls: []
-  size: 55800
-  timestamp: 1686575452215
+  size: 56186
+  timestamp: 1716874730539
 - kind: conda
   name: libzlib
-  version: 1.2.13
-  build: hd590300_5
-  build_number: 5
+  version: 1.3.1
+  build: h4ab18f5_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
-  sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  md5: f36c115f1ee199da648e0597ec2047ad
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
+  sha256: adf6096f98b537a11ae3729eaa642b0811478f0ea0402ca67b5108fe2cb0010d
+  md5: 57d7dc60e9325e3de37ff8dffd18e814
   depends:
   - libgcc-ng >=12
   constrains:
-  - zlib 1.2.13 *_5
+  - zlib 1.3.1 *_1
   license: Zlib
   license_family: Other
   purls: []
-  size: 61588
-  timestamp: 1686575217516
+  size: 61574
+  timestamp: 1716874187109
+- kind: conda
+  name: libzlib
+  version: 1.3.1
+  build: h87427d6_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
+  sha256: 80a62db652b1da0ccc100812a1d86e94f75028968991bfb17f9536f3aa72d91d
+  md5: b7575b5aa92108dcc9aaab0f05f2dbce
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_1
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 57372
+  timestamp: 1716874211519
 - kind: conda
   name: llvm-openmp
-  version: 18.1.2
-  build: hb6ac08f_0
+  version: 18.1.8
+  build: h15ab845_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
-  sha256: dc40b678f5be2caf4e89ee3dc9037399d0bcd46543bc258dc46e1b92d241c6a6
-  md5: e7f7e91cfabd8c7172c9ae405214dd68
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+  sha256: 0fd74128806bd839c7a9aa343faf265b94aece84f75f67f14b6246936138e61e
+  md5: 2c3c6c8aaf8728f87326964a82fdc7d8
+  depends:
+  - __osx >=10.13
   constrains:
-  - openmp 18.1.2|18.1.2.*
+  - openmp 18.1.8|18.1.8.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 300480
-  timestamp: 1711010792383
+  size: 300682
+  timestamp: 1718887195436
 - kind: conda
   name: lz4-c
   version: 1.9.4
@@ -10707,50 +11092,51 @@ packages:
 - kind: conda
   name: lzo
   version: '2.10'
-  build: h516909a_1000
-  build_number: 1000
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h516909a_1000.tar.bz2
-  sha256: 25d16e6aaa3d0b450e61d0c4fadd7c9fd17f16e2fef09b34507209342d63c9f6
-  md5: bb14fcb13341b81d5eb386423b9d2bac
-  depends:
-  - libgcc-ng >=7.5.0
-  license: GPL v2+
-  license_family: GPL2
-  purls: []
-  size: 321113
-  timestamp: 1597681972321
-- kind: conda
-  name: lzo
-  version: '2.10'
-  build: haf1e3a3_1000
-  build_number: 1000
+  build: h10d778d_1001
+  build_number: 1001
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-haf1e3a3_1000.tar.bz2
-  sha256: c8a9401eff2efbbcc6da03d0066ee85d72402f7658c240e7968c64052a0d0493
-  md5: 0b6bca372a95d6c602c7a922e928ce79
-  license: GPL v2+
+  url: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
+  sha256: 4006c57f805ca6aec72ee0eb7166b2fd648dd1bf3721b9de4b909cd374196643
+  md5: bfecd73e4a2dc18ffd5288acf8a212ab
+  license: GPL-2.0-or-later
   license_family: GPL2
   purls: []
-  size: 194278
-  timestamp: 1597682686489
+  size: 146405
+  timestamp: 1713516112292
 - kind: conda
   name: lzo
   version: '2.10'
-  build: he774522_1000
-  build_number: 1000
+  build: hcfcfb64_1001
+  build_number: 1001
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-he774522_1000.tar.bz2
-  sha256: ff064e34d3cad829f1e31f2d26125b61d20ba8d3771f8f5337069027b8e3fab4
-  md5: d5cf4b7eaa52316f135eed9e8548ad57
+  url: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
+  sha256: 39e176b8cc8fe878d87594fae0504c649d1c2c6d5476dd7238237d19eb825751
+  md5: 629f4f4e874cf096eb93a23240910cee
   depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  license: GPL v2+
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: GPL-2.0-or-later
   license_family: GPL2
   purls: []
-  size: 170192
-  timestamp: 1597682500084
+  size: 142771
+  timestamp: 1713516312465
+- kind: conda
+  name: lzo
+  version: '2.10'
+  build: hd590300_1001
+  build_number: 1001
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+  sha256: 88433b98a9dd9da315400e7fb9cd5f70804cb17dca8b1c85163a64f90f584126
+  md5: ec7398d21e2651e0dcb0044d03b9a339
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL2
+  purls: []
+  size: 171416
+  timestamp: 1713515738503
 - kind: conda
   name: m2w64-gcc-libgfortran
   version: 5.3.0
@@ -10835,13 +11221,13 @@ packages:
   timestamp: 1608166099896
 - kind: conda
   name: mapclassify
-  version: 2.6.1
+  version: 2.7.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.6.1-pyhd8ed1ab_0.conda
-  sha256: 204ab8b242229d422b33cfec07ea61cefa8bd22375a16658afbabaafce031d64
-  md5: 6aceae1ad4f16cf7b73ee04189947f98
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+  sha256: 7b0be62b175db5cc36bcca1b995fccd4a22cd1ffdf612edc188f329087f048f7
+  md5: 014ab9453f9e9fb915937b46830d48e8
   depends:
   - networkx >=2.7
   - numpy >=1.23
@@ -10852,9 +11238,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/mapclassify
-  size: 38684
-  timestamp: 1696563711967
+  - pkg:pypi/mapclassify?source=conda-forge-mapping
+  size: 57466
+  timestamp: 1721848501218
 - kind: conda
   name: markdown-it-py
   version: 3.0.0
@@ -10870,7 +11256,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/markdown-it-py
+  - pkg:pypi/markdown-it-py?source=conda-forge-mapping
   size: 64356
   timestamp: 1686175179621
 - kind: conda
@@ -10889,7 +11275,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/markupsafe
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 25742
   timestamp: 1706900456837
 - kind: conda
@@ -10909,7 +11295,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/markupsafe
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 26685
   timestamp: 1706900070330
 - kind: conda
@@ -10931,19 +11317,19 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/markupsafe
+  - pkg:pypi/markupsafe?source=conda-forge-mapping
   size: 29060
   timestamp: 1706900374745
 - kind: conda
   name: matplotlib
-  version: 3.8.3
+  version: 3.9.1
   build: py312h2e8e312_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.8.3-py312h2e8e312_0.conda
-  sha256: a8f9f94ed6be01eb6c4bc2327b3206dc2e87d0901d6330fe1aa069df82b92d5e
-  md5: ab33ab32d357937a0c165fbe5dec854c
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_0.conda
+  sha256: 41e8bdd3b583ef7fdb01e44efb63d01856d94f585815cc884f4f777330534589
+  md5: ae02b181a2ff235df506d50ff64562c5
   depends:
-  - matplotlib-base >=3.8.3,<3.8.4.0a0
+  - matplotlib-base >=3.9.1,<3.9.2.0a0
   - pyqt >=5.10
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -10952,18 +11338,18 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=conda-forge-mapping
-  size: 8859
-  timestamp: 1708027288324
+  size: 9086
+  timestamp: 1720649436978
 - kind: conda
   name: matplotlib
-  version: 3.8.3
+  version: 3.9.1
   build: py312h7900ff3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.8.3-py312h7900ff3_0.conda
-  sha256: 4c85b3b8d12f3e72076a8fdaec297ea8b25fe8a60fa39feddf30725e0ab91a27
-  md5: 7bdc5e2a07d2e387c3b456da8ec6e6d0
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py312h7900ff3_0.conda
+  sha256: 8c06e3cb558f1d960b7e425439c435e6db5aa55255b7f99c5028ed9c75b3c2b9
+  md5: a5031dbd62fa2f33e180f5d7f331b6ea
   depends:
-  - matplotlib-base >=3.8.3,<3.8.4.0a0
+  - matplotlib-base >=3.9.1,<3.9.2.0a0
   - pyqt >=5.10
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -10972,18 +11358,18 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=conda-forge-mapping
-  size: 8510
-  timestamp: 1708026672386
+  size: 8631
+  timestamp: 1720648551733
 - kind: conda
   name: matplotlib
-  version: 3.8.3
+  version: 3.9.1
   build: py312hb401068_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.8.3-py312hb401068_0.conda
-  sha256: b4892fb470f6db3ca485a5160bd9454633ebe5193acfc1151d5f2adc522aef24
-  md5: 7015bf84c9d39284c4746d814da2a0f1
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py312hb401068_0.conda
+  sha256: 85bf0f06501f606e0dd5f1e6b8f6494a6581780aecfcd7f0600f021089ecf5de
+  md5: 4938ff12b9ec103d5caca8c4666955c3
   depends:
-  - matplotlib-base >=3.8.3,<3.8.4.0a0
+  - matplotlib-base >=3.9.1,<3.9.2.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tornado >=5
@@ -10991,18 +11377,18 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=conda-forge-mapping
-  size: 8580
-  timestamp: 1708027206417
+  size: 8721
+  timestamp: 1720648915042
 - kind: conda
   name: matplotlib-base
-  version: 3.8.3
-  build: py312h1fe5000_0
+  version: 3.9.1
+  build: py312h0d5aeb7_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.3-py312h1fe5000_0.conda
-  sha256: 1b86adb0729b816b9cfdd4a681f056edd4a1092ae3b2e54efb1514fc0b77416e
-  md5: 5f65fc4ce880d4c795e217d563a114ec
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py312h0d5aeb7_0.conda
+  sha256: 9f4c796d6eb7841bbfd68e6272d25fe719d842134e08a17994e857f517062ba0
+  md5: 824194f775dbc413b1dc44d58f3249db
   depends:
-  - __osx >=10.12
+  - __osx >=10.13
   - certifi >=2020.06.20
   - contourpy >=1.0.1
   - cycler >=0.10
@@ -11010,28 +11396,29 @@ packages:
   - freetype >=2.12.1,<3.0a0
   - kiwisolver >=1.3.1
   - libcxx >=16
-  - numpy >=1.21,<2
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.23
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
   - python >=3.12,<3.13.0a0
   - python-dateutil >=2.7
   - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib
-  size: 7723072
-  timestamp: 1708027170066
+  - pkg:pypi/matplotlib?source=conda-forge-mapping
+  size: 7782521
+  timestamp: 1720648847458
 - kind: conda
   name: matplotlib-base
-  version: 3.8.3
-  build: py312h26ecaf7_0
+  version: 3.9.1
+  build: py312h90004f6_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.3-py312h26ecaf7_0.conda
-  sha256: 70a548c7cf8d61d055a5daf5dce3b95e4d0ad698d35f932e1f39c0462eda2898
-  md5: 61dd1bddda8329454b5e1428646b5fe2
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_0.conda
+  sha256: 44f5d5285226a7a7a31fd00dc30d3cd4a6c487d5b0fd3c92aae2354b33860b4d
+  md5: d6bd02226b5b233a197a006faceae45f
   depends:
   - certifi >=2020.06.20
   - contourpy >=1.0.1
@@ -11039,31 +11426,32 @@ packages:
   - fonttools >=4.22.0
   - freetype >=2.12.1,<3.0a0
   - kiwisolver >=1.3.1
-  - numpy >=1.21,<2
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.23
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
   - python >=3.12,<3.13.0a0
   - python-dateutil >=2.7
   - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib
-  size: 7694141
-  timestamp: 1708027251491
+  - pkg:pypi/matplotlib?source=conda-forge-mapping
+  size: 7763916
+  timestamp: 1720649375337
 - kind: conda
   name: matplotlib-base
-  version: 3.8.3
-  build: py312he5832f3_0
+  version: 3.9.1
+  build: py312h9201f00_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.3-py312he5832f3_0.conda
-  sha256: d6e01e76397a750db8de24591411fa9daa057948b327966bf2cc0c9fc03f1451
-  md5: 3b0545901b09b1376b9c0e0ec72409de
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py312h9201f00_0.conda
+  sha256: 6535eaf7260fc7ebd30b208197dc5eb00a1f1e4bbbbc057bb8bc52442b28fcf8
+  md5: e1dc3a7d999666f5c58cbb391940e235
   depends:
   - certifi >=2020.06.20
   - contourpy >=1.0.1
@@ -11073,39 +11461,40 @@ packages:
   - kiwisolver >=1.3.1
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - numpy >=1.21,<2
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
+  - numpy >=1.23
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
   - python >=3.12,<3.13.0a0
   - python-dateutil >=2.7
   - python_abi 3.12.* *_cp312
+  - qhull >=2020.2,<2020.3.0a0
   - tk >=8.6.13,<8.7.0a0
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib
-  size: 7835321
-  timestamp: 1708026649660
+  - pkg:pypi/matplotlib?source=conda-forge-mapping
+  size: 7778927
+  timestamp: 1720648511249
 - kind: conda
   name: matplotlib-inline
-  version: 0.1.6
+  version: 0.1.7
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  md5: b21613793fcc81d944c76c9f2864a7de
+  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
+  sha256: 7ea68676ea35fbb095420bbcc1c82c4767b8be7bb56abb6989b7f89d957a3bab
+  md5: 779345c95648be40d22aaa89de7d4254
   depends:
   - python >=3.6
   - traitlets
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/matplotlib-inline
-  size: 12273
-  timestamp: 1660814913405
+  - pkg:pypi/matplotlib-inline?source=conda-forge-mapping
+  size: 14599
+  timestamp: 1713250613726
 - kind: conda
   name: mdurl
   version: 0.1.2
@@ -11120,73 +11509,74 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/mdurl
+  - pkg:pypi/mdurl?source=conda-forge-mapping
   size: 14680
   timestamp: 1704317789138
 - kind: conda
   name: minizip
-  version: 4.0.5
-  build: h0ab5242_0
+  version: 4.0.6
+  build: hb638d1e_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.6-hb638d1e_0.conda
+  sha256: b334446aa40fe368ea816f5ee47145aea4408812a5a8d016db51923d7c465835
+  md5: 43e2b972e258a25a1e01790ad0e3287a
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 85324
+  timestamp: 1717296997985
+- kind: conda
+  name: minizip
+  version: 4.0.7
+  build: h401b404_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.5-h0ab5242_0.conda
-  sha256: 1a56549751f4c4a7998e0a8bcff367c3992cb832c0b211d775cfd644e1ef5e6b
-  md5: 557396140c71eba588e96d597e0c61aa
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.7-h401b404_0.conda
+  sha256: 6315ea87d094418e744deb79a22331718b36a0e6e107cd7fc3c52c7922bc8133
+  md5: 4474532a312b2245c5c77f1176989b46
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Zlib
   license_family: Other
   purls: []
-  size: 91279
-  timestamp: 1709725664431
+  size: 91409
+  timestamp: 1718483022284
 - kind: conda
   name: minizip
-  version: 4.0.5
-  build: h37d7099_0
+  version: 4.0.7
+  build: h62b0c8d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.5-h37d7099_0.conda
-  sha256: 426f4db1d56cdefa478a5ece35ed7624860548ace87d6ad927c4c9c6a7a20fec
-  md5: 2203b2e83c20305b3d669556c345c8e9
+  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.7-h62b0c8d_0.conda
+  sha256: e02a6e1a43b0ff44bb9460d46d3f7687a1876d435fb3c2c6cf9e19bab60901f6
+  md5: 9cb19284d7d835918241acf8180099db
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
   - libcxx >=16
   - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: Zlib
   license_family: Other
   purls: []
-  size: 78099
-  timestamp: 1709726140187
-- kind: conda
-  name: minizip
-  version: 4.0.5
-  build: h5bed578_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.5-h5bed578_0.conda
-  sha256: 3b77d2f3e71df522e88e1ec4e30742257523ff3e42a4ae0d6c9c7605b4aa6e54
-  md5: acd216ec6d40c7e05991dccc4f9165f2
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 85264
-  timestamp: 1709726113246
+  size: 78595
+  timestamp: 1718483214061
 - kind: conda
   name: mistune
   version: 3.0.2
@@ -11201,26 +11591,26 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/mistune
+  - pkg:pypi/mistune?source=conda-forge-mapping
   size: 66022
   timestamp: 1698947249750
 - kind: conda
   name: mkl
   version: 2024.1.0
-  build: h66d3029_692
-  build_number: 692
+  build: h66d3029_694
+  build_number: 694
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_692.conda
-  sha256: abfdb5eb3a17af59a827ea49fcb4d2bf18e70b62498bf3720351962e636cb5b7
-  md5: b43ec7ed045323edeff31e348eea8652
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_694.conda
+  sha256: 4f86e9ad74a7792c836cd4cb7fc415bcdb50718ffbaa90c5571297f71764b980
+  md5: a17423859d3fb912c8f2e9797603ddb6
   depends:
   - intel-openmp 2024.*
   - tbb 2021.*
-  license: LicenseRef-ProprietaryIntel
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   purls: []
-  size: 109491063
-  timestamp: 1712153746272
+  size: 109381621
+  timestamp: 1716561374449
 - kind: conda
   name: mpg123
   version: 1.32.6
@@ -11263,7 +11653,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/multimethod
+  - pkg:pypi/multimethod?source=conda-forge-mapping
   size: 14782
   timestamp: 1677278842704
 - kind: conda
@@ -11280,58 +11670,17 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/munkres
+  - pkg:pypi/munkres?source=conda-forge-mapping
   size: 12452
   timestamp: 1600387789153
 - kind: conda
   name: mypy
-  version: 1.9.0
-  build: py312h41838bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.9.0-py312h41838bb_0.conda
-  sha256: 74ba59f7ef392d4b54fe0abe4b143e3b3129da0f5fdad4d8094c47d3357e2c74
-  md5: 31083a297ef62583cfe9b930439d787f
-  depends:
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/mypy
-  size: 10251447
-  timestamp: 1709935487712
-- kind: conda
-  name: mypy
-  version: 1.9.0
-  build: py312h98912ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.9.0-py312h98912ed_0.conda
-  sha256: 0d8542e0e237b5e1b4dc3ac2928b8565c88a10cddd5428cf0ad7c0019ab46d5f
-  md5: 67bb56a0bcd5c4fb37eb531aa032c5a4
-  depends:
-  - libgcc-ng >=12
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/mypy
-  size: 16450794
-  timestamp: 1709935018052
-- kind: conda
-  name: mypy
-  version: 1.9.0
-  build: py312he70551f_0
+  version: 1.10.1
+  build: py312h4389bb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.9.0-py312he70551f_0.conda
-  sha256: 2b4126d2a4cfdc42935842f6617c0d635e9b67c0bc3cb24e5fa76985b60a146f
-  md5: a035a256c3ad0da94d7111720eee088a
+  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.10.1-py312h4389bb4_0.conda
+  sha256: 00e7a8f7ac90709b9195eb5655a55f53b8a0297a563201d75b9406936ed69b0b
+  md5: 94e70ace716472016f5a717d4ab7531f
   depends:
   - mypy_extensions >=1.0.0
   - psutil >=4.0
@@ -11344,9 +11693,51 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/mypy
-  size: 8285516
-  timestamp: 1709935177711
+  - pkg:pypi/mypy?source=conda-forge-mapping
+  size: 8414692
+  timestamp: 1719301939732
+- kind: conda
+  name: mypy
+  version: 1.10.1
+  build: py312h9a8786e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.1-py312h9a8786e_0.conda
+  sha256: d65af401f7368680f164990f110d084ee5139cd01a62189c76a88ab87ea50285
+  md5: 35504aad41d76808fa379bee8cd6882e
+  depends:
+  - libgcc-ng >=12
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mypy?source=conda-forge-mapping
+  size: 16471696
+  timestamp: 1719302037228
+- kind: conda
+  name: mypy
+  version: 1.10.1
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.1-py312hbd25219_0.conda
+  sha256: 353e75ea35e3c44294787f318e710379f7f0618962a918af90e91597a2710dea
+  md5: 38d751fa3fd6e793f11903f816ee1cfe
+  depends:
+  - __osx >=10.13
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mypy?source=conda-forge-mapping
+  size: 10370551
+  timestamp: 1719302314714
 - kind: conda
   name: mypy_extensions
   version: 1.0.0
@@ -11361,48 +11752,50 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/mypy-extensions
+  - pkg:pypi/mypy-extensions?source=conda-forge-mapping
   size: 10492
   timestamp: 1675543414256
 - kind: conda
   name: mysql-common
   version: 8.3.0
-  build: hf1915f5_4
-  build_number: 4
+  build: h70512c7_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.3.0-hf1915f5_4.conda
-  sha256: 4cf6d29e091398735348550cb74cfd5006e04892d54b6b1ba916935f1af1a151
-  md5: 784a4df6676c581ca624fbe460703a6d
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.3.0-h70512c7_5.conda
+  sha256: 09296629aab020fb131c8256d8683087769c53ce5197ca3a2abe040bfb285d88
+  md5: 4b652e3e572cbb3f297e77c96313faea
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 784844
-  timestamp: 1709910607121
+  size: 780145
+  timestamp: 1721386057930
 - kind: conda
   name: mysql-libs
   version: 8.3.0
-  build: hca2cd23_4
-  build_number: 4
+  build: ha479ceb_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.3.0-hca2cd23_4.conda
-  sha256: c39cdd1a5829aeffc611f789bdfd4dbd4ce1aa829c73d728defec180b5265d91
-  md5: 1b50eebe2a738a3146c154d2eceaa8b6
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.3.0-ha479ceb_5.conda
+  sha256: c6e9b0961b6877eda8c300b12a0939c81f403a4eb5c0db802e13130fd5a3a059
+  md5: 82776ee8145b9d1fd6546604de4b351d
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common 8.3.0 hf1915f5_4
-  - openssl >=3.2.1,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - mysql-common 8.3.0 h70512c7_5
+  - openssl >=3.3.1,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 1537884
-  timestamp: 1709910705541
+  size: 1532137
+  timestamp: 1721386157918
 - kind: conda
   name: nbclient
   version: 0.10.0
@@ -11421,18 +11814,19 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/nbclient
+  - pkg:pypi/nbclient?source=conda-forge-mapping
   size: 27851
   timestamp: 1710317767117
 - kind: conda
   name: nbconvert-core
-  version: 7.16.3
-  build: pyhd8ed1ab_0
+  version: 7.16.4
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.3-pyhd8ed1ab_0.conda
-  sha256: 522d28206fbafa634763da1ae9119a9edd141d8c516ed13878f77b67921e1bb5
-  md5: 0cab42b4917e71df9dc2224b9940ef19
+  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.4-pyhd8ed1ab_1.conda
+  sha256: 074d858c5808e0a832acc0da37cd70de1565e8d6e17a62d5a11b3902b5e78319
+  md5: e2d2abb421c13456a9a9f80272fdf543
   depends:
   - beautifulsoup4
   - bleach
@@ -11452,14 +11846,14 @@ packages:
   - tinycss2
   - traitlets >=5.0
   constrains:
+  - nbconvert =7.16.4=*_1
   - pandoc >=2.9.2,<4.0.0
-  - nbconvert =7.16.3=*_0
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/nbconvert
-  size: 189119
-  timestamp: 1711069786088
+  - pkg:pypi/nbconvert?source=conda-forge-mapping
+  size: 189599
+  timestamp: 1718135529468
 - kind: conda
   name: nbformat
   version: 5.10.4
@@ -11478,35 +11872,35 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/nbformat
+  - pkg:pypi/nbformat?source=conda-forge-mapping
   size: 101232
   timestamp: 1712239122969
 - kind: conda
   name: ncurses
-  version: 6.4.20240210
+  version: '6.5'
+  build: h5846eda_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
+  sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
+  md5: 02a888433d165c99bf09784a7b14d900
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 823601
+  timestamp: 1715195267791
+- kind: conda
+  name: ncurses
+  version: '6.5'
   build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
-  sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
-  md5: 97da8860a0da5413c7c98a3b3838a645
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+  sha256: 4fc3b384f4072b68853a0013ea83bdfd3d66b0126e2238e1d6e1560747aa7586
+  md5: fcea371545eda051b6deafb24889fc69
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
   purls: []
-  size: 895669
-  timestamp: 1710866638986
-- kind: conda
-  name: ncurses
-  version: 6.4.20240210
-  build: h73e2aa4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
-  sha256: 50b72acf08acbc4e5332807653e2ca6b26d4326e8af16fad1fd3f2ce9ea55503
-  md5: 50f28c512e9ad78589e3eab34833f762
-  license: X11 AND BSD-3-Clause
-  purls: []
-  size: 823010
-  timestamp: 1710866856626
+  size: 887465
+  timestamp: 1715194722503
 - kind: conda
   name: nest-asyncio
   version: 1.6.0
@@ -11521,7 +11915,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/nest-asyncio
+  - pkg:pypi/nest-asyncio?source=conda-forge-mapping
   size: 11638
   timestamp: 1705850780510
 - kind: conda
@@ -11544,27 +11938,27 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/networkx
+  - pkg:pypi/networkx?source=conda-forge-mapping
   size: 1185670
   timestamp: 1712540499262
 - kind: conda
   name: nodeenv
-  version: 1.8.0
+  version: 1.9.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.8.0-pyhd8ed1ab_0.conda
-  sha256: 1320306234552717149f36f825ddc7e27ea295f24829e9db4cc6ceaff0b032bd
-  md5: 2a75b296096adabbabadd5e9782e5fcc
+  url: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_0.conda
+  sha256: 85ee07342ab055dc081f3de8292c5e7195e43e046db9c5750f242f928f6bb8f2
+  md5: dfe0528d0f1c16c1f7c528ea5536ab30
   depends:
   - python 2.7|>=3.7
   - setuptools
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/nodeenv
-  size: 34358
-  timestamp: 1683893151613
+  - pkg:pypi/nodeenv?source=conda-forge-mapping
+  size: 34489
+  timestamp: 1717585382642
 - kind: conda
   name: notebook-shim
   version: 0.2.4
@@ -11580,7 +11974,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/notebook-shim
+  - pkg:pypi/notebook-shim?source=conda-forge-mapping
   size: 16880
   timestamp: 1707957948029
 - kind: conda
@@ -11616,50 +12010,75 @@ packages:
   timestamp: 1669785313586
 - kind: conda
   name: nss
-  version: '3.98'
-  build: h1d7d5a4_0
+  version: '3.102'
+  build: h593d115_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
-  sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
-  md5: 54b56c2fdf973656b748e0378900ec13
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.102-h593d115_0.conda
+  sha256: 5e5dbae2f5bc55646a9d70601432ea71b867ce06bccd174e479ac36abf5d0807
+  md5: 40e5e48c55a45621c4399ca9236406b7
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 2019716
-  timestamp: 1708065114928
+  size: 1974313
+  timestamp: 1720064644368
 - kind: conda
   name: nss
-  version: '3.98'
-  build: ha05da47_0
+  version: '3.102'
+  build: he7eb89d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
-  sha256: 3d99dd976aeb8678e4ac5fcbd574e1de50cdc57b742e22855f294c8047d5c68e
-  md5: 79d062716d8e1f77cf806c6fe0f4405c
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.102-he7eb89d_0.conda
+  sha256: 205386081d59f541784594628d542996b0bcfac1fe32d42010221706bcaf88a4
+  md5: 95e32708bfbae8cd9936c0ad006439a1
   depends:
+  - __osx >=10.13
   - libcxx >=16
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 1908769
-  timestamp: 1708065399315
+  size: 1853247
+  timestamp: 1720064737210
 - kind: conda
   name: numpy
-  version: 1.26.4
-  build: py312h8753938_0
+  version: 2.0.1
+  build: py312h1103770_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.1-py312h1103770_0.conda
+  sha256: 0746a37d09036b4164ac14dd1328dd4e449a038383aac1e25e2d5f3a691518da
+  md5: 9f444595d8d9682891f2f078fc19da43
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/numpy?source=conda-forge-mapping
+  size: 8345605
+  timestamp: 1721966364929
+- kind: conda
+  name: numpy
+  version: 2.0.1
+  build: py312h49bc9c5_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
-  sha256: 73570817a5109d396b4ebbe5124a89525959269fd33fa33fd413700289fbe0ef
-  md5: f9ac74c3b07c396014434aca1e58d362
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.1-py312h49bc9c5_0.conda
+  sha256: 13b38db57cefbbea0cb6a44a5c75df8010480dc6200eda3491c8d203072d1675
+  md5: e7fed4e2639f3a0d58bd8b2164059e8d
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -11672,20 +12091,20 @@ packages:
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
-  license_family: BSD
   purls:
-  - pkg:pypi/numpy
-  size: 6495445
-  timestamp: 1707226412944
+  - pkg:pypi/numpy?source=conda-forge-mapping
+  size: 6945867
+  timestamp: 1721966986321
 - kind: conda
   name: numpy
-  version: 1.26.4
-  build: py312he3a82b2_0
+  version: 2.0.1
+  build: py312h8813227_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
-  sha256: 6152b73fba3e227afa4952df8753128fc9669bbaf142ee8f9972bf9df3bf8856
-  md5: 96c61a21c4276613748dba069554846b
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.1-py312h8813227_0.conda
+  sha256: 3f73ed4464e3dc639c875b6cbe86e8095f88afe047bdfdc3d4b4ae120dd830e8
+  md5: 7f239fbf9d9355f86529a35af0b24d29
   depends:
+  - __osx >=10.13
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=16
@@ -11695,44 +12114,19 @@ packages:
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
-  license_family: BSD
   purls:
-  - pkg:pypi/numpy
-  size: 6990646
-  timestamp: 1707226178262
-- kind: conda
-  name: numpy
-  version: 1.26.4
-  build: py312heda63a1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
-  sha256: fe3459c75cf84dcef6ef14efcc4adb0ade66038ddd27cadb894f34f4797687d8
-  md5: d8285bea2a350f63fab23bf460221f3f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy
-  size: 7484186
-  timestamp: 1707225809722
+  - pkg:pypi/numpy?source=conda-forge-mapping
+  size: 7464264
+  timestamp: 1721966235928
 - kind: conda
   name: odc-geo
-  version: 0.4.3
+  version: 0.4.8
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.3-pyhd8ed1ab_0.conda
-  sha256: 1b50f96543040c38b00fc348fe3904379590062f13bfd63489d06b39960f0f45
-  md5: 3d821615c2a9ed2b3a8778917bb0d56b
+  url: https://conda.anaconda.org/conda-forge/noarch/odc-geo-0.4.8-pyhd8ed1ab_0.conda
+  sha256: 3d3c46618815efb7bd8bf73b974f300296ff260158b1f203069785474723818c
+  md5: abb44a416828ea4c77f53c512cbf46b1
   depends:
   - affine
   - cachetools
@@ -11744,9 +12138,9 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/odc-geo
-  size: 123247
-  timestamp: 1709329463760
+  - pkg:pypi/odc-geo?source=conda-forge-mapping
+  size: 126081
+  timestamp: 1721211191583
 - kind: conda
   name: openjpeg
   version: 2.5.2
@@ -11758,7 +12152,7 @@ packages:
   depends:
   - libpng >=1.6.43,<1.7.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -11780,7 +12174,7 @@ packages:
   - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -11798,7 +12192,7 @@ packages:
   - libcxx >=16
   - libpng >=1.6.43,<1.7.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-2-Clause
   license_family: BSD
   purls: []
@@ -11806,55 +12200,52 @@ packages:
   timestamp: 1709159538792
 - kind: conda
   name: openpyxl
-  version: 3.1.2
-  build: py312h104f124_1
-  build_number: 1
+  version: 3.1.4
+  build: py312h8847cbe_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.2-py312h104f124_1.conda
-  sha256: cd8bf57b42fe405f1849f840f3ef0d818e1c070466e26cdd9e569236bf30d65d
-  md5: 37d146e56f7725d3865b72fe2d389484
+  url: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.4-py312h8847cbe_0.conda
+  sha256: cbdcb24091af51ce4381c816da5dc03410c75011d0b5064443cb88b3c5d28bfb
+  md5: 5ec31518540979d709fd3c101c9059d3
   depends:
   - et_xmlfile
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/openpyxl
-  size: 656343
-  timestamp: 1695465049261
+  - pkg:pypi/openpyxl?source=conda-forge-mapping
+  size: 658691
+  timestamp: 1718277856218
 - kind: conda
   name: openpyxl
-  version: 3.1.2
-  build: py312h98912ed_1
-  build_number: 1
+  version: 3.1.4
+  build: py312h98912ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.2-py312h98912ed_1.conda
-  sha256: e0c61ee0f467aa2ee93315f0612d86a1b62551572d4a38cb69fcde8b81d73d14
-  md5: 7f4e257ea4714e9166a93b733b26c2da
+  url: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.4-py312h98912ed_0.conda
+  sha256: 8eb87b64976051866368a69a58e31ba7c7329ee491805fd14d5347b6a20fb122
+  md5: 678227a6922230b10dbf93b8d161c38d
   depends:
   - et_xmlfile
   - libgcc-ng >=12
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/openpyxl
-  size: 694521
-  timestamp: 1695464937608
+  - pkg:pypi/openpyxl?source=conda-forge-mapping
+  size: 700536
+  timestamp: 1718277650915
 - kind: conda
   name: openpyxl
-  version: 3.1.2
-  build: py312he70551f_1
-  build_number: 1
+  version: 3.1.4
+  build: py312he70551f_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.2-py312he70551f_1.conda
-  sha256: 4a766f6f23e76ad2fb76233d3f23b533309b99b9823127179ba98eaa8e60ae58
-  md5: 62d8cadbe4cad81bfe3088168c434b14
+  url: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.4-py312he70551f_0.conda
+  sha256: 5a34cd7d5995ab89c9a4931e4f671cfd058dd7c2cff03712509a312874cc83a9
+  md5: 7937983367558a16c10c4c7e581d49f1
   depends:
   - et_xmlfile
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -11862,18 +12253,18 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/openpyxl
-  size: 629289
-  timestamp: 1695465331584
+  - pkg:pypi/openpyxl?source=conda-forge-mapping
+  size: 631324
+  timestamp: 1718278171858
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hcfcfb64_1
-  build_number: 1
+  version: 3.3.1
+  build: h2466b09_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
-  sha256: 61ce4e11c3c26ed4e4d9b7e7e2483121a1741ad0f9c8db0a91a28b6e05182ce6
-  md5: 958e0418e93e50c575bff70fbcaa12d8
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
+  sha256: d86c4fa31294ad9068717788197e97e5637e056c82745ffb6d0e88fd1fef1a9d
+  md5: 375dbc2a4d5a2e4c738703207e8e368b
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -11884,18 +12275,19 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 8230112
-  timestamp: 1710796158475
+  size: 8385012
+  timestamp: 1721197465883
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hd590300_1
-  build_number: 1
+  version: 3.3.1
+  build: h4bc722e_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
-  sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
-  md5: 9d731343cff6ee2e5a25c4a091bf8e2a
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
+  sha256: b294b3cc706ad1048cdb514f0db3da9f37ae3fcc0c53a7104083dd0918adb200
+  md5: e1b454497f9f7c1147fdde4b53f1b512
   depends:
+  - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc-ng >=12
   constrains:
@@ -11903,88 +12295,97 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 2865379
-  timestamp: 1710793235846
+  size: 2895213
+  timestamp: 1721194688955
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hd75f5a5_1
-  build_number: 1
+  version: 3.3.1
+  build: h87427d6_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
-  sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
-  md5: 570a6f04802df580be529f3a72d2bbf7
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
+  sha256: 3cb0c05fbfd8cdb9b767396fc0e0af2d78eb4d68592855481254104330d4a4eb
+  md5: 3f3dbeedbee31e257866407d9dea1ff5
   depends:
+  - __osx >=10.13
   - ca-certificates
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 2506344
-  timestamp: 1710793930515
+  size: 2552939
+  timestamp: 1721194674491
 - kind: conda
   name: orc
-  version: 2.0.0
-  build: h1e5e2c1_0
+  version: 2.0.1
+  build: h17fec99_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h1e5e2c1_0.conda
-  sha256: ed8cfe1f35e8ef703e540e7731e77fade1410bba406e17727a10dee08c37d5b4
-  md5: 53e8f030579d34e1a36a735d527c021f
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+  sha256: d340c67b23fb0e1ef7e13574dd4a428f360bfce93b2a588b3b63625926b038d6
+  md5: 3bf65f0d8e7322a1cfe8b670fa35ec81
+  depends:
+  - libgcc-ng >=12
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1029691
+  timestamp: 1716789702707
+- kind: conda
+  name: orc
+  version: 2.0.1
+  build: h7e885a9_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
+  sha256: 8aca1dcb6e9b3e71ffbec26c2b84f45fa682d9075b78cd30acc48044b64149ec
+  md5: 97012c0aeee0bf55c05b5ec42cac0864
   depends:
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1028974
-  timestamp: 1710232781925
+  size: 925642
+  timestamp: 1716789911582
 - kind: conda
   name: orc
-  version: 2.0.0
-  build: h6c6cd50_0
+  version: 2.0.1
+  build: hf43e91b_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.0-h6c6cd50_0.conda
-  sha256: 0c198b6a8de238d53002e7c03e4b1e94e769cf388adac2717fdaadfee9381a14
-  md5: 5ce58b9a5679fe6640d6d68228099ce9
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
+  sha256: 718010a056ef084a12bfd6b4d7908c8817a0093ecc395c270857134e002d5857
+  md5: 15d11d156ad646e69176df6af6ef0826
   depends:
   - __osx >=10.13
   - libcxx >=16
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - snappy >=1.2.0,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 433224
-  timestamp: 1710233383447
-- kind: conda
-  name: orc
-  version: 2.0.0
-  build: heb0c069_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-heb0c069_0.conda
-  sha256: 5a9c0904f38e5c2e1d1494bd192ff98fca13ca07ed1590497b16a801bef497a0
-  md5: 2733034196c084cdc07e0facfea995ea
-  depends:
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 953672
-  timestamp: 1710233287310
+  size: 438785
+  timestamp: 1716789731333
 - kind: conda
   name: overrides
   version: 7.7.0
@@ -12000,36 +12401,85 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/overrides
+  - pkg:pypi/overrides?source=conda-forge-mapping
   size: 30232
   timestamp: 1706394723472
 - kind: conda
   name: packaging
-  version: '24.0'
+  version: '24.1'
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
-  sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
-  md5: 248f521b64ce055e7feae3105e7abeb8
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
+  sha256: 36aca948219e2c9fdd6d80728bcc657519e02f06c2703d8db3446aec67f51d81
+  md5: cbe1bb1f21567018ce595d9c2be0f0db
   depends:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/packaging
-  size: 49832
-  timestamp: 1710076089469
+  - pkg:pypi/packaging?source=conda-forge-mapping
+  size: 50290
+  timestamp: 1718189540074
 - kind: conda
   name: pandas
-  version: 2.2.1
-  build: py312h2ab9e98_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.1-py312h2ab9e98_0.conda
-  sha256: 3031be90c1234ab3f8e60b548cecae2c0278c661b4e1dc7c6c0e15beb7f0fd23
-  md5: 864da9103c0201f4ee512910eee91ab0
+  version: 2.2.2
+  build: py312h1171441_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py312h1171441_1.conda
+  sha256: 99ef3986a0c6a5fe31a94b298f3ef60eb7ec7aa683a9aee6682f97d003aeb423
+  md5: 240737937f1f046b0e03ecc11ac4ec98
   depends:
-  - numpy >=1.26.4,<2.0a0
+  - __osx >=10.13
+  - libcxx >=16
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.12.* *_cp312
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pandas?source=conda-forge-mapping
+  size: 14673730
+  timestamp: 1715898164799
+- kind: conda
+  name: pandas
+  version: 2.2.2
+  build: py312h1d6d2e6_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
+  sha256: 80fd53b68aa89b929d03874b99621ec8cc6a12629bd8bfbdca87a95f8852af96
+  md5: ae00b61f3000d2284d1f2584d4dfafa8
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.12.* *_cp312
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pandas?source=conda-forge-mapping
+  size: 15458981
+  timestamp: 1715898284697
+- kind: conda
+  name: pandas
+  version: 2.2.2
+  build: py312h72972c8_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py312h72972c8_1.conda
+  sha256: f27b950c52cac5784b184a258c599cea81fcbfbd688897da799de4b6bf91af6e
+  md5: 92a5cf9f4778c6c9e02582d99885b34d
+  depends:
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
@@ -12041,63 +12491,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas
-  size: 14240940
-  timestamp: 1708709956543
-- kind: conda
-  name: pandas
-  version: 2.2.1
-  build: py312h83c8a23_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.1-py312h83c8a23_0.conda
-  sha256: ea83713caaa07c33c9530bc7469bec0b73fdd24ffee286cc6f3d26b1aa89f397
-  md5: c562e07382cdc3194c21b8eca06460ff
-  depends:
-  - libcxx >=16
-  - numpy >=1.26.4,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.12.* *_cp312
-  - pytz >=2020.1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pandas
-  size: 14549245
-  timestamp: 1708710128393
-- kind: conda
-  name: pandas
-  version: 2.2.1
-  build: py312hfb8ada1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py312hfb8ada1_0.conda
-  sha256: 148e4f38f2ed6525171f3c779e970a999f5bc78ddb9a9d300847d73bbd742c33
-  md5: e8fcd9179004edd4fb1bcd888d0aeb47
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.26.4,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.12.* *_cp312
-  - pytz >=2020.1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/pandas
-  size: 15435322
-  timestamp: 1708709375175
+  - pkg:pypi/pandas?source=conda-forge-mapping
+  size: 14181121
+  timestamp: 1715899159343
 - kind: conda
   name: pandas-stubs
-  version: 2.2.1.240316
+  version: 2.2.2.240603
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.1.240316-pyhd8ed1ab_0.conda
-  sha256: 34883e8d436a37858a88d7a756b35142d63d042c8b416b6ad83278cbce7abe3e
-  md5: 309fb20ff5d681cb3c783cc0c800d770
+  url: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.2.240603-pyhd8ed1ab_0.conda
+  sha256: f22e5bb371fac515c4a53d49fe4d7fcddc71136e5ed3094fde0f37dfc249d244
+  md5: 2ffa854e866926e8e6a76274b9aca854
   depends:
   - numpy >=1.26.0
   - python >=3.9
@@ -12105,35 +12510,35 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas-stubs
-  size: 98146
-  timestamp: 1710768532899
+  - pkg:pypi/pandas-stubs?source=conda-forge-mapping
+  size: 97949
+  timestamp: 1717510726829
 - kind: conda
   name: pandera
-  version: 0.18.3
+  version: 0.20.3
   build: hd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pandera-0.18.3-hd8ed1ab_0.conda
-  sha256: 80daf30527d62c5694a89ae551be4aff40d7a82c9d25b73ea6b6e24309a5a50d
-  md5: a8e2857c67ded4b6d0ab6fabbb9ec065
+  url: https://conda.anaconda.org/conda-forge/noarch/pandera-0.20.3-hd8ed1ab_0.conda
+  sha256: d8f6c4b2e82ea9f3a0ee24080e38cae8c46fccf9c1751b005a10d31b7dcc7873
+  md5: c5dccdafb966b0a4a156cba0168379c7
   depends:
-  - pandera-base >=0.18.3,<0.18.4.0a0
+  - pandera-base >=0.20.3,<0.20.4.0a0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/pandera?source=conda-forge-mapping
-  size: 6858
-  timestamp: 1710200385758
+  size: 6805
+  timestamp: 1721327041967
 - kind: conda
   name: pandera-base
-  version: 0.18.3
+  version: 0.20.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.18.3-pyhd8ed1ab_0.conda
-  sha256: 00b0994260df53f85077e478ba6dbdbc227f62c4e077ec6a7906722e91df223f
-  md5: e96ee36cbebac49688a927b3b74c38ed
+  url: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.20.3-pyhd8ed1ab_0.conda
+  sha256: 319948578d3c73411ce3dd63b3b497a38b2e8c0e5559ac6cf75db0ac5a24ee4e
+  md5: 736acd845c4fe83600fc44358e62100b
   depends:
   - multimethod <=1.10.0
   - numpy >=1.19.0
@@ -12147,48 +12552,48 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pandera
-  size: 128349
-  timestamp: 1710200381463
+  - pkg:pypi/pandera?source=conda-forge-mapping
+  size: 148324
+  timestamp: 1721327037113
 - kind: conda
   name: pandoc
-  version: 3.1.11.1
+  version: 3.1.12.3
   build: h57928b3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.11.1-h57928b3_0.conda
-  sha256: 84cbba7f556b173c84cb3aba6a43ff088dd4808d529a598e5fd124dca710bc1b
-  md5: 81747ed06ea58a00b41ea15bf6e1fe30
+  url: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.12.3-h57928b3_0.conda
+  sha256: 0c36e2a3d53d9db8d6270b57548e90017edb6be09708910783143cf560f48ec7
+  md5: fb5e84d5b27eb70305880095e2dbf9d3
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 24254504
-  timestamp: 1707474734217
+  size: 24893042
+  timestamp: 1710767473433
 - kind: conda
   name: pandoc
-  version: 3.1.11.1
+  version: 3.1.12.3
   build: h694c41f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.11.1-h694c41f_0.conda
-  sha256: 3adbae2ba5d78c45c9ec9d802b820c2e659129b7ba044cc76487ce33dbc800f2
-  md5: 6cff44b16d1231fe9682c64d12ab66a5
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.12.3-h694c41f_0.conda
+  sha256: a1b36cfe362fd70ebb2ce7afa0ba6e5ccadfbb6a805bc0132f1642f151af080e
+  md5: dbd54d0b1e33c2c2713ca41fb32c51f6
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 13738785
-  timestamp: 1707474535801
+  size: 14050252
+  timestamp: 1710767029911
 - kind: conda
   name: pandoc
-  version: 3.1.11.1
+  version: 3.1.12.3
   build: ha770c72_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.11.1-ha770c72_0.conda
-  sha256: 30b1318dbf7a89d4b2f66a9b10c8799376a32506043a510e1d27ba286c564633
-  md5: 0e2f14aff42adf4675bcd5335d644a5f
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.12.3-ha770c72_0.conda
+  sha256: 26bfcda675fbddd059a8861dc75b9e497980ec6c679ec2a27e7d74042c4b295b
+  md5: cdea66892b19a454f939487318b6c517
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 20502973
-  timestamp: 1707474170203
+  size: 21002590
+  timestamp: 1710766932698
 - kind: conda
   name: pandocfilters
   version: 1.5.0
@@ -12203,7 +12608,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandocfilters
+  - pkg:pypi/pandocfilters?source=conda-forge-mapping
   size: 11627
   timestamp: 1631603397334
 - kind: conda
@@ -12220,61 +12625,62 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/parso
+  - pkg:pypi/parso?source=conda-forge-mapping
   size: 75191
   timestamp: 1712320447201
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: h0ad2156_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
-  sha256: 226714bbf89d45bf7da4c7551e21b8a833f51d33379fe3dfbfe31b72832d4dba
-  md5: 9c8651803886ce9d5983e107a0df4ea8
+  version: '10.44'
+  build: h0f59acf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.44-h0f59acf_0.conda
+  sha256: 90646ad0d8f9d0fd896170c4f3d754e88c4ba0eaf856c24d00842016f644baab
+  md5: 3914f7ac1761dce57102c72ca7c35d01
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 836581
-  timestamp: 1708118455741
+  size: 955778
+  timestamp: 1718466128333
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: h17e33f8_0
+  version: '10.44'
+  build: h3d7b363_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
-  sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
-  md5: d0485b8aa2cedb141a7bd27b4efa4c9c
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.44-h3d7b363_0.conda
+  sha256: 44351611091ed72c4682ad23e53d7874334757298ff0ebb2acd769359ae82ab3
+  md5: 007d07ab5027e0bf49f6fa660a9f89a0
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 818317
-  timestamp: 1708118868321
+  size: 816867
+  timestamp: 1718466930248
 - kind: conda
   name: pcre2
-  version: '10.43'
-  build: hcad00b1_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
-  sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
-  md5: 8292dea9e022d9610a11fce5e0896ed8
+  version: '10.44'
+  build: h7634a1b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.44-h7634a1b_0.conda
+  sha256: b397f92ef7d561f817c5336295d6696c72d2576328baceb9dc51bfc772bcb48e
+  md5: b8f63aec37f31ffddac6dfdc0b31a73e
   depends:
+  - __osx >=10.13
   - bzip2 >=1.0.8,<2.0a0
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 950847
-  timestamp: 1708118050286
+  size: 858178
+  timestamp: 1718466163292
 - kind: conda
   name: pexpect
   version: 4.9.0
@@ -12289,7 +12695,7 @@ packages:
   - python >=3.7
   license: ISC
   purls:
-  - pkg:pypi/pexpect
+  - pkg:pypi/pexpect?source=conda-forge-mapping
   size: 53600
   timestamp: 1706113273252
 - kind: conda
@@ -12307,50 +12713,51 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pickleshare
+  - pkg:pypi/pickleshare?source=conda-forge-mapping
   size: 9332
   timestamp: 1602536313357
 - kind: conda
   name: pillow
-  version: 10.3.0
-  build: py312h0c923fa_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py312h0c923fa_0.conda
-  sha256: 3e33ce8ba364948eeeeb06da435059b1ed0e6cfb2b1195931b76e190ee671310
-  md5: 6f0591ae972e9b815739da3392fbb3c3
+  version: 10.4.0
+  build: py312h287a98d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.4.0-py312h287a98d_0.conda
+  sha256: f3bca9472702f32bf85196efbf013e9dabe130776e76c7f81062f18682f33a05
+  md5: 59ea71eed98aee0bebbbdd3b118167c7
   depends:
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
+  - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow
-  size: 42531277
-  timestamp: 1712154782302
+  - pkg:pypi/pillow?source=conda-forge-mapping
+  size: 42068301
+  timestamp: 1719903698022
 - kind: conda
   name: pillow
-  version: 10.3.0
-  build: py312h6f6a607_0
+  version: 10.4.0
+  build: py312h381445a_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py312h6f6a607_0.conda
-  sha256: f1621c28346609886ccce14b6ae0069b5cb34925ace73e05a8c06770d2ad7a19
-  md5: 8d5f5f1fa36200f1ef987299a47de403
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py312h381445a_0.conda
+  sha256: 2c76c1ded20c5199d134ccecab596412510a016218f342914fd85384a850e7ed
+  md5: cc1e714c3cc43c59d9d0efa228c16364
   depends:
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -12360,35 +12767,35 @@ packages:
   - vc14_runtime >=14.29.30139
   license: HPND
   purls:
-  - pkg:pypi/pillow
-  size: 42439434
-  timestamp: 1712155248737
+  - pkg:pypi/pillow?source=conda-forge-mapping
+  size: 42560613
+  timestamp: 1719904152461
 - kind: conda
   name: pillow
-  version: 10.3.0
-  build: py312hdcec9eb_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py312hdcec9eb_0.conda
-  sha256: a7fdcc1e56b66d95622bad073cc8d347cc180988040419754abb2a4ed7b29471
-  md5: 425bb325f970e57a047ac57c4586489d
+  version: 10.4.0
+  build: py312hbd70edc_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.4.0-py312hbd70edc_0.conda
+  sha256: 38b6e8c63c8ebfd9c8552312cecd385ec7bfad6e5733f5c6b6df0db801ea5f43
+  md5: 8d55e92fa6380ac8c245f253b096fefd
   depends:
+  - __osx >=10.13
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
-  - libgcc-ng >=12
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow
-  size: 41991755
-  timestamp: 1712154634705
+  - pkg:pypi/pillow?source=conda-forge-mapping
+  size: 42081826
+  timestamp: 1719903909255
 - kind: conda
   name: pip
   version: '24.0'
@@ -12405,7 +12812,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pip
+  - pkg:pypi/pip?source=conda-forge-mapping
   size: 1398245
   timestamp: 1706960660581
 - kind: conda
@@ -12470,52 +12877,52 @@ packages:
   - python >=3.6
   license: MIT AND PSF-2.0
   purls:
-  - pkg:pypi/pkgutil-resolve-name
+  - pkg:pypi/pkgutil-resolve-name?source=conda-forge-mapping
   size: 10778
   timestamp: 1694617398467
 - kind: conda
   name: platformdirs
-  version: 4.2.0
+  version: 4.2.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-  sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
-  md5: a0bc3eec34b0fab84be6b2da94e98e20
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.2-pyhd8ed1ab_0.conda
+  sha256: adc59384cf0b2fc6dc7362840151e8cb076349197a38f7230278252698a88442
+  md5: 6f6cf28bf8e021933869bae3f84b8fc9
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/platformdirs
-  size: 20210
-  timestamp: 1706713564353
+  - pkg:pypi/platformdirs?source=conda-forge-mapping
+  size: 20572
+  timestamp: 1715777739019
 - kind: conda
   name: pluggy
-  version: 1.4.0
+  version: 1.5.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.4.0-pyhd8ed1ab_0.conda
-  sha256: 6edfd2c41938ea772096c674809bfcf2ebb9bef7e82de6c7ea0b966b86bfb4d0
-  md5: 139e9feb65187e916162917bb2484976
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
+  sha256: 33eaa3359948a260ebccf9cdc2fd862cea5a6029783289e13602d8e634cd9a26
+  md5: d3483c8fc2dc2cc3f5cf43e26d60cabf
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pluggy
-  size: 23384
-  timestamp: 1706116931972
+  - pkg:pypi/pluggy?source=conda-forge-mapping
+  size: 23815
+  timestamp: 1713667175451
 - kind: conda
   name: plum-dispatch
-  version: 2.3.3
+  version: 2.5.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.3.3-pyhd8ed1ab_0.conda
-  sha256: 74d8645a6f8d343cc146e2b75ab20004840fd14cdbc0fa9076f12cff157efffe
-  md5: fadd4630a6ead3313bf0c8f1d4cf4a32
+  url: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
+  sha256: 164be5a53d1ed46f3465f805588dec1b23e5e9a2f2f68f2a8b5297917b1ef68e
+  md5: f8d38e43e2b367976d7135e602b5c9b6
   depends:
   - beartype >=0.12
   - python >=3.8
@@ -12523,9 +12930,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/plum-dispatch
-  size: 35889
-  timestamp: 1711401439271
+  - pkg:pypi/plum-dispatch?source=conda-forge-mapping
+  size: 39993
+  timestamp: 1721234810330
 - kind: conda
   name: ply
   version: '3.11'
@@ -12541,92 +12948,29 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ply
+  - pkg:pypi/ply?source=conda-forge-mapping
   size: 49196
   timestamp: 1712243121626
 - kind: conda
   name: poppler
-  version: 24.03.0
-  build: h0c752f9_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.03.0-h0c752f9_0.conda
-  sha256: 05c0e43fda42be7745a68681511125ee244f465a9515fe6d4b564a224ca3b46b
-  md5: 6b55d989edec2e1ea71236ca4cdd4960
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - gettext >=0.21.1,<1.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=16
-  - libglib >=2.78.4,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - poppler-data
-  license: GPL-2.0-only
-  license_family: GPL
-  purls: []
-  size: 1569576
-  timestamp: 1710150922930
-- kind: conda
-  name: poppler
-  version: 24.03.0
-  build: h590f24d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.03.0-h590f24d_0.conda
-  sha256: 0ea3e63ae3ba07bcae8cc541647c647c68aeec32dfbe3bbaeecc845833b27a6f
-  md5: c688853df9dcfed47200d0e28e5dfe11
-  depends:
-  - cairo >=1.18.0,<2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.16,<3.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.4,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - openjpeg >=2.5.2,<3.0a0
-  - poppler-data
-  license: GPL-2.0-only
-  license_family: GPL
-  purls: []
-  size: 1846447
-  timestamp: 1710150513789
-- kind: conda
-  name: poppler
-  version: 24.03.0
-  build: hc2f3c52_0
+  version: 24.07.0
+  build: h686f694_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/poppler-24.03.0-hc2f3c52_0.conda
-  sha256: e3d51588c6c97c0fa03c905049d5b9af139faad8e40545d809af44eef0a43f16
-  md5: 76d65f5a02e1ed1d914d8b7368e1a59e
+  url: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
+  sha256: c22de4784acad150c56c0064ba383abd80b097eeb0c192461efec8e572599a2c
+  md5: 4e21d8257375ae401877013416ebc12b
   depends:
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libglib >=2.78.4,<3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libpng >=1.6.43,<1.7.0a0
   - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - poppler-data
   - ucrt >=10.0.20348.0
@@ -12635,8 +12979,74 @@ packages:
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 2315178
-  timestamp: 1710151582969
+  size: 2374174
+  timestamp: 1720374177748
+- kind: conda
+  name: poppler
+  version: 24.07.0
+  build: h744cbf2_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.07.0-h744cbf2_0.conda
+  sha256: 012c492087fdcc10a97fab28f3e105ca995bc796f72f0744b1cd050ca35828e5
+  md5: 1603ef5fcf8bffffc3451ca182b6df0a
+  depends:
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.102,<4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  size: 1586876
+  timestamp: 1720373241748
+- kind: conda
+  name: poppler
+  version: 24.07.0
+  build: hb0d391f_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
+  sha256: 20ddd62419f3ddf779dfaae7d12001b0e63e365f781b1137f6db0b428193a3cb
+  md5: 561842bc59112340fa1f5f1ed06ae4a2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.0,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.102,<4.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - poppler-data
+  license: GPL-2.0-only
+  license_family: GPL
+  purls: []
+  size: 1906317
+  timestamp: 1720373278987
 - kind: conda
   name: poppler-data
   version: 0.4.12
@@ -12653,80 +13063,78 @@ packages:
   timestamp: 1675353652214
 - kind: conda
   name: postgresql
-  version: '16.2'
-  build: h06f2bd8_1
-  build_number: 1
+  version: '16.3'
+  build: h1d90168_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.2-h06f2bd8_1.conda
-  sha256: 2a96af8385c51e97950ed00d802186069bf4933b3be111956508ab6be158d463
-  md5: fe36c4a9254176dde4ca696016c50aa8
+  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.3-h1d90168_0.conda
+  sha256: 69a0887d23f51bc7e35097bf03f88d2ff14e88cc578c3f8296a178c8378950ec
+  md5: a7ccb9b98d8e3ef61c0ca6d470e8e66d
   depends:
+  - __osx >=10.13
   - krb5 >=1.21.2,<1.22.0a0
-  - libpq 16.2 ha925e61_1
+  - libpq 16.3 h4501773_0
   - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
   - readline >=8.2,<9.0a0
   - tzcode
   - tzdata
   license: PostgreSQL
   purls: []
-  size: 4627906
-  timestamp: 1710864850772
+  size: 4612922
+  timestamp: 1715267536439
 - kind: conda
   name: postgresql
-  version: '16.2'
-  build: h82ecc9d_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h82ecc9d_1.conda
-  sha256: 7fc52e69478973f173f055ade6c4087564362be9172c294b493a79671fef9a7e
-  md5: 7a5806219d0f77ce8393375d040df065
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libpq 16.2 h33b98f1_1
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tzcode
-  - tzdata
-  license: PostgreSQL
-  purls: []
-  size: 5308675
-  timestamp: 1710863687299
-- kind: conda
-  name: postgresql
-  version: '16.2'
-  build: h94c9ec1_1
-  build_number: 1
+  version: '16.3'
+  build: h7f155c9_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.2-h94c9ec1_1.conda
-  sha256: 35d632652bc965e5f7b6b4f9f8a36c6c399d1defc2e4f68841f42d5b9a51ee70
-  md5: c76ba206e82b0d0dbfc9d6d48b80053b
+  url: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.3-h7f155c9_0.conda
+  sha256: 7cd34a8803a3687f6fbed5908dd9b2ecb0ff923a1ac7c4d602d0f06a5804edbd
+  md5: a253c97c94a2c2886e1cb79e34a5b641
   depends:
   - krb5 >=1.21.2,<1.22.0a0
-  - libpq 16.2 hdb24f17_1
+  - libpq 16.3 hab9416b_0
   - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: PostgreSQL
   purls: []
-  size: 18712345
-  timestamp: 1710864543420
+  size: 18697452
+  timestamp: 1715267263356
+- kind: conda
+  name: postgresql
+  version: '16.3'
+  build: h8e811e2_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.3-h8e811e2_0.conda
+  sha256: 4cd39edd84011657978e35abdc880cf3e49785e8a86f1c99a34029a3e4998abe
+  md5: e4d52462da124ed3792472f95a36fc2a
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libpq 16.3 ha72fbe1_0
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tzcode
+  - tzdata
+  license: PostgreSQL
+  purls: []
+  size: 5332852
+  timestamp: 1715266435060
 - kind: conda
   name: pre-commit
-  version: 3.7.0
+  version: 3.7.1
   build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.0-pyha770c72_0.conda
-  sha256: b7a1d56fb1374df77019521bbcbe109ff17337181c4d392918e5ec1a10a9df87
-  md5: 846ba0877cda9c4f11e13720cacd1968
+  url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.7.1-pyha770c72_0.conda
+  sha256: 689c169ce6ed5d516d8524cc1e6ef2687dff19747c1ed1ee9b347a71f47ff12d
+  md5: 724bc4489c1174fc8e3233b0624fa51f
   depends:
   - cfgv >=2.0.0
   - identify >=1.0.0
@@ -12737,21 +13145,21 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pre-commit
-  size: 180574
-  timestamp: 1711480432386
+  - pkg:pypi/pre-commit?source=conda-forge-mapping
+  size: 179748
+  timestamp: 1715432871404
 - kind: conda
   name: proj
-  version: 9.3.1
-  build: h1d62c97_0
+  version: 9.4.1
+  build: hb784bbd_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.3.1-h1d62c97_0.conda
-  sha256: 234f8f7b255dc9036812ec30d097c0725047f3fc7e8e0bc7944e4e17d242ab99
-  md5: 44ec51d0857d9be26158bb85caa74fdb
+  url: https://conda.anaconda.org/conda-forge/linux-64/proj-9.4.1-hb784bbd_0.conda
+  sha256: ec9d16725925c62a7974faa396ca61878cb4cc7398c6c0e76d3ae28cffafc7db
+  md5: c38c5246d064ef16eba065d93c46f1c6
   depends:
-  - libcurl >=8.4.0,<9.0a0
+  - libcurl >=8.8.0,<9.0a0
   - libgcc-ng >=12
-  - libsqlite >=3.44.2,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libstdcxx-ng >=12
   - libtiff >=4.6.0,<4.7.0a0
   - sqlite
@@ -12760,41 +13168,19 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 3004737
-  timestamp: 1701484763294
+  size: 3048862
+  timestamp: 1718272927953
 - kind: conda
   name: proj
-  version: 9.3.1
-  build: h81faed2_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.3.1-h81faed2_0.conda
-  sha256: 51bc021e25c88a12151d6ab4d3e956e72ea21d2684315f6ea99ee699aaefc1ea
-  md5: 3940ef505861767d26659645f9ec0460
-  depends:
-  - __osx >=10.9
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libsqlite >=3.44.2,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - sqlite
-  constrains:
-  - proj4 ==999999999999
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 2713966
-  timestamp: 1701485089266
-- kind: conda
-  name: proj
-  version: 9.3.1
-  build: he13c7e8_0
+  version: 9.4.1
+  build: hd9569ee_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/proj-9.3.1-he13c7e8_0.conda
-  sha256: bcf34f3610e2c34a74fccf76e47e0fd41d36afd8fc043920fef0ab34230bcd01
-  md5: 57aa204e187d515bb2600bc74a7e7dfc
+  url: https://conda.anaconda.org/conda-forge/win-64/proj-9.4.1-hd9569ee_0.conda
+  sha256: 6ebc0dc14e3057c859c09702149ddc0d301cbfb0e1c7553b617b194e0b0cabfb
+  md5: 123d005359753b6f1f7cae5dab367826
   depends:
-  - libcurl >=8.4.0,<9.0a0
-  - libsqlite >=3.44.2,<4.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
   - sqlite
   - ucrt >=10.0.20348.0
@@ -12805,8 +13191,30 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 2663958
-  timestamp: 1701485332654
+  size: 2700952
+  timestamp: 1718273646988
+- kind: conda
+  name: proj
+  version: 9.4.1
+  build: hf92c781_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/proj-9.4.1-hf92c781_0.conda
+  sha256: c047c55cb2e239d35d7f28fc50225d5798be37af1e84d9036966447c82b373f5
+  md5: b128ccdae180135720ab963c68bc2f1a
+  depends:
+  - __osx >=10.13
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  - libsqlite >=3.46.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2800404
+  timestamp: 1718273429868
 - kind: conda
   name: prometheus_client
   version: 0.20.0
@@ -12821,72 +13229,37 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/prometheus-client
+  - pkg:pypi/prometheus-client?source=conda-forge-mapping
   size: 48913
   timestamp: 1707932844383
 - kind: conda
   name: prompt-toolkit
-  version: 3.0.42
+  version: 3.0.47
   build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-  sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
-  md5: 0bf64bf10eee21f46ac83c161917fa86
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.47-pyha770c72_0.conda
+  sha256: d93ac5853e398aaa10f0dd7addd64b411f94ace1f9104d619cd250e19a5ac5b4
+  md5: 1247c861065d227781231950e14fe817
   depends:
   - python >=3.7
   - wcwidth
   constrains:
-  - prompt_toolkit 3.0.42
+  - prompt_toolkit 3.0.47
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/prompt-toolkit
-  size: 270398
-  timestamp: 1702399557137
+  - pkg:pypi/prompt-toolkit?source=conda-forge-mapping
+  size: 270710
+  timestamp: 1718048095491
 - kind: conda
   name: psutil
-  version: 5.9.8
-  build: py312h41838bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.8-py312h41838bb_0.conda
-  sha256: 12e5053d19bddaf7841e59cbe9ba98fa5d4d8502ceccddad80888515e1366107
-  md5: 03926e7089a5e61b77043b470ae7b553
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil
-  size: 495162
-  timestamp: 1705722685887
-- kind: conda
-  name: psutil
-  version: 5.9.8
-  build: py312h98912ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py312h98912ed_0.conda
-  sha256: 27e7f8f5d30c74439f39d61e21ac14c0cd03b5d55f7bf9f946fb619016f73c61
-  md5: 3facaca6cc0f7988df3250efccd32da3
-  depends:
-  - libgcc-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil
-  size: 486243
-  timestamp: 1705722547420
-- kind: conda
-  name: psutil
-  version: 5.9.8
-  build: py312he70551f_0
+  version: 6.0.0
+  build: py312h4389bb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.8-py312he70551f_0.conda
-  sha256: 36f8addb327f80da4d6bd421170ff4cf8fb570d9ee8df39372427a4e33298dca
-  md5: 5f2998851564bea33a159bd00e6249e8
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-6.0.0-py312h4389bb4_0.conda
+  sha256: c9ed9457fa4c4900b7f2fc5e28493bdd3885acb823ed48c01dae59f043a65ad8
+  md5: 86fd428b42be7495c93d0ff837adfc9e
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -12896,9 +13269,45 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/psutil
-  size: 503677
-  timestamp: 1705722843679
+  - pkg:pypi/psutil?source=conda-forge-mapping
+  size: 509298
+  timestamp: 1719275243368
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312h9a8786e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-6.0.0-py312h9a8786e_0.conda
+  sha256: d629363515df957507411fd24db2a0635ac893e5d60b2ee2f656b53be9c70b1d
+  md5: 1aeffa86c55972ca4e88ac843eccedf2
+  depends:
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=conda-forge-mapping
+  size: 493452
+  timestamp: 1719274737481
+- kind: conda
+  name: psutil
+  version: 6.0.0
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-6.0.0-py312hbd25219_0.conda
+  sha256: 06e949079497cf8e1c9e253b77be709ec0c11816656814e1ad857ac5cbbea65b
+  md5: db086d71e9be086313110a670b6d549f
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=conda-forge-mapping
+  size: 499307
+  timestamp: 1719274858092
 - kind: conda
   name: pthread-stubs
   version: '0.4'
@@ -12973,7 +13382,7 @@ packages:
   - python
   license: ISC
   purls:
-  - pkg:pypi/ptyprocess
+  - pkg:pypi/ptyprocess?source=conda-forge-mapping
   size: 16546
   timestamp: 1609419417991
 - kind: conda
@@ -12999,114 +13408,170 @@ packages:
   timestamp: 1705690081905
 - kind: conda
   name: pure_eval
-  version: 0.2.2
+  version: 0.2.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-  md5: 6784285c7e55cb7212efabc79e4c2883
+  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_0.conda
+  sha256: dcfcb3cee1ae0a89729601582cc3edea20ba13c9493967a03a693c67567af0c8
+  md5: 0f051f09d992e0d08941706ad519ee0e
   depends:
   - python >=3.5
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pure-eval
-  size: 14551
-  timestamp: 1642876055775
+  - pkg:pypi/pure-eval?source=conda-forge-mapping
+  size: 16551
+  timestamp: 1721585805256
 - kind: conda
   name: pyarrow
-  version: 15.0.2
-  build: py312h176e3d2_1_cpu
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.2-py312h176e3d2_1_cpu.conda
-  sha256: b1e6c813d5bb2fee372a8622f85219f97392b2cd684777aa4f782ec34f0f7e98
-  md5: e5340d2a8d88003d053b49e852459a4c
+  version: 17.0.0
+  build: py312h0be7463_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-17.0.0-py312h0be7463_0.conda
+  sha256: 40db7bebb0cf98fefc55090824f1dd9c09712b212fb5ad63ed1cbd987559e071
+  md5: 7fc42831758e18d56726d3b311ab4f01
   depends:
-  - libarrow 15.0.2 hb86450c_1_cpu
-  - libarrow-acero 15.0.2 h59595ed_1_cpu
-  - libarrow-dataset 15.0.2 h59595ed_1_cpu
-  - libarrow-flight 15.0.2 hc6145d9_1_cpu
-  - libarrow-flight-sql 15.0.2 h757c851_1_cpu
-  - libarrow-gandiva 15.0.2 hb016d2e_1_cpu
-  - libarrow-substrait 15.0.2 h757c851_1_cpu
-  - libgcc-ng >=12
-  - libparquet 15.0.2 h352af49_1_cpu
-  - libstdcxx-ng >=12
-  - numpy >=1.26.4,<2.0a0
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_0_*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pyarrow?source=conda-forge-mapping
+  size: 26064
+  timestamp: 1721675191430
+- kind: conda
+  name: pyarrow
+  version: 17.0.0
+  build: py312h7e22eef_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-17.0.0-py312h7e22eef_0.conda
+  sha256: 34cc9c03bc5e8de7b3da6dcd3f06c92b6e9623b331af4fff0316ca426c7473ca
+  md5: 12bd36a96ef5a821cbb4c0deb73ec2ba
+  depends:
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_0_*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pyarrow?source=conda-forge-mapping
+  size: 26403
+  timestamp: 1721676431512
+- kind: conda
+  name: pyarrow
+  version: 17.0.0
+  build: py312h9cebb41_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-17.0.0-py312h9cebb41_0.conda
+  sha256: dad58bd56bafefbe38fed46aa43bbd3b5e1ae4fb55ec634ad1f34cbab2361199
+  md5: 2ae7d9f1d04309e421b5feb4ab8bede5
+  depends:
+  - libarrow-acero 17.0.0.*
+  - libarrow-dataset 17.0.0.*
+  - libarrow-substrait 17.0.0.*
+  - libparquet 17.0.0.*
+  - numpy >=1.19,<3
+  - pyarrow-core 17.0.0 *_0_*
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pyarrow?source=conda-forge-mapping
+  size: 25920
+  timestamp: 1721675204274
+- kind: conda
+  name: pyarrow-core
+  version: 17.0.0
+  build: py312h12b3929_0_cpu
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-17.0.0-py312h12b3929_0_cpu.conda
+  sha256: 6c1294e69b2769710f6b4f863bf390cdf4270b87e8444fa33ffb834e3d08a032
+  md5: d7966df22032e4b6f422f21c03467049
+  depends:
+  - __osx >=10.13
+  - libarrow 17.0.0.* *cpu
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
+  - orc >=2.0.1
+  - apache-arrow-proc =*=cpu
+  - aws-crt-cpp >=0.26.12
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pyarrow?source=conda-forge-mapping
+  size: 4093493
+  timestamp: 1721675141155
+- kind: conda
+  name: pyarrow-core
+  version: 17.0.0
+  build: py312h264c024_0_cpu
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-17.0.0-py312h264c024_0_cpu.conda
+  sha256: dad414493665716badddd57b88f6a3c88f7b7fb61d4d08135e24089ad53e412c
+  md5: 5b70c592fec73f73770efac74217ebc1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libarrow 17.0.0.* *cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - aws-crt-cpp >=0.26.12
+  - orc >=2.0.1
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/pyarrow
-  size: 4513384
-  timestamp: 1711179296429
+  - pkg:pypi/pyarrow?source=conda-forge-mapping
+  size: 4625528
+  timestamp: 1721674983925
 - kind: conda
-  name: pyarrow
-  version: 15.0.2
-  build: py312h85e32bb_1_cpu
-  build_number: 1
+  name: pyarrow-core
+  version: 17.0.0
+  build: py312h3529c54_0_cpu
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.2-py312h85e32bb_1_cpu.conda
-  sha256: c50e4f26039ff880c38f72ba8454ccec62be4825cb78244424b552eef1d1ed1b
-  md5: 20a1bf6c88b1494acc2245e9d92f427b
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-17.0.0-py312h3529c54_0_cpu.conda
+  sha256: a14ee1d3857b799f55971d60dabfaef59fbc76ba3504e2b631d7b2389132fb57
+  md5: 04251f5725d74c74c79201fadc8e93b2
   depends:
-  - libarrow 15.0.2 h878f99b_1_cpu
-  - libarrow-acero 15.0.2 h63175ca_1_cpu
-  - libarrow-dataset 15.0.2 h63175ca_1_cpu
-  - libarrow-flight 15.0.2 h02312f3_1_cpu
-  - libarrow-flight-sql 15.0.2 h55b4db4_1_cpu
-  - libarrow-gandiva 15.0.2 h3f2ff47_1_cpu
-  - libarrow-substrait 15.0.2 h89268de_1_cpu
-  - libparquet 15.0.2 h7ec3a38_1_cpu
-  - numpy >=1.26.4,<2.0a0
+  - libarrow 17.0.0.* *cpu
+  - libzlib >=1.3.1,<2.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
+  - orc >=2.0.1
   - apache-arrow-proc =*=cpu
+  - aws-crt-cpp >=0.26.12
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/pyarrow
-  size: 3450655
-  timestamp: 1711183473119
-- kind: conda
-  name: pyarrow
-  version: 15.0.2
-  build: py312hc4c33ac_1_cpu
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.2-py312hc4c33ac_1_cpu.conda
-  sha256: 43c182aaadacb631b754ffef56a89cd8bf2be5afdc98c05c07223919b91e493e
-  md5: 31a48943b65f497d47afa9ba20f1ed08
-  depends:
-  - libarrow 15.0.2 h8d4fe2c_1_cpu
-  - libarrow-acero 15.0.2 hd427752_1_cpu
-  - libarrow-dataset 15.0.2 hd427752_1_cpu
-  - libarrow-flight 15.0.2 h39e3226_1_cpu
-  - libarrow-flight-sql 15.0.2 h1a3ed6a_1_cpu
-  - libarrow-gandiva 15.0.2 h43798cf_1_cpu
-  - libarrow-substrait 15.0.2 h1a3ed6a_1_cpu
-  - libcxx >=16
-  - libparquet 15.0.2 h089a9f7_1_cpu
-  - numpy >=1.26.4,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - apache-arrow-proc =*=cpu
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/pyarrow
-  size: 4004151
-  timestamp: 1711267736737
+  - pkg:pypi/pyarrow?source=conda-forge-mapping
+  size: 3528452
+  timestamp: 1721675697543
 - kind: conda
   name: pycparser
   version: '2.22'
@@ -13121,76 +13586,37 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pycparser
+  - pkg:pypi/pycparser?source=conda-forge-mapping
   size: 105098
   timestamp: 1711811634025
 - kind: conda
   name: pydantic
-  version: 2.6.4
+  version: 2.8.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.4-pyhd8ed1ab_0.conda
-  sha256: 9747044e91a607c175bbce67fdb5865de5373151098bbb4a2cd79bc05666a299
-  md5: 2e8e9f16431085f4b5a218b31fe557a3
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.8.2-pyhd8ed1ab_0.conda
+  sha256: 5a877153f7eaaab9724db5b64366a35e346007c9c104c1d6a6042f83b2f4f0df
+  md5: 539a038a24a959662df1fcaa2cfc5c3e
   depends:
   - annotated-types >=0.4.0
-  - pydantic-core 2.16.3
+  - pydantic-core 2.20.1
   - python >=3.7
   - typing-extensions >=4.6.1
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pydantic
-  size: 271508
-  timestamp: 1710622392396
+  - pkg:pypi/pydantic?source=conda-forge-mapping
+  size: 292538
+  timestamp: 1720293163725
 - kind: conda
   name: pydantic-core
-  version: 2.16.3
-  build: py312h1b0e595_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.16.3-py312h1b0e595_0.conda
-  sha256: 5445c03a37c01c36c4f1afa1947d573a58fb4b75d98619b198f51a410133a1fd
-  md5: de58d43f5fa908c07e2462c8401b9a7c
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing-extensions >=4.6.0,!=4.7.0
-  constrains:
-  - __osx >=10.12
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pydantic-core
-  size: 1571983
-  timestamp: 1708701626319
-- kind: conda
-  name: pydantic-core
-  version: 2.16.3
-  build: py312h4b3b743_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.3-py312h4b3b743_0.conda
-  sha256: 1a20fada51e2edd5019900b566a7140ab07e1fc687fbd12f6a5f344295846d93
-  md5: 891952a48cded31e909dac06a1e0311f
-  depends:
-  - libgcc-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing-extensions >=4.6.0,!=4.7.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pydantic-core
-  size: 1638828
-  timestamp: 1708701163582
-- kind: conda
-  name: pydantic-core
-  version: 2.16.3
-  build: py312hfccd98a_0
+  version: 2.20.1
+  build: py312h2615798_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.16.3-py312hfccd98a_0.conda
-  sha256: bdc8a0e2c280caaa6fa347d1ccc3427a9000d6351f3e95a0881fc577479ca97e
-  md5: de81a2ee8910c861b461edc12d7d7a41
+  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.20.1-py312h2615798_0.conda
+  sha256: 2dfe7ebca8de86e35e4231000936bcf14b56e6d9a3c09f4abc91ab090050c5ca
+  md5: bf5efeeab4b8c0259119a4281b5d3531
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -13201,35 +13627,79 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pydantic-core
-  size: 1617588
-  timestamp: 1708701919369
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
+  size: 1570939
+  timestamp: 1720042355599
+- kind: conda
+  name: pydantic-core
+  version: 2.20.1
+  build: py312ha47ea1c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.20.1-py312ha47ea1c_0.conda
+  sha256: d82efcb45a6958af050851f76544fd35a6968fc50f613a2b24dd3467fab7a8d7
+  md5: 8e095b6acd6405ea0da845d191302faf
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
+  size: 1529185
+  timestamp: 1720041729851
+- kind: conda
+  name: pydantic-core
+  version: 2.20.1
+  build: py312hf008fa9_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.20.1-py312hf008fa9_0.conda
+  sha256: adf117d3289c8dd97ffdb3076bc488217fedd02f3d96d35cc971f4de33460602
+  md5: 8cc8f335b7e355558854236d86b2bea4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.6.0,!=4.7.0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=conda-forge-mapping
+  size: 1612296
+  timestamp: 1720041586700
 - kind: conda
   name: pygments
-  version: 2.17.2
+  version: 2.18.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
-  md5: 140a7f159396547e9799aa98f9f0742e
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_0.conda
+  sha256: 78267adf4e76d0d64ea2ffab008c501156c108bb08fecb703816fb63e279780b
+  md5: b7f5c092b8f9800150d998a71b76d5a1
   depends:
-  - python >=3.7
+  - python >=3.8
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pygments
-  size: 860425
-  timestamp: 1700608076927
+  - pkg:pypi/pygments?source=conda-forge-mapping
+  size: 879295
+  timestamp: 1714846885370
 - kind: conda
   name: pyobjc-core
-  version: '10.2'
-  build: py312h74abf1d_0
+  version: 10.3.1
+  build: py312he77c50b_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.2-py312h74abf1d_0.conda
-  sha256: adc9590ed50322275a7e835377157c93e93fd457133ecb62d0ccb60cf2906340
-  md5: fc53fe067431dee92471aac39ed58128
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py312he77c50b_0.conda
+  sha256: d3f056d2fb9fb2838b79672b17f2b1305218c1e95fbf05f0b02ac1eca513082d
+  md5: fb6108445d2e14c5aa1f79fa97aab8ed
   depends:
+  - __osx >=10.13
   - libffi >=3.4,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -13237,89 +13707,87 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-core
-  size: 469732
-  timestamp: 1710591122760
+  - pkg:pypi/pyobjc-core?source=conda-forge-mapping
+  size: 496184
+  timestamp: 1718171987828
 - kind: conda
   name: pyobjc-framework-cocoa
-  version: '10.2'
-  build: py312h74abf1d_0
+  version: 10.3.1
+  build: py312he77c50b_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.2-py312h74abf1d_0.conda
-  sha256: 6a8b5be723f5c9188bfe3219e0448450775e2e0e798e6986e46605df4c875437
-  md5: b5fca135abb5b6d34afceb96c91e60fd
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py312he77c50b_0.conda
+  sha256: aa99ea58ad2f8ade894c11f5be2e9e28860efe527f0994532c84bef20eef249a
+  md5: 58a1af350ed69dd0d9e43c652c9b35b6
   depends:
+  - __osx >=10.13
   - libffi >=3.4,<4.0a0
-  - pyobjc-core 10.2.*
+  - pyobjc-core 10.3.1.*
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-framework-cocoa
-  size: 369208
-  timestamp: 1710597488587
+  - pkg:pypi/pyobjc-framework-cocoa?source=conda-forge-mapping
+  size: 375734
+  timestamp: 1718645660119
 - kind: conda
   name: pyogrio
-  version: 0.7.2
-  build: py312h3aaa50d_1
-  build_number: 1
+  version: 0.9.0
+  build: py312h43b3a95_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.7.2-py312h3aaa50d_1.conda
-  sha256: 89bc19507aa7dc6ed746862c2cd5d749c6e850d2c71f035f8fdadfee875bb82d
-  md5: 26912d0833a2004013a6baf59d83a218
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.9.0-py312h43b3a95_0.conda
+  sha256: 9dc89062437d698a1060644c96c9800bacb12370ddf416f75d2fda87afde5dea
+  md5: 1a22b21b82d6d134a06440dbaf46d1d7
   depends:
-  - __osx >=10.9
+  - __osx >=10.13
   - gdal
-  - libcxx >=16.0.6
-  - libgdal >=3.8.0,<3.9.0a0
-  - numpy >=1.26.0,<2.0a0
+  - libcxx >=16
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy
   - packaging
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyogrio
-  size: 597677
-  timestamp: 1700083590982
+  - pkg:pypi/pyogrio?source=conda-forge-mapping
+  size: 664241
+  timestamp: 1718696098770
 - kind: conda
   name: pyogrio
-  version: 0.7.2
-  build: py312h66d9856_1
-  build_number: 1
+  version: 0.9.0
+  build: py312h8ad7a51_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.7.2-py312h66d9856_1.conda
-  sha256: 6f956d6a6107169744ed3d1b1958cb3ec1f2b18659fcf69b44e45f3311ba8d64
-  md5: ca00256c57930bc4addd3e6649ce340c
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.9.0-py312h8ad7a51_0.conda
+  sha256: 4f2cc106c738be0076c11b487546bd448aa8fca7f19d2b0f54afd8fa2ee0b7d1
+  md5: f4d2803818632b2175fa58de7f653901
   depends:
   - gdal
   - libgcc-ng >=12
-  - libgdal >=3.8.0,<3.9.0a0
+  - libgdal >=3.9.0,<3.10.0a0
   - libstdcxx-ng >=12
-  - numpy >=1.26.0,<2.0a0
+  - numpy
   - packaging
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyogrio
-  size: 656792
-  timestamp: 1700083444209
+  - pkg:pypi/pyogrio?source=conda-forge-mapping
+  size: 734215
+  timestamp: 1718696048397
 - kind: conda
   name: pyogrio
-  version: 0.7.2
-  build: py312he3b4e22_1
-  build_number: 1
+  version: 0.9.0
+  build: py312hd215820_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.7.2-py312he3b4e22_1.conda
-  sha256: 634295877fe52c9822a16eed69e21b164752b9d29905b6c0b3bbce4e73097bad
-  md5: 5ce109a1361640104e8853978a56634a
+  url: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.9.0-py312hd215820_0.conda
+  sha256: 069f0782954c9000928f155c97965b51535eddee3feba87c2d86462056c50847
+  md5: 389c4ae48840c02e25aadcfd6def0673
   depends:
   - gdal
-  - libgdal >=3.8.0,<3.9.0a0
-  - numpy >=1.26.0,<2.0a0
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy
   - packaging
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -13329,9 +13797,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyogrio
-  size: 809000
-  timestamp: 1700084142163
+  - pkg:pypi/pyogrio?source=conda-forge-mapping
+  size: 887820
+  timestamp: 1718696645436
 - kind: conda
   name: pyparsing
   version: 3.1.2
@@ -13346,62 +13814,42 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyparsing
+  - pkg:pypi/pyparsing?source=conda-forge-mapping
   size: 89455
   timestamp: 1709721146886
 - kind: conda
   name: pyproj
   version: 3.6.1
-  build: py312h14d93e9_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py312h14d93e9_5.conda
-  sha256: f586f1ff7cf73e4610368ac7c3834a7b9229e7801c459107b55a6085e934d002
-  md5: 9e4bb17395dc13f270ce7f574b3b18b4
-  depends:
-  - certifi
-  - proj >=9.3.1,<9.3.2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/pyproj
-  size: 482212
-  timestamp: 1702028483675
-- kind: conda
-  name: pyproj
-  version: 3.6.1
-  build: py312h38f1c37_5
-  build_number: 5
+  build: py312h5d05ceb_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py312h38f1c37_5.conda
-  sha256: cecb339a20ed336e1d91c603852bcd061cad84a10ac5b23f88d6c8c177da4f2d
-  md5: 867baf2a7c5c6147e05ecc90f6c52a0c
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py312h5d05ceb_7.conda
+  sha256: 76a8d7c8ff3f0f9ea265622517c194a05084dca584e8eb1b38fe9ef74bde1b39
+  md5: b53ddc25da04839cc62b0b158a7ecb38
   depends:
   - certifi
   - libgcc-ng >=12
-  - proj >=9.3.1,<9.3.2.0a0
+  - proj >=9.4.0,<9.5.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyproj
-  size: 544962
-  timestamp: 1702028241932
+  - pkg:pypi/pyproj?source=conda-forge-mapping
+  size: 546159
+  timestamp: 1717792743003
 - kind: conda
   name: pyproj
   version: 3.6.1
-  build: py312hc725b1e_5
-  build_number: 5
+  build: py312h6f27134_7
+  build_number: 7
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py312hc725b1e_5.conda
-  sha256: 5613805eed4a13a2d3c47c500bfedfd55a923bede9b5f558ca12ddbfbe62b7f6
-  md5: 03b58ca2e2652462e83db38e241a352d
+  url: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py312h6f27134_7.conda
+  sha256: 0d3b70d5a69390ff04a43a873eb34ba2c76cc1fe60efbbdddd71f1e7cfdf9306
+  md5: 55b89ad7727e92bd948e9d77b5adf6cc
   depends:
   - certifi
-  - proj >=9.3.1,<9.3.2.0a0
+  - proj >=9.4.0,<9.5.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
@@ -13410,9 +13858,30 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyproj
-  size: 723069
-  timestamp: 1702028616503
+  - pkg:pypi/pyproj?source=conda-forge-mapping
+  size: 733067
+  timestamp: 1717793181003
+- kind: conda
+  name: pyproj
+  version: 3.6.1
+  build: py312ha320102_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py312ha320102_7.conda
+  sha256: 4c70d5ec5bed9a4eec1160f64de93d70a44bd3c7c0a2533756148dec5ce12197
+  md5: 42173e3a4efa0af22a562c59a12781f1
+  depends:
+  - __osx >=10.13
+  - certifi
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyproj?source=conda-forge-mapping
+  size: 482966
+  timestamp: 1717792747463
 - kind: conda
   name: pyqt
   version: 5.15.9
@@ -13433,7 +13902,7 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls:
-  - pkg:pypi/pyqt5
+  - pkg:pypi/pyqt5?source=conda-forge-mapping
   size: 5263946
   timestamp: 1695421350577
 - kind: conda
@@ -13457,7 +13926,7 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls:
-  - pkg:pypi/pyqt5
+  - pkg:pypi/pyqt5?source=conda-forge-mapping
   size: 3894083
   timestamp: 1695421066159
 - kind: conda
@@ -13480,7 +13949,7 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls:
-  - pkg:pypi/pyqt5-sip
+  - pkg:pypi/pyqt5-sip?source=conda-forge-mapping
   size: 85809
   timestamp: 1695418132533
 - kind: conda
@@ -13504,7 +13973,7 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls:
-  - pkg:pypi/pyqt5-sip
+  - pkg:pypi/pyqt5-sip?source=conda-forge-mapping
   size: 79366
   timestamp: 1695418564486
 - kind: conda
@@ -13524,7 +13993,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pysocks
+  - pkg:pypi/pysocks?source=conda-forge-mapping
   size: 19348
   timestamp: 1661605138291
 - kind: conda
@@ -13543,34 +14012,33 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pysocks
+  - pkg:pypi/pysocks?source=conda-forge-mapping
   size: 18981
   timestamp: 1661604969727
 - kind: conda
   name: pytest
-  version: 8.1.1
+  version: 8.3.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
-  sha256: 3c481d6b54af1a33c32a3f3eaa3e0971955431e7023db55808740cd062271c73
-  md5: 94ff09cdedcb7b17e9cd5097ee2cfcff
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.3.2-pyhd8ed1ab_0.conda
+  sha256: 72c84a3cd9fe82835a88e975fd2a0dbf2071d1c423ea4f79e7930578c1014873
+  md5: e010a224b90f1f623a917c35addbb924
   depends:
   - colorama
   - exceptiongroup >=1.0.0rc8
   - iniconfig
   - packaging
-  - pluggy <2.0,>=1.4
+  - pluggy <2,>=1.5
   - python >=3.8
   - tomli >=1
   constrains:
   - pytest-faulthandler >=2
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/pytest
-  size: 255523
-  timestamp: 1709992719691
+  - pkg:pypi/pytest?source=conda-forge-mapping
+  size: 257671
+  timestamp: 1721923749407
 - kind: conda
   name: pytest-cov
   version: 5.0.0
@@ -13588,45 +14056,103 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest-cov
+  - pkg:pypi/pytest-cov?source=conda-forge-mapping
   size: 25507
   timestamp: 1711411153367
 - kind: conda
   name: pytest-xdist
-  version: 3.5.0
+  version: 3.6.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.5.0-pyhd8ed1ab_0.conda
-  sha256: 8dc1d422e48e5a80eb72e26ed0135bb4843cf508d3b1cb006c3257c8639784d1
-  md5: d5f595da2daead898ca958ac62f0307b
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.6.1-pyhd8ed1ab_0.conda
+  sha256: c9f27ed55352bee2c9f7cc2fdaf12b322ee280b1989d7e763b4540d4fe7ec995
+  md5: b39568655c127a9c4a44d178ac99b6d0
   depends:
-  - execnet >=1.1
-  - pytest >=6.2.0
-  - python >=3.7
+  - execnet >=2.1
+  - pytest >=7.0.0
+  - python >=3.8
   constrains:
   - psutil >=3.0
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest-xdist
-  size: 36516
-  timestamp: 1700593072448
+  - pkg:pypi/pytest-xdist?source=conda-forge-mapping
+  size: 38320
+  timestamp: 1718138508765
 - kind: conda
   name: python
-  version: 3.12.2
-  build: h2628c8c_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
-  sha256: b8eda863b48ae4531635e23fd15e759d93212b6204c6847d591e25fa5fd67477
-  md5: be8803e9f75a477df61d4aabea3c1246
+  version: 3.12.4
+  build: h194c7f8_0_cpython
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.4-h194c7f8_0_cpython.conda
+  sha256: 97a78631e6c928bf7ad78d52f7f070fcf3bd37619fa48dc4394c21cf3058cdee
+  md5: d73490214f536cccb5819e9873048c92
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 32073625
+  timestamp: 1718621771849
+- kind: conda
+  name: python
+  version: 3.12.4
+  build: h37a9e06_0_cpython
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.4-h37a9e06_0_cpython.conda
+  sha256: 677958ee90eff229755d4e0ed40af6d835c9131e863b1539b34bbf07d7a775f3
+  md5: 94e2b77992f580ac6b7a4fc9b53018b3
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 13848015
+  timestamp: 1718619909707
+- kind: conda
+  name: python
+  version: 3.12.4
+  build: h889d299_0_cpython
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.4-h889d299_0_cpython.conda
+  sha256: 1db32594bfd8db2a49af66c14aaf479520f98df7a86e9d6e6a9ae484d369f4da
+  md5: 4527737432f0fade2fc1e5852c672133
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - ucrt >=10.0.20348.0
@@ -13637,65 +14163,8 @@ packages:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
   purls: []
-  size: 16083296
-  timestamp: 1708116662336
-- kind: conda
-  name: python
-  version: 3.12.2
-  build: h9f0c242_0_cpython
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
-  sha256: 7647ac06c3798a182a4bcb1ff58864f1ef81eb3acea6971295304c23e43252fb
-  md5: 0179b8007ba008cf5bec11f3b3853902
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 14596811
-  timestamp: 1708118065292
-- kind: conda
-  name: python
-  version: 3.12.2
-  build: hab00c5b_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
-  sha256: ddb7a2d8d78046bda5d7631e6814f9468d2eb054e10f86f4648c9d1fdaa30c0f
-  md5: ad7b68400f3a6ebe72b00be093c7f301
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
-  - libxcrypt >=4.4.36
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  purls: []
-  size: 32312631
-  timestamp: 1708118077305
+  size: 16173770
+  timestamp: 1718619012084
 - kind: conda
   name: python-dateutil
   version: 2.9.0
@@ -13711,26 +14180,26 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/python-dateutil
+  - pkg:pypi/python-dateutil?source=conda-forge-mapping
   size: 222742
   timestamp: 1709299922152
 - kind: conda
   name: python-fastjsonschema
-  version: 2.19.1
+  version: 2.20.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
-  sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
-  md5: 4d3ceee3af4b0f9a1f48f57176bf8625
+  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
+  sha256: 7d8c931b89c9980434986b4deb22c2917b58d9936c3974139b9c10ae86fdfe60
+  md5: b98d2018c01ce9980c03ee2850690fab
   depends:
   - python >=3.3
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/fastjsonschema
-  size: 225250
-  timestamp: 1703781171097
+  - pkg:pypi/fastjsonschema?source=conda-forge-mapping
+  size: 226165
+  timestamp: 1718477110630
 - kind: conda
   name: python-json-logger
   version: 2.0.7
@@ -13745,7 +14214,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/python-json-logger
+  - pkg:pypi/python-json-logger?source=conda-forge-mapping
   size: 13383
   timestamp: 1677079727691
 - kind: conda
@@ -13762,7 +14231,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/tzdata
+  - pkg:pypi/tzdata?source=conda-forge-mapping
   size: 144024
   timestamp: 1707747742930
 - kind: conda
@@ -13827,7 +14296,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytz
+  - pkg:pypi/pytz?source=conda-forge-mapping
   size: 188538
   timestamp: 1706886944988
 - kind: conda
@@ -13848,7 +14317,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32
+  - pkg:pypi/pywin32?source=conda-forge-mapping
   size: 6127499
   timestamp: 1695974557413
 - kind: conda
@@ -13869,7 +14338,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pywinpty
+  - pkg:pypi/pywinpty?source=conda-forge-mapping
   size: 212261
   timestamp: 1708995486138
 - kind: conda
@@ -13888,7 +14357,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 185636
   timestamp: 1695373742454
 - kind: conda
@@ -13908,7 +14377,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 196583
   timestamp: 1695373632212
 - kind: conda
@@ -13930,17 +14399,59 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml
+  - pkg:pypi/pyyaml?source=conda-forge-mapping
   size: 167932
   timestamp: 1695374097139
 - kind: conda
   name: pyzmq
-  version: 25.1.2
-  build: py312h1ac6f91_0
+  version: 26.0.3
+  build: py312h8fd38d8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.0.3-py312h8fd38d8_0.conda
+  sha256: a3bf1e1af97a256a3a498cc7f2fedb478df18cf629cc9e9aa73a5b4cfc204d45
+  md5: 27efa6d21e98bcab4585a6b913df7625
+  depends:
+  - libgcc-ng >=12
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyzmq?source=conda-forge-mapping
+  size: 461684
+  timestamp: 1715024520808
+- kind: conda
+  name: pyzmq
+  version: 26.0.3
+  build: py312ha04878a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.0.3-py312ha04878a_0.conda
+  sha256: 65a17e5cbece9fa2d6df687502bcbe504f0fd906aa02a85b23de5ff55d423926
+  md5: a2a851071ceea5b90391003faf94b203
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pyzmq?source=conda-forge-mapping
+  size: 446747
+  timestamp: 1715024631161
+- kind: conda
+  name: pyzmq
+  version: 26.0.3
+  build: py312hd7027bb_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.2-py312h1ac6f91_0.conda
-  sha256: 9371101999c75aa562c5aa4ae0dfefa140bee635a3f8e15768628689f70d7765
-  md5: 74194f888cc7b11d8c18edf416b61a1b
+  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.0.3-py312hd7027bb_0.conda
+  sha256: 9c13d1300fa5ee9a4c7c8cb14fb70b4ace9f4247318774f306f6123aa4e6e46a
+  md5: 0fc1ec9be7d6274d3e01f6c7908f69e5
   depends:
   - libsodium >=1.0.18,<1.0.19.0a0
   - python >=3.12,<3.13.0a0
@@ -13949,213 +14460,221 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zeromq >=4.3.5,<4.3.6.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
+  license: BSD-3-Clause
+  license_family: BSD
   purls:
-  - pkg:pypi/pyzmq
-  size: 480772
-  timestamp: 1701783863250
+  - pkg:pypi/pyzmq?source=conda-forge-mapping
+  size: 445178
+  timestamp: 1715025185530
 - kind: conda
-  name: pyzmq
-  version: 25.1.2
-  build: py312h886d080_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.2-py312h886d080_0.conda
-  sha256: 5aa0ba1f67e2b25ede34a713df6655e519211a96ea109857768930d96bcd0ca0
-  md5: cc2cdf8f1792d29d21e17024745813d8
-  depends:
-  - libgcc-ng >=12
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - libstdcxx-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - zeromq >=4.3.5,<4.4.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  purls:
-  - pkg:pypi/pyzmq
-  size: 528745
-  timestamp: 1701783368181
-- kind: conda
-  name: pyzmq
-  version: 25.1.2
-  build: py312hc789acb_0
+  name: qhull
+  version: '2020.2'
+  build: h3c5361c_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.2-py312hc789acb_0.conda
-  sha256: 1e5fb7095be7edb90efd50cde7b417bf4f1f5ae216d0b597ada61ee201f56d29
-  md5: af49da330d412bc3203bc84f8153d685
+  url: https://conda.anaconda.org/conda-forge/osx-64/qhull-2020.2-h3c5361c_5.conda
+  sha256: 79d804fa6af9c750e8b09482559814ae18cd8df549ecb80a4873537a5a31e06e
+  md5: dd1ea9ff27c93db7c01a7b7656bd4ad4
   depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - zeromq >=4.3.5,<4.4.0a0
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  purls:
-  - pkg:pypi/pyzmq
-  size: 487865
-  timestamp: 1701783621950
+  - __osx >=10.13
+  - libcxx >=16
+  license: LicenseRef-Qhull
+  purls: []
+  size: 528122
+  timestamp: 1720814002588
+- kind: conda
+  name: qhull
+  version: '2020.2'
+  build: h434a139_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  purls: []
+  size: 552937
+  timestamp: 1720813982144
+- kind: conda
+  name: qhull
+  version: '2020.2'
+  build: hc790b64_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
+  sha256: 887d53486a37bd870da62b8fa2ebe3993f912ad04bd755e7ed7c47ced97cbaa8
+  md5: 854fbdff64b572b5c0b470f334d34c11
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LicenseRef-Qhull
+  purls: []
+  size: 1377020
+  timestamp: 1720814433486
 - kind: conda
   name: qt-main
   version: 5.15.8
-  build: hc9dc06e_21
-  build_number: 21
+  build: h06adc49_23
+  build_number: 23
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h06adc49_23.conda
+  sha256: 35a3c7a30e86c4cb6cca09008ca7d05fbc5801e5db949a9c1c5ca6bcd01afb4f
+  md5: 1f6a464e4fc36114ac7286d1db8d260e
+  depends:
+  - gst-plugins-base >=1.24.5,<1.25.0a0
+  - gstreamer >=1.24.5,<1.25.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libclang13 >=15.0.7
+  - libglib >=2.80.3,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libsqlite >=3.46.0,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - qt 5.15.8
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 60286742
+  timestamp: 1721091009568
+- kind: conda
+  name: qt-main
+  version: 5.15.8
+  build: h320f8da_24
+  build_number: 24
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-hc9dc06e_21.conda
-  sha256: 6b4594f6f2fad65a7ed52993f602e3ab183193755fe4a492aaa48e463b23105b
-  md5: b325046180590c868ce0dbf267b82eb8
+  url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h320f8da_24.conda
+  sha256: 43773cf96efce22f8c46b4666fba89953c71cad60b309693147fb90b04557c64
+  md5: bec111b67cb8dc63277c6af65d214044
   depends:
   - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.11,<1.3.0a0
+  - alsa-lib >=1.2.12,<1.3.0a0
   - dbus >=1.13.6,<2.0a0
   - fontconfig >=2.14.2,<3.0a0
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
-  - gst-plugins-base >=1.24.1,<1.25.0a0
-  - gstreamer >=1.24.1,<1.25.0a0
-  - harfbuzz >=8.3.0,<9.0a0
+  - gst-plugins-base >=1.24.5,<1.25.0a0
+  - gstreamer >=1.24.5,<1.25.0a0
+  - harfbuzz >=9.0.0,<10.0a0
   - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
+  - krb5 >=1.21.3,<1.22.0a0
   - libclang-cpp15 >=15.0.7,<15.1.0a0
   - libclang13 >=15.0.7
   - libcups >=2.3.3,<2.4.0a0
   - libevent >=2.1.12,<2.1.13.0a0
   - libexpat >=2.6.2,<3.0a0
   - libgcc-ng >=12
-  - libglib >=2.80.0,<3.0a0
+  - libglib >=2.80.3,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libllvm15 >=15.0.7,<15.1.0a0
   - libpng >=1.6.43,<1.7.0a0
-  - libpq >=16.2,<17.0a0
-  - libsqlite >=3.45.2,<4.0a0
+  - libpq >=16.3,<17.0a0
+  - libsqlite >=3.46.0,<4.0a0
   - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<1.17.0a0
   - libxkbcommon >=1.7.0,<2.0a0
-  - libxml2 >=2.12.6,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libxml2 >=2.12.7,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - mysql-libs >=8.3.0,<8.4.0a0
   - nspr >=4.35,<5.0a0
-  - nss >=3.98,<4.0a0
-  - openssl >=3.2.1,<4.0a0
+  - nss >=3.102,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   - pulseaudio-client >=17.0,<17.1.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
   - xcb-util-image >=0.4.0,<0.5.0a0
-  - xcb-util-keysyms >=0.4.0,<0.5.0a0
-  - xcb-util-renderutil >=0.3.9,<0.4.0a0
-  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
   - xorg-libice >=1.1.1,<2.0a0
   - xorg-libsm >=1.2.4,<2.0a0
   - xorg-libx11 >=1.8.9,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-xf86vidmodeproto
-  - zstd >=1.5.5,<1.6.0a0
+  - zstd >=1.5.6,<1.6.0a0
   constrains:
   - qt 5.15.8
   license: LGPL-3.0-only
   license_family: LGPL
   purls: []
-  size: 61305384
-  timestamp: 1712549380352
-- kind: conda
-  name: qt-main
-  version: 5.15.8
-  build: hcef0176_21
-  build_number: 21
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-hcef0176_21.conda
-  sha256: 7eb717efea95fb0f8384f7c59b709dbe3c7a2c1fabca60c8792760211c430251
-  md5: 76544d3dfeff8fd52250df168cb0005b
-  depends:
-  - gst-plugins-base >=1.24.1,<1.25.0a0
-  - gstreamer >=1.24.1,<1.25.0a0
-  - icu >=73.2,<74.0a0
-  - krb5 >=1.21.2,<1.22.0a0
-  - libclang13 >=15.0.7
-  - libglib >=2.80.0,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.43,<1.7.0a0
-  - libsqlite >=3.45.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  constrains:
-  - qt 5.15.8
-  license: LGPL-3.0-only
-  license_family: LGPL
-  purls: []
-  size: 59806644
-  timestamp: 1712551057454
+  size: 60403438
+  timestamp: 1721277287096
 - kind: conda
   name: quarto
-  version: 1.4.550
-  build: h57928b3_1
-  build_number: 1
+  version: 1.4.557
+  build: h57928b3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/quarto-1.4.550-h57928b3_1.conda
-  sha256: 6415fc839ad74202b20ed7781de3aa076f0bc202f7dd977e6ea782dfb00def71
-  md5: d92f625feb8436864b4bfd2bc7f420da
+  url: https://conda.anaconda.org/conda-forge/win-64/quarto-1.4.557-h57928b3_0.conda
+  sha256: bda426f126388f55970c590bd518eaf9b9e5f21c36f074e60a037806925d7011
+  md5: aef36b6be779eb3f5fd80ea8499d405c
   depends:
   - dart-sass
   - deno >=1.37.2,<1.37.3.0a0
   - deno-dom >=0.1.35,<0.1.36.0a0
   - esbuild
-  - pandoc >=3.1.11.1,<3.1.12.0a0
+  - pandoc >=3.1.12.3,<3.1.13.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 15688899
-  timestamp: 1708104504691
+  size: 15699818
+  timestamp: 1721146428477
 - kind: conda
   name: quarto
-  version: 1.4.550
-  build: h694c41f_1
-  build_number: 1
+  version: 1.4.557
+  build: h694c41f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/quarto-1.4.550-h694c41f_1.conda
-  sha256: 914a1b22f3b9616309ee6a066c50707cab37de0e9eb23cd0db3488d05c3991c1
-  md5: 451204adcf15c8411d12ba240e7e979a
+  url: https://conda.anaconda.org/conda-forge/osx-64/quarto-1.4.557-h694c41f_0.conda
+  sha256: 724bbfce9510016aa055d7f6b09f5699d965103b7ae171cda57d00ff528fe162
+  md5: 6c89a6bf63516b38ad9cfc13c75c5676
   depends:
   - dart-sass
   - deno >=1.37.2,<1.37.3.0a0
   - deno-dom >=0.1.35,<0.1.36.0a0
   - esbuild
-  - pandoc >=3.1.11.1,<3.1.12.0a0
+  - pandoc >=3.1.12.3,<3.1.13.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 15721907
-  timestamp: 1708104547618
+  size: 15905690
+  timestamp: 1721146614907
 - kind: conda
   name: quarto
-  version: 1.4.550
-  build: ha770c72_1
-  build_number: 1
+  version: 1.4.557
+  build: ha770c72_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.4.550-ha770c72_1.conda
-  sha256: 2fd62d66eb6a08b95ba8933aaff7a0e3241c7ced93b5114a3b1e8d28ee24b330
-  md5: b7b89be76bcdab239f7956e5fc2727ab
+  url: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.4.557-ha770c72_0.conda
+  sha256: 0e05614ea54597ffd96111907d96b23c49eb7d0695ae1875c431655d98a65ecd
+  md5: 564f00d6feca800e6f1ecffd8ca21ea0
   depends:
   - dart-sass
   - deno >=1.37.2,<1.37.3.0a0
   - deno-dom >=0.1.35,<0.1.36.0a0
   - esbuild
-  - pandoc >=3.1.11.1,<3.1.12.0a0
+  - pandoc >=3.1.12.3,<3.1.13.0a0
   license: GPL-2.0-or-later
   license_family: GPL
   purls: []
-  size: 15312136
-  timestamp: 1708104283642
+  size: 15177349
+  timestamp: 1721146183562
 - kind: conda
   name: quartodoc
-  version: 0.7.2
+  version: 0.7.5
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.2-pyhd8ed1ab_0.conda
-  sha256: 1a214d61abb5a7f424e1397d06595eac4b62b4f4c8190994da23123d5b9bb0f9
-  md5: 9bf1905bef4492b77781e058cc27db35
+  url: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.7.5-pyhd8ed1ab_0.conda
+  sha256: b274b1715455b4cc629fff973fa74cf7c712072d25c24fc1c01396778d3be567
+  md5: e792d8c21d24dbb2b880c07430328536
   depends:
   - click
   - griffe >=0.33
@@ -14165,6 +14684,7 @@ packages:
   - pydantic
   - python >=3.10
   - pyyaml
+  - requests
   - sphobjinv >=2.3.1
   - tabulate >=0.9.0
   - typing-extensions >=4.4.0
@@ -14172,18 +14692,49 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/quartodoc
-  size: 64615
-  timestamp: 1702333703635
+  - pkg:pypi/quartodoc?source=conda-forge-mapping
+  size: 65878
+  timestamp: 1718900565226
 - kind: conda
   name: rasterio
-  version: 1.3.9
-  build: py312h26ef92c_2
-  build_number: 2
+  version: 1.3.10
+  build: py312h1c98354_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.10-py312h1c98354_4.conda
+  sha256: 84d06dacb0fdc9c85f6b0c0019d9589a4801c0fa928a37799908f338186cdaab
+  md5: dcec838580fd6e2e4210168608946ac8
+  depends:
+  - __osx >=10.13
+  - affine
+  - attrs
+  - certifi
+  - click >=4
+  - click-plugins
+  - cligj >=0.5
+  - libcxx >=16
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.5.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/rasterio?source=conda-forge-mapping
+  size: 7216436
+  timestamp: 1717806079690
+- kind: conda
+  name: rasterio
+  version: 1.3.10
+  build: py312hc022a17_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.9-py312h26ef92c_2.conda
-  sha256: 33fa2502729d3ee1e5ca5097278b247ca62bbb5ca7bac1709f66d70bcc5399d0
-  md5: 96d14d34711307a6dc3cd59b090faf43
+  url: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.3.10-py312hc022a17_4.conda
+  sha256: 860acfea3f4d6540ab3eb8a8160264daca58e6caa1683a8a56e1ce52666e5cf3
+  md5: a291a31c046d55ef7c6c4f5036314fe5
   depends:
   - affine
   - attrs
@@ -14192,10 +14743,10 @@ packages:
   - click-plugins
   - cligj >=0.5
   - libgcc-ng >=12
-  - libgdal >=3.8.1,<3.9.0a0
+  - libgdal >=3.9.0,<3.10.0a0
   - libstdcxx-ng >=12
-  - numpy >=1.26.2,<2.0a0
-  - proj >=9.3.1,<9.3.2.0a0
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.5.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - setuptools >=0.9.8
@@ -14203,48 +14754,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/rasterio
-  size: 7190256
-  timestamp: 1702440857949
+  - pkg:pypi/rasterio?source=conda-forge-mapping
+  size: 7552237
+  timestamp: 1717805844953
 - kind: conda
   name: rasterio
-  version: 1.3.9
-  build: py312h2bf6802_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rasterio-1.3.9-py312h2bf6802_2.conda
-  sha256: 02a0a5da11579408e8700be80c19219fd79dd1532bd8fa8f986399b0182a978b
-  md5: 0a49fa306ebb685ee4673ea0cd6ea1c0
-  depends:
-  - affine
-  - attrs
-  - certifi
-  - click >=4
-  - click-plugins
-  - cligj >=0.5
-  - libcxx >=15
-  - libgdal >=3.8.1,<3.9.0a0
-  - numpy >=1.26.2,<2.0a0
-  - proj >=9.3.1,<9.3.2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - setuptools >=0.9.8
-  - snuggs >=1.4.1
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/rasterio
-  size: 7529244
-  timestamp: 1702441222560
-- kind: conda
-  name: rasterio
-  version: 1.3.9
-  build: py312hc028deb_2
-  build_number: 2
+  version: 1.3.10
+  build: py312he4a2ebf_4
+  build_number: 4
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.9-py312hc028deb_2.conda
-  sha256: 7a1713571d670c86bd1b47a1236ade7a93e0b6f67960f51a6981d12869c7d419
-  md5: 3278c8d3806674305672d7a465ab0882
+  url: https://conda.anaconda.org/conda-forge/win-64/rasterio-1.3.10-py312he4a2ebf_4.conda
+  sha256: 0cacfa2aaa57e36801bd3afd2c62825639877ce5a999db01ed5ddf39dbffb3cc
+  md5: cc10bb1055bfae6361361523e0fa6495
   depends:
   - affine
   - attrs
@@ -14252,9 +14773,9 @@ packages:
   - click >=4
   - click-plugins
   - cligj >=0.5
-  - libgdal >=3.8.1,<3.9.0a0
-  - numpy >=1.26.2,<2.0a0
-  - proj >=9.3.1,<9.3.2.0a0
+  - libgdal >=3.9.0,<3.10.0a0
+  - numpy >=1.19,<3
+  - proj >=9.4.0,<9.5.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - setuptools >=0.9.8
@@ -14265,9 +14786,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/rasterio
-  size: 7675343
-  timestamp: 1702441950706
+  - pkg:pypi/rasterio?source=conda-forge-mapping
+  size: 7645713
+  timestamp: 1717806702230
 - kind: conda
   name: rasterstats
   version: 0.19.0
@@ -14290,27 +14811,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/rasterstats
+  - pkg:pypi/rasterstats?source=conda-forge-mapping
   size: 20607
   timestamp: 1685447856675
-- kind: conda
-  name: rdma-core
-  version: '51.0'
-  build: hd3aeb46_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-51.0-hd3aeb46_0.conda
-  sha256: bcc774b60605b09701cfad41b2d6d9c3f052dd4adfc1f02bf1c929076f48fe30
-  md5: 493598e1f28c01e316fda127715593aa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libnl >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  license: Linux-OpenIB
-  license_family: BSD
-  purls: []
-  size: 4734659
-  timestamp: 1711958296706
 - kind: conda
   name: re2
   version: 2023.09.01
@@ -14394,13 +14897,13 @@ packages:
   timestamp: 1679532707590
 - kind: conda
   name: referencing
-  version: 0.34.0
+  version: 0.35.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.34.0-pyhd8ed1ab_0.conda
-  sha256: 2e631e9e1d49280770573f7acc7441b70181b2dc21948bb1be15eaae80550672
-  md5: e4492c22e314be5c75db3469e3bbf3d9
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.35.1-pyhd8ed1ab_0.conda
+  sha256: be8d6d9e86b1a3fef5424127ff81782f8ca63d3058980859609f6f1ecdd34cb3
+  md5: 0fc8b52192a8898627c3efae1003e9f6
   depends:
   - attrs >=22.2.0
   - python >=3.8
@@ -14408,32 +14911,32 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/referencing
-  size: 42071
-  timestamp: 1710763821612
+  - pkg:pypi/referencing?source=conda-forge-mapping
+  size: 42210
+  timestamp: 1714619625532
 - kind: conda
   name: requests
-  version: 2.31.0
+  version: 2.32.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
-  sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  md5: a30144e4156cdbb236f99ebb49828f8b
+  url: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
+  sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
+  md5: 5ede4753180c7a550a443c430dc8ab52
   depends:
   - certifi >=2017.4.17
   - charset-normalizer >=2,<4
   - idna >=2.5,<4
-  - python >=3.7
+  - python >=3.8
   - urllib3 >=1.21.1,<3
   constrains:
   - chardet >=3.0.2,<6
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/requests
-  size: 56690
-  timestamp: 1684774408600
+  - pkg:pypi/requests?source=conda-forge-mapping
+  size: 58810
+  timestamp: 1717057174842
 - kind: conda
   name: rfc3339-validator
   version: 0.1.4
@@ -14449,7 +14952,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rfc3339-validator
+  - pkg:pypi/rfc3339-validator?source=conda-forge-mapping
   size: 8064
   timestamp: 1638811838081
 - kind: conda
@@ -14466,24 +14969,24 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rfc3986-validator
+  - pkg:pypi/rfc3986-validator?source=conda-forge-mapping
   size: 7818
   timestamp: 1598024297745
 - kind: conda
   name: ribasim
-  version: 2024.9.0
+  version: 2024.10.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.9.0-pyhd8ed1ab_0.conda
-  sha256: 0608079c00c7eb361295af37f3b3683d1b07716273c40df37143429191ce2d36
-  md5: b72ed6350c789641be35d2af84b4c4b8
+  url: https://conda.anaconda.org/conda-forge/noarch/ribasim-2024.10.0-pyhd8ed1ab_0.conda
+  sha256: 8763fe14e25ce12407e2b56e3ec3019dc93416a3fae838c6c5c5c39e4a2ea61e
+  md5: 6764d892db65d2b0f2ac8a072d61d2f0
   depends:
   - geopandas
   - matplotlib-base
-  - numpy <2.0
+  - numpy
   - pandas
-  - pandera >=0.18
+  - pandera >=0.20
   - pyarrow
   - pydantic ~=2.0
   - pyogrio
@@ -14495,8 +14998,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ribasim?source=conda-forge-mapping
-  size: 37529
-  timestamp: 1719004865324
+  size: 38500
+  timestamp: 1721804986901
 - kind: pypi
   name: ribasim-nl
   version: 0.0.1
@@ -14524,18 +15027,18 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rich
+  - pkg:pypi/rich?source=conda-forge-mapping
   size: 184347
   timestamp: 1709150578093
 - kind: conda
   name: rioxarray
-  version: 0.15.3
+  version: 0.17.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.15.3-pyhd8ed1ab_0.conda
-  sha256: 4555e0dfe946c8c10e18e8e29431d4a719724faf47a45c3f04aaf10b028d691a
-  md5: c2e61165d23538664edad7e3bff31ae2
+  url: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
+  sha256: 992ce1a2667dd2beac45157dcb9058775e0522ebf1a70f1563c0fd0608f9480a
+  md5: 160464c6f979eb68e9a9ea31dd6b5aa6
   depends:
   - numpy >=1.23
   - packaging
@@ -14547,54 +15050,17 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/rioxarray
-  size: 51046
-  timestamp: 1712166953555
+  - pkg:pypi/rioxarray?source=conda-forge-mapping
+  size: 51306
+  timestamp: 1721412091165
 - kind: conda
   name: rpds-py
-  version: 0.18.0
-  build: py312h1b0e595_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.18.0-py312h1b0e595_0.conda
-  sha256: bdb47dd05828b8624f7aa0895a35f0edbbef04732a8911da5acc2fb8d6b533e9
-  md5: 75d882a5a5ff8e970eff0e30591d6ca6
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - __osx >=10.12
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/rpds-py
-  size: 302124
-  timestamp: 1707923275835
-- kind: conda
-  name: rpds-py
-  version: 0.18.0
-  build: py312h4b3b743_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.18.0-py312h4b3b743_0.conda
-  sha256: 7d8ca38e56db7f803dbc42240bd1918d6084f01cfd56e252a7121c5cdf850191
-  md5: cc8165b34bdb002ade83b068f44e5774
-  depends:
-  - libgcc-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/rpds-py
-  size: 919366
-  timestamp: 1707922953470
-- kind: conda
-  name: rpds-py
-  version: 0.18.0
-  build: py312hfccd98a_0
+  version: 0.19.1
+  build: py312h2615798_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.18.0-py312hfccd98a_0.conda
-  sha256: fa16681746a210e79783cde2069e8704cdb29b15d4e99e16859853f260da9867
-  md5: 4f201390adc379696fb0bd3f2b5cdcc7
+  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.19.1-py312h2615798_0.conda
+  sha256: 892407686805709a37a6dd29da06042f891a35774b25cee51368a29be9ccac6b
+  md5: 80bb17e18169ac455444b8167a105059
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -14602,65 +15068,49 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/rpds-py
-  size: 201960
-  timestamp: 1707923686383
+  - pkg:pypi/rpds-py?source=conda-forge-mapping
+  size: 206243
+  timestamp: 1721862293173
 - kind: conda
-  name: rtree
-  version: 1.2.0
-  build: py312h72b5f30_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rtree-1.2.0-py312h72b5f30_0.conda
-  sha256: 6dafc5ab1ba907a6665f5df60b241f57e9b0953fd29bfe95e3bc46f75a36a236
-  md5: 9b80ceb8d83fe2e929db84278c551f68
-  depends:
-  - libspatialindex >=1.9.3,<1.9.4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/rtree
-  size: 62968
-  timestamp: 1705698300779
-- kind: conda
-  name: rtree
-  version: 1.2.0
-  build: py312h8974cf7_0
+  name: rpds-py
+  version: 0.19.1
+  build: py312ha47ea1c_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rtree-1.2.0-py312h8974cf7_0.conda
-  sha256: ff6433e1fc3b95f85e2f7e5a549f8b17710acd5345ff37e687210fa5b2451948
-  md5: 63416e40d1e466da6309b893f4c4649b
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.19.1-py312ha47ea1c_0.conda
+  sha256: dc5ce3a63deffc69263a8e8699e43ae64b45663ce3f39799c10b35524cc3e861
+  md5: c54025057789a55e07d585e743fc8744
   depends:
-  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - __osx >=10.13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=10.13
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/rtree
-  size: 62828
-  timestamp: 1705698173963
+  - pkg:pypi/rpds-py?source=conda-forge-mapping
+  size: 295442
+  timestamp: 1721861174737
 - kind: conda
-  name: rtree
-  version: 1.2.0
-  build: py312hb0aae1a_0
+  name: rpds-py
+  version: 0.19.1
+  build: py312hf008fa9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rtree-1.2.0-py312hb0aae1a_0.conda
-  sha256: 234d8d81c8c7ddd96b826a60ebecb762b530b1b12ed632c28e7704337e86e470
-  md5: ad9e0b706ffac22ae394d5357c14b7c7
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.19.1-py312hf008fa9_0.conda
+  sha256: 931d84722857bfdc9c1bbf8acc9c3bcf9aa294d8d9b4f26015569a3a0fbabefd
+  md5: ebdebabe560c06a70bc41221b9606945
   depends:
-  - libspatialindex >=1.9.3,<1.9.4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/rtree
-  size: 62265
-  timestamp: 1705698063894
+  - pkg:pypi/rpds-py?source=conda-forge-mapping
+  size: 333274
+  timestamp: 1721861124399
 - kind: conda
   name: ruff
   version: 0.5.5
@@ -14726,106 +15176,108 @@ packages:
   timestamp: 1721941081428
 - kind: conda
   name: s2n
-  version: 1.4.8
-  build: h06160fa_0
+  version: 1.4.17
+  build: he19d79f_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.8-h06160fa_0.conda
-  sha256: 1068495f0f8f8b999dda339429dfaf5a8bd2e7a25bb386b6c39fd33ba01753fd
-  md5: 0240a49dffea6daea27aa388663edcab
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.17-he19d79f_0.conda
+  sha256: 6d1aa582964771a6cf47d120e2c5cdc700fe3744101cd5660af1eb81d47d689a
+  md5: e25ac9bf10f8e6aa67727b1cdbe762ef
   depends:
   - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 340708
-  timestamp: 1710939097247
+  size: 349926
+  timestamp: 1719619139334
 - kind: conda
   name: scikit-learn
-  version: 1.4.1.post1
-  build: py312h394d371_0
+  version: 1.5.1
+  build: py312h775a589_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.4.1.post1-py312h394d371_0.conda
-  sha256: 0e18aec47e6cef8e34865417e2712b3fdacea1982a8b1acb6b1f0c185d9a4f07
-  md5: 7f50e0cc10407f2033d0305fee78490e
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py312h775a589_0.conda
+  sha256: cf9735937209d01febf1f912559e28dc3bb753906460e5b85dc24f0d57a78d96
+  md5: bd8c79ccb9498336cbb174cf0151024a
   depends:
+  - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   - joblib >=1.2.0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - scipy
-  - threadpoolctl >=2.0.0
+  - threadpoolctl >=3.1.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scikit-learn
-  size: 10189265
-  timestamp: 1708074374862
+  - pkg:pypi/scikit-learn?source=conda-forge-mapping
+  size: 10384469
+  timestamp: 1719998679827
 - kind: conda
   name: scikit-learn
-  version: 1.4.1.post1
-  build: py312h7167a34_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.4.1.post1-py312h7167a34_0.conda
-  sha256: 865a6f53b36f939df9b6e4580577171575fca260d33161c4e7115735a8a2fcdf
-  md5: 0b8c6fb8f3f06d99cce439d79be6322d
-  depends:
-  - joblib >=1.2.0
-  - libcxx >=16
-  - llvm-openmp >=16.0.6
-  - llvm-openmp >=17.0.6
-  - numpy >=1.26.4,<2.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - scipy
-  - threadpoolctl >=2.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/scikit-learn
-  size: 9221383
-  timestamp: 1708077865675
-- kind: conda
-  name: scikit-learn
-  version: 1.4.1.post1
-  build: py312hcacafb1_0
+  version: 1.5.1
+  build: py312h816cc57_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.4.1.post1-py312hcacafb1_0.conda
-  sha256: 75cdb4d4b66198c591ae5e730d11b573122326dfe80d9d3232bc2d71eb1bbee1
-  md5: 4d4454b5c8ae82fc0a38895219d26315
+  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py312h816cc57_0.conda
+  sha256: 00ab427eaebdc17816655ec7d116de9511a8ad04020fc47e0b4bc5dcfc46bbbb
+  md5: fa83d73ec4a87352b6bbfcdfde5aeab2
   depends:
   - joblib >=1.2.0
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - scipy
-  - threadpoolctl >=2.0.0
+  - threadpoolctl >=3.1.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scikit-learn
-  size: 8889723
-  timestamp: 1708074980466
+  - pkg:pypi/scikit-learn?source=conda-forge-mapping
+  size: 9225862
+  timestamp: 1719999149012
+- kind: conda
+  name: scikit-learn
+  version: 1.5.1
+  build: py312hc214ba5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py312hc214ba5_0.conda
+  sha256: 62a33e1266c9e2e99e5bb68127160e04a592b62e553faa4f6ad2df264b9654f0
+  md5: 32625e0f29884a4704070c07a25edf94
+  depends:
+  - __osx >=10.13
+  - joblib >=1.2.0
+  - libcxx >=16
+  - llvm-openmp >=16.0.6
+  - numpy >=1.19,<3
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - scipy
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scikit-learn?source=conda-forge-mapping
+  size: 9488534
+  timestamp: 1719998895551
 - kind: conda
   name: scipy
-  version: 1.13.0
-  build: py312h8753938_0
+  version: 1.14.0
+  build: py312h1f4e10d_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.13.0-py312h8753938_0.conda
-  sha256: 8441a6e6805e6a99e02c56a52ec1672b549f33739061c313a9c4c7655476a852
-  md5: 0acd540ee94e0f2148e8d351ed7c49e8
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_1.conda
+  sha256: e2c55a57bdac972d5f0ecae09a8a8041ee6519627231851e8edb27fd8e1a5e11
+  md5: 4667a8b9e594a70eb0ef680615a4b411
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.26.4,<1.28
-  - numpy >=1.26.4,<2.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
@@ -14834,18 +15286,20 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy
-  size: 15588141
-  timestamp: 1712257711887
+  - pkg:pypi/scipy?source=conda-forge-mapping
+  size: 15758479
+  timestamp: 1720325181489
 - kind: conda
   name: scipy
-  version: 1.13.0
-  build: py312h8adb940_0
+  version: 1.14.0
+  build: py312hb9702fa_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.13.0-py312h8adb940_0.conda
-  sha256: 1b14bd37c0973417093baa6d68bd9fb6c66da313681a7f345c1f8ba58545ff23
-  md5: 818232a7807c76970172af9c7698ba4a
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_1.conda
+  sha256: 259651aa3966f9735aab2b3ee9c25d4fa93914484e9b757c0b6fda87bac78a0f
+  md5: 9899db3cf8965c3aecab3daf5227d3eb
   depends:
+  - __osx >=10.13
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=16
@@ -14853,24 +15307,25 @@ packages:
   - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.26.4,<1.28
-  - numpy >=1.26.4,<2.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy
-  size: 16518412
-  timestamp: 1712257461114
+  - pkg:pypi/scipy?source=conda-forge-mapping
+  size: 16203819
+  timestamp: 1720323983766
 - kind: conda
   name: scipy
-  version: 1.13.0
-  build: py312heda63a1_0
+  version: 1.14.0
+  build: py312hc2bc53b_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.13.0-py312heda63a1_0.conda
-  sha256: 54571d3f3583f64a184b19b0cd50bea7f102052053e48017120026ee1ccacd6f
-  md5: c53b9f319cafc679476f5613599857e8
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312hc2bc53b_1.conda
+  sha256: 6bd24bc823863bb568ffe0ebdfb506d4413d94d15b478b12a0b223d9373f531e
+  md5: eae80145f63aa04a02dda456d4883b46
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -14879,100 +15334,100 @@ packages:
   - libgfortran5 >=12.3.0
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - numpy >=1.26.4,<1.28
-  - numpy >=1.26.4,<2.0a0
+  - numpy <2.3
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy
-  size: 17373483
-  timestamp: 1712256604150
+  - pkg:pypi/scipy?source=conda-forge-mapping
+  size: 17653680
+  timestamp: 1720324049729
 - kind: conda
   name: send2trash
-  version: 1.8.2
-  build: pyh08f2357_0
+  version: 1.8.3
+  build: pyh0d859eb_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
-  sha256: 55208c6b48d68dc9ad2e2cf81ab9dc6b8a1d607e67acf9115bdc7794accc84bc
-  md5: c00d32dfa733d381b6a1908d0d67e0d7
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
+  sha256: c4401b071e86ddfa0ea4f34b85308db2516b6aeca50053535996864cfdee7b3f
+  md5: 778594b20097b5a948c59e50ae42482a
+  depends:
+  - __linux
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/send2trash?source=conda-forge-mapping
+  size: 22868
+  timestamp: 1712585140895
+- kind: conda
+  name: send2trash
+  version: 1.8.3
+  build: pyh31c8845_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
+  sha256: f911307db932c92510da6c3c15b461aef935720776643a1fbf3683f61001068b
+  md5: c3cb67fc72fb38020fe7923dbbcf69b0
+  depends:
+  - __osx
+  - pyobjc-framework-cocoa
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/send2trash?source=conda-forge-mapping
+  size: 23165
+  timestamp: 1712585504123
+- kind: conda
+  name: send2trash
+  version: 1.8.3
+  build: pyh5737063_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
+  sha256: d8aa230501a33250af2deee03006a2579f0335e7240a9c7286834788dcdcfaa8
+  md5: 5a86a21050ca3831ec7f77fb302f1132
   depends:
   - __win
-  - python >=3.6
+  - python >=3.7
   - pywin32
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/send2trash
-  size: 23279
-  timestamp: 1682601755260
-- kind: conda
-  name: send2trash
-  version: 1.8.2
-  build: pyh41d4057_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
-  sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
-  md5: ada5a17adcd10be4fc7e37e4166ba0e2
-  depends:
-  - __linux
-  - python >=3.6
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/send2trash
-  size: 22821
-  timestamp: 1682601391911
-- kind: conda
-  name: send2trash
-  version: 1.8.2
-  build: pyhd1c38e8_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
-  sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
-  md5: 2657c3de5371c571aef6678afb4aaadd
-  depends:
-  - __osx
-  - pyobjc-framework-cocoa
-  - python >=3.6
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/send2trash
-  size: 23021
-  timestamp: 1682601619389
+  - pkg:pypi/send2trash?source=conda-forge-mapping
+  size: 23319
+  timestamp: 1712585816346
 - kind: conda
   name: setuptools
-  version: 69.2.0
+  version: 71.0.4
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
-  sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
-  md5: da214ecd521a720a9d521c68047682dc
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-71.0.4-pyhd8ed1ab_0.conda
+  sha256: e1b5dd28d2ea2a7ad660fbc8d1f2ef682a2f8460f80240d836d62e56225ac680
+  md5: ee78ac9c720d0d02fcfd420866b82ab1
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/setuptools
-  size: 471183
-  timestamp: 1710344615844
+  - pkg:pypi/setuptools?source=conda-forge-mapping
+  size: 1463254
+  timestamp: 1721475299854
 - kind: conda
   name: shapely
-  version: 2.0.3
-  build: py312h7d70906_0
+  version: 2.0.5
+  build: py312h3a88d77_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.3-py312h7d70906_0.conda
-  sha256: 76b66f2f5be07c2d809c02c7224db359d189f3e24a3658a9393f5b47598996ba
-  md5: 246e222db0eb7cd8d82a543b708176a7
+  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.5-py312h3a88d77_0.conda
+  sha256: 723a8f400918b63626cd49ab3364a661fe07c70c3e022431fc610e196a14b49f
+  md5: b4a76f36780fa55cd2104f2970ff6bed
   depends:
-  - geos >=3.12.1,<3.12.2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - geos >=3.12.2,<3.12.3.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
@@ -14981,48 +15436,50 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/shapely
-  size: 533406
-  timestamp: 1708368702843
+  - pkg:pypi/shapely?source=conda-forge-mapping
+  size: 535191
+  timestamp: 1720886719216
 - kind: conda
   name: shapely
-  version: 2.0.3
-  build: py312h8fb43f9_0
+  version: 2.0.5
+  build: py312h594820c_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.3-py312h8fb43f9_0.conda
-  sha256: 4fb02761e26e36597bb0df763cbcd3e3cdb8e3c3786920807d9d6762ba66a130
-  md5: abad6d4900e92349375863ad7e162d1f
+  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.5-py312h594820c_0.conda
+  sha256: 15a9a4bf93032bc5714c9c98fc7028883e6ffcca69d91fe1dc3e619119bc5045
+  md5: b7c1b53fdae47febbde2e25e207c7389
   depends:
-  - geos >=3.12.1,<3.12.2.0a0
-  - numpy >=1.26.4,<2.0a0
+  - __osx >=10.13
+  - geos >=3.12.2,<3.12.3.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/shapely
-  size: 534065
-  timestamp: 1708368600079
+  - pkg:pypi/shapely?source=conda-forge-mapping
+  size: 538432
+  timestamp: 1720886351691
 - kind: conda
   name: shapely
-  version: 2.0.3
-  build: py312h9e6bd2c_0
+  version: 2.0.5
+  build: py312h8413631_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.3-py312h9e6bd2c_0.conda
-  sha256: 780c1f964f99454ed6034156deedd9b67373d54295434f77623ab884ce6b0f97
-  md5: 5e0580a84d702cda52c8b0245e4c14d2
+  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.5-py312h8413631_0.conda
+  sha256: 7ed7ec680dce240f74aca2ddfc6b69487841645237683612e082084fc880a9a9
+  md5: 3e67354b24c7ee057ddee367f310ad3e
   depends:
-  - geos >=3.12.1,<3.12.2.0a0
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.12.2,<3.12.3.0a0
   - libgcc-ng >=12
-  - numpy >=1.26.4,<2.0a0
+  - numpy >=1.19,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/shapely
-  size: 566752
-  timestamp: 1708368105478
+  - pkg:pypi/shapely?source=conda-forge-mapping
+  size: 568517
+  timestamp: 1720886333536
 - kind: conda
   name: simplejson
   version: 3.19.2
@@ -15037,7 +15494,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/simplejson
+  - pkg:pypi/simplejson?source=conda-forge-mapping
   size: 128950
   timestamp: 1696596106966
 - kind: conda
@@ -15055,7 +15512,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/simplejson
+  - pkg:pypi/simplejson?source=conda-forge-mapping
   size: 130931
   timestamp: 1696596072174
 - kind: conda
@@ -15075,7 +15532,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/simplejson
+  - pkg:pypi/simplejson?source=conda-forge-mapping
   size: 129515
   timestamp: 1696596080274
 - kind: conda
@@ -15097,7 +15554,7 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls:
-  - pkg:pypi/sip
+  - pkg:pypi/sip?source=conda-forge-mapping
   size: 576283
   timestamp: 1697300599736
 - kind: conda
@@ -15120,7 +15577,7 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls:
-  - pkg:pypi/sip
+  - pkg:pypi/sip?source=conda-forge-mapping
   size: 589657
   timestamp: 1697301028797
 - kind: conda
@@ -15137,57 +15594,58 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/six
+  - pkg:pypi/six?source=conda-forge-mapping
   size: 14259
   timestamp: 1620240338595
 - kind: conda
   name: snappy
-  version: 1.1.10
-  build: h225ccf5_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
-  sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
-  md5: 4320a8781f14cd959689b86e349f3b73
+  version: 1.2.1
+  build: h23299a8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
+  md5: 7635a408509e20dcfc7653ca305ad799
   depends:
-  - libcxx >=14.0.6
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 34657
-  timestamp: 1678534768395
+  size: 59350
+  timestamp: 1720004197144
 - kind: conda
   name: snappy
-  version: 1.1.10
-  build: h9fff704_0
+  version: 1.2.1
+  build: ha2e4443_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
-  sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  md5: e6d228cd0bb74a51dd18f5bfce0b4115
+  url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
+  sha256: dc7c8e0e8c3e8702aae81c52d940bfaabe756953ee51b1f1757e891bab62cf7f
+  md5: 6b7dcc7349efd123d493d2dbe85a045f
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 38865
-  timestamp: 1678534590321
+  size: 42465
+  timestamp: 1720003704360
 - kind: conda
   name: snappy
-  version: 1.1.10
-  build: hfb803bf_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
-  sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
-  md5: cff1df79c9cff719460eb2dd172568de
+  version: 1.2.1
+  build: he1e6707_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
+  sha256: a979319cd4916f0e7450aa92bb3cf4c2518afa80be50de99f31d075e693a6dd9
+  md5: ddceef5df973c8ff7d6b32353c0cb358
   depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
+  - __osx >=10.13
+  - libcxx >=16
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 57065
-  timestamp: 1678534804734
+  size: 37036
+  timestamp: 1720003862906
 - kind: conda
   name: sniffio
   version: 1.3.1
@@ -15202,7 +15660,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/sniffio
+  - pkg:pypi/sniffio?source=conda-forge-mapping
   size: 15064
   timestamp: 1708953086199
 - kind: conda
@@ -15221,7 +15679,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/snuggs
+  - pkg:pypi/snuggs?source=conda-forge-mapping
   size: 8136
   timestamp: 1568905295860
 - kind: conda
@@ -15239,136 +15697,133 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/soupsieve
+  - pkg:pypi/soupsieve?source=conda-forge-mapping
   size: 36754
   timestamp: 1693929424267
 - kind: conda
   name: spdlog
-  version: 1.12.0
-  build: h64d2f7d_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.12.0-h64d2f7d_2.conda
-  sha256: 4b582768ebb9d234c0a9e0eae482733f167d53e316f0f48aac19a028a83a8570
-  md5: e039fdff30fd25fbfc7cb91755d80a4f
+  version: 1.13.0
+  build: h1a4aec9_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.13.0-h1a4aec9_0.conda
+  sha256: 2f1a981d8d1e06511081ef10068c083965bf1ea0fe7546f8a5f1e37a2982110a
+  md5: 2288eabc17f9fec9b64dac2cfe07b8ac
   depends:
-  - fmt >=10.1.1,<11.0a0
+  - fmt >=10.2.1,<11.0a0
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 162075
+  timestamp: 1713902597770
+- kind: conda
+  name: spdlog
+  version: 1.13.0
+  build: h64d2f7d_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.13.0-h64d2f7d_0.conda
+  sha256: 7c5c8d6e2df300f7887e5488a21b11d854ffbc51a1b149af4164d6cbd225fd7a
+  md5: e21d3d1aef3973f78ee161bb053c5922
+  depends:
+  - fmt >=10.2.1,<11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 160999
-  timestamp: 1697421628776
+  size: 161230
+  timestamp: 1713902489730
 - kind: conda
   name: spdlog
-  version: 1.12.0
-  build: h8dd852c_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.12.0-h8dd852c_2.conda
-  sha256: 3bce42d94b4cd5672bde68ec47374e558b2bc481621f759f70b56bf3da12c31f
-  md5: 1be852e792cca50421504cee933e3063
-  depends:
-  - __osx >=10.9
-  - fmt >=10.1.1,<11.0a0
-  - libcxx >=16.0.6
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 161449
-  timestamp: 1697421663869
-- kind: conda
-  name: spdlog
-  version: 1.12.0
-  build: hd2e6256_2
-  build_number: 2
+  version: 1.13.0
+  build: hd2e6256_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.12.0-hd2e6256_2.conda
-  sha256: 34c2ac3ecafc109ea659087f2a429b8fd7c557eb75d072e723a9954472726e62
-  md5: f37afc6ce10d45b9fae2f55ddc635b9f
+  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.13.0-hd2e6256_0.conda
+  sha256: 2027b971e83a9c9d292c12880269fe08e782fe9b15b93b5a3ddc8697116e6750
+  md5: 18f9348f064632785d54dbd1db9344bb
   depends:
-  - fmt >=10.1.1,<11.0a0
+  - fmt >=10.2.1,<11.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 187863
-  timestamp: 1697421353980
+  size: 188328
+  timestamp: 1713902039030
 - kind: conda
   name: sphobjinv
-  version: 2.3.1
+  version: 2.3.1.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1-pyhd8ed1ab_0.conda
-  sha256: 38dfa70c707e35b93cff2a79043c01c2fa0c0ed5cda37ae2abdad047d6721567
-  md5: acdf6eee61eef569196651bf644d1b23
+  url: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.1-pyhd8ed1ab_0.conda
+  sha256: 7a5e727b2ee384f5d78596c808ef9fc147a0f3ceedb39dc42b2531d52df2e0d4
+  md5: 3503896d50f4e463bb86c77bab85ce07
   depends:
   - attrs >=19.2
   - certifi
   - jsonschema >=3.0
-  - python >=3.6
+  - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/sphobjinv
-  size: 68315
-  timestamp: 1669810397386
+  - pkg:pypi/sphobjinv?source=conda-forge-mapping
+  size: 69178
+  timestamp: 1716387030819
 - kind: conda
   name: sqlite
-  version: 3.45.2
-  build: h2c6b66d_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.45.2-h2c6b66d_0.conda
-  sha256: 22d2692c82b73480c9adc80472bfb241262586edaf1dac1a7504434e47185d3c
-  md5: 1423efca06ed343c1da0fc429bae0779
-  depends:
-  - libgcc-ng >=12
-  - libsqlite 3.45.2 h2797004_0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - readline >=8.2,<9.0a0
-  license: Unlicense
-  purls: []
-  size: 848420
-  timestamp: 1710254767782
-- kind: conda
-  name: sqlite
-  version: 3.45.2
-  build: h7461747_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.45.2-h7461747_0.conda
-  sha256: c9c1b7d6025d5efa74f4ddbda1ae72a721f041ad3d4a6ec3dda600befe9dffaa
-  md5: fc4dae09f6b38084f3bfc87c77032584
-  depends:
-  - libsqlite 3.45.2 h92b6c6a_0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - readline >=8.2,<9.0a0
-  license: Unlicense
-  purls: []
-  size: 900944
-  timestamp: 1710255034551
-- kind: conda
-  name: sqlite
-  version: 3.45.2
-  build: hcfcfb64_0
+  version: 3.46.0
+  build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.45.2-hcfcfb64_0.conda
-  sha256: 2d54418dff5cc35d3c5b99d7094d6ea9956cacbc9777df46c74020c4f8e32b39
-  md5: 329d25303ed8299f8f900344cd69a705
+  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.46.0-h2466b09_0.conda
+  sha256: 204edea00bb813d1e3da31dcd8caf1cb355ded08be3065ca53dea066bf75b827
+  md5: f60e557d64002fe9955b929226adf81d
   depends:
-  - libsqlite 3.45.2 hcfcfb64_0
+  - libsqlite 3.46.0 h2466b09_0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Unlicense
   purls: []
-  size: 873024
-  timestamp: 1710255122348
+  size: 885699
+  timestamp: 1718051144579
+- kind: conda
+  name: sqlite
+  version: 3.46.0
+  build: h28673e1_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.46.0-h28673e1_0.conda
+  sha256: 7d868d34348615450c43cb4737b44987a0e45fdf4759502b323494dc8c931409
+  md5: b76e50276ebb3131cb84aac8123ca75d
+  depends:
+  - __osx >=10.13
+  - libsqlite 3.46.0 h1b8f9f3_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  purls: []
+  size: 912413
+  timestamp: 1718050767696
+- kind: conda
+  name: sqlite
+  version: 3.46.0
+  build: h6d4b2fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.46.0-h6d4b2fc_0.conda
+  sha256: e849d576e52bf3e6fc5786f89b7d76978f2e2438587826c95570324cb572e52b
+  md5: 77ea8dff5cf8550cc8f5629a6af56323
+  depends:
+  - libgcc-ng >=12
+  - libsqlite 3.46.0 hde9e2c9_0
+  - libzlib >=1.2.13,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - readline >=8.2,<9.0a0
+  license: Unlicense
+  purls: []
+  size: 860352
+  timestamp: 1718050658212
 - kind: conda
   name: stack_data
   version: 0.6.2
@@ -15386,7 +15841,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/stack-data
+  - pkg:pypi/stack-data?source=conda-forge-mapping
   size: 26205
   timestamp: 1669632203115
 - kind: conda
@@ -15404,28 +15859,28 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/tabulate
+  - pkg:pypi/tabulate?source=conda-forge-mapping
   size: 35912
   timestamp: 1665138565317
 - kind: conda
   name: tbb
-  version: 2021.11.0
-  build: h91493d7_1
-  build_number: 1
+  version: 2021.12.0
+  build: hc790b64_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.11.0-h91493d7_1.conda
-  sha256: aa30c089fdd6f66c7808592362e29963586e094159964a5fb61fb8efa9e349bc
-  md5: 21069f3ed16812f9f4f2700667b6ec86
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_3.conda
+  sha256: 721a88d702e31efd9437d387774ef9157846743e66648f5f863b29ae322e8479
+  md5: a16e2a639e87c554abee5192ce6ee308
   depends:
-  - libhwloc >=2.9.3,<2.9.4.0a0
+  - libhwloc >=2.11.1,<2.11.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 161382
-  timestamp: 1706164225098
+  size: 161213
+  timestamp: 1720768916898
 - kind: conda
   name: terminado
   version: 0.18.1
@@ -15443,7 +15898,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/terminado
+  - pkg:pypi/terminado?source=conda-forge-mapping
   size: 22452
   timestamp: 1710262728753
 - kind: conda
@@ -15463,7 +15918,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/terminado
+  - pkg:pypi/terminado?source=conda-forge-mapping
   size: 22717
   timestamp: 1710265922593
 - kind: conda
@@ -15483,145 +15938,155 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/terminado
+  - pkg:pypi/terminado?source=conda-forge-mapping
   size: 22883
   timestamp: 1710262943966
 - kind: conda
   name: threadpoolctl
-  version: 3.4.0
+  version: 3.5.0
   build: pyhc1e730c_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
-  sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
-  md5: b296278eef667c673bf51de6535bad88
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.5.0-pyhc1e730c_0.conda
+  sha256: 45e402941f6bed094022c5726a2ca494e6224b85180d2367fb6ddd9aea68079d
+  md5: df68d78237980a159bd7149f33c0e8fd
   depends:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/threadpoolctl
-  size: 23032
-  timestamp: 1710943698793
+  - pkg:pypi/threadpoolctl?source=conda-forge-mapping
+  size: 23548
+  timestamp: 1714400228771
 - kind: conda
   name: tiledb
-  version: 2.21.2
-  build: h0d80af6_0
+  version: 2.25.0
+  build: h414c7de_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.25.0-h414c7de_2.conda
+  sha256: 6664734493c84582c03baf81346260a20ea532430eb046ec9e8c4fafdd4c2886
+  md5: 03e0dd1ce7e5b747655148f87770998e
+  depends:
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - fmt >=10.2.1,<11.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.9.0,<9.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.40.33810
+  - zstd >=1.5.6,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 3111452
+  timestamp: 1721927285210
+- kind: conda
+  name: tiledb
+  version: 2.25.0
+  build: h61fe09d_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.21.2-h0d80af6_0.conda
-  sha256: 5ea975c68f855a5cf617fb2c7a70c0814e57c3a84f6108a13b9fda89a5446a86
-  md5: 7b0a0b85bf1cea8aa81e273dfb4fc815
+  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.25.0-h61fe09d_2.conda
+  sha256: 227a11999321d462a45ae580be11bd31631cf7a3506ec524c29c4e14218a7664
+  md5: 07bab3e33a53a39355e2e081e81e8f76
   depends:
   - __osx >=10.13
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
-  - azure-storage-blobs-cpp >=12.10.0,<12.10.1.0a0
-  - azure-storage-common-cpp >=12.5.0,<12.5.1.0a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
   - bzip2 >=1.0.8,<2.0a0
   - fmt >=10.2.1,<11.0a0
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.7.1,<9.0a0
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.9.0,<9.0a0
   - libcxx >=16
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.1,<4.0a0
-  - spdlog >=1.12.0,<1.13.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 4158296
-  timestamp: 1712336061857
+  size: 3872645
+  timestamp: 1721926516320
 - kind: conda
   name: tiledb
-  version: 2.21.2
-  build: h25b666a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.21.2-h25b666a_0.conda
-  sha256: 48431fd4578f9316e978b0102e35b8963ab3c2b8b44e4f89cc3cae556cf4bc25
-  md5: 0d2ecc1e3a499e01fa3e696f5ade839c
-  depends:
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
-  - azure-storage-blobs-cpp >=12.10.0,<12.10.1.0a0
-  - azure-storage-common-cpp >=12.5.0,<12.5.1.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - fmt >=10.2.1,<11.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.7.1,<9.0a0
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.1,<4.0a0
-  - spdlog >=1.12.0,<1.13.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.5,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 3336315
-  timestamp: 1712335629912
-- kind: conda
-  name: tiledb
-  version: 2.21.2
-  build: ha9641ad_0
+  version: 2.25.0
+  build: h769197d_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.21.2-ha9641ad_0.conda
-  sha256: 414b441a41b40f509721d145f946b5e59c5d390b53ee04cf993302a73e6b5920
-  md5: 04fcd8b5da3c8c8cf17f6ba7e8f839f9
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.25.0-h769197d_2.conda
+  sha256: 3b4b697b2bd156341b8af4b7c7cffa7597c7d421d3d5d8157c026ecba1fd515f
+  md5: d80a6fe7ad3ee98875539a02e066c196
   depends:
-  - aws-crt-cpp >=0.26.4,<0.26.5.0a0
-  - aws-sdk-cpp >=1.11.267,<1.11.268.0a0
-  - azure-core-cpp >=1.11.1,<1.11.2.0a0
-  - azure-storage-blobs-cpp >=12.10.0,<12.10.1.0a0
-  - azure-storage-common-cpp >=12.5.0,<12.5.1.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-crt-cpp >=0.27.3,<0.27.4.0a0
+  - aws-sdk-cpp >=1.11.329,<1.11.330.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-common-cpp >=12.7.0,<12.7.1.0a0
   - bzip2 >=1.0.8,<2.0a0
   - fmt >=10.2.1,<11.0a0
   - libabseil * cxx17*
-  - libabseil >=20240116.1,<20240117.0a0
-  - libcurl >=8.7.1,<9.0a0
+  - libabseil >=20240116.2,<20240117.0a0
+  - libcurl >=8.9.0,<9.0a0
   - libgcc-ng >=12
-  - libgoogle-cloud >=2.22.0,<2.23.0a0
-  - libgoogle-cloud-storage >=2.22.0,<2.23.0a0
+  - libgoogle-cloud >=2.26.0,<2.27.0a0
+  - libgoogle-cloud-storage >=2.26.0,<2.27.0a0
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.1,<4.0a0
-  - spdlog >=1.12.0,<1.13.0a0
-  - zstd >=1.5.5,<1.6.0a0
+  - openssl >=3.3.1,<4.0a0
+  - spdlog >=1.13.0,<1.14.0a0
+  - zstd >=1.5.6,<1.6.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 4669892
-  timestamp: 1712334804806
+  size: 4358393
+  timestamp: 1721926256758
 - kind: conda
   name: tinycss2
-  version: 1.2.1
+  version: 1.3.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-  sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
-  md5: 7234c9eefff659501cd2fe0d2ede4d48
+  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.3.0-pyhd8ed1ab_0.conda
+  sha256: bc55e5899e66805589c02061e315bfc23ae6cc2f2811f5cc13fb189a5ed9d90f
+  md5: 8662629d9a05f9cff364e31ca106c1ac
   depends:
   - python >=3.5
   - webencodings >=0.4
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/tinycss2
-  size: 23235
-  timestamp: 1666100385187
+  - pkg:pypi/tinycss2?source=conda-forge-mapping
+  size: 25405
+  timestamp: 1713975078735
 - kind: conda
   name: tk
   version: 8.6.13
@@ -15632,7 +16097,7 @@ packages:
   sha256: 30412b2e9de4ff82d8c2a7e5d06a15f4f4fef1809a72138b6ccb53a33b26faf5
   md5: bf830ba5afc507c6232d4ef0fb1a882d
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
   purls: []
@@ -15667,7 +16132,7 @@ packages:
   md5: d453b98d9c83e71da0741bb0ff4d76bc
   depends:
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
   purls: []
@@ -15687,7 +16152,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/toml
+  - pkg:pypi/toml?source=conda-forge-mapping
   size: 18433
   timestamp: 1604308660817
 - kind: conda
@@ -15704,7 +16169,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/tomli
+  - pkg:pypi/tomli?source=conda-forge-mapping
   size: 15940
   timestamp: 1644342331069
 - kind: conda
@@ -15721,52 +16186,17 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/tomli-w
+  - pkg:pypi/tomli-w?source=conda-forge-mapping
   size: 10052
   timestamp: 1638551820635
 - kind: conda
   name: tornado
-  version: '6.4'
-  build: py312h41838bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4-py312h41838bb_0.conda
-  sha256: 558f50290a25d8da6071a8e951b2b0c2ef77f457254438fa7c19cb9ee9f5d952
-  md5: 2d2d1fde5800d45cb56218583156d23d
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/tornado
-  size: 840576
-  timestamp: 1708363459702
-- kind: conda
-  name: tornado
-  version: '6.4'
-  build: py312h98912ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4-py312h98912ed_0.conda
-  sha256: 5764795df60bd9fdbe54ec6df20ef2a94507b2a22b29be899b78745383bafab3
-  md5: e8332e534dca8c5c12c8352e0a23501c
-  depends:
-  - libgcc-ng >=12
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/tornado
-  size: 840527
-  timestamp: 1708363299520
-- kind: conda
-  name: tornado
-  version: '6.4'
-  build: py312he70551f_0
+  version: 6.4.1
+  build: py312h4389bb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4-py312he70551f_0.conda
-  sha256: 0ebb1cd17f63f47262c42114a2b0af2b8d0bc19b0ae52e90e312a77ff7c55270
-  md5: 98907504f8c3eb0452bb10362227ce16
+  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py312h4389bb4_0.conda
+  sha256: 1db4650b15e902828ecc67754eb287971879401ce35437f3a8c3c3da2158af2c
+  md5: 00a82356b77563593acad8b86de9c5c7
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -15776,47 +16206,84 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado
-  size: 844146
-  timestamp: 1708363742639
+  - pkg:pypi/tornado?source=conda-forge-mapping
+  size: 844267
+  timestamp: 1717723122629
+- kind: conda
+  name: tornado
+  version: 6.4.1
+  build: py312h9a8786e_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h9a8786e_0.conda
+  sha256: fcf92fde5bac323921d97f8f2e66ee134ea01094f14d4e99c56f98187241c638
+  md5: fd9c83fde763b494f07acee1404c280e
+  depends:
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/tornado?source=conda-forge-mapping
+  size: 839315
+  timestamp: 1717723013620
+- kind: conda
+  name: tornado
+  version: 6.4.1
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py312hbd25219_0.conda
+  sha256: efba7cd7d5c311f57fd1a658c0f8ae65f9c5f3c9c41111a689dcad45407944c8
+  md5: 5a40db69b327c71511248f8186965bd3
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/tornado?source=conda-forge-mapping
+  size: 842608
+  timestamp: 1717722844100
 - kind: conda
   name: traitlets
-  version: 5.14.2
+  version: 5.14.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.2-pyhd8ed1ab_0.conda
-  sha256: 9ea6073091c130470a51b51703c8d2d959434992e29c4aa4abeba07cd56533a3
-  md5: af5fa2d2186003472e766a23c46cae04
+  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
+  sha256: 8a64fa0f19022828513667c2c7176cfd125001f3f4b9bc00d33732e627dd2592
+  md5: 3df84416a021220d8b5700c613af2dc5
   depends:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/traitlets
-  size: 110288
-  timestamp: 1710254564088
+  - pkg:pypi/traitlets?source=conda-forge-mapping
+  size: 110187
+  timestamp: 1713535244513
 - kind: conda
   name: typeguard
-  version: 4.2.1
-  build: pyhd8ed1ab_0
+  version: 4.3.0
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.2.1-pyhd8ed1ab_0.conda
-  sha256: dd140e850215c729a50cbface4a1fc640dcc91f8da43ce467977a298c4dfe89a
-  md5: 47102c2390ebdc73a8a1843e77dab61e
+  url: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.3.0-pyhd8ed1ab_1.conda
+  sha256: 1bbf56b43b7a4f696e6d4027404865519bc676760129580ba558555dedfdcfa9
+  md5: 10f49ee1beb82947170c5a5e1a8c0ef3
   depends:
-  - importlib_metadata >=3.6
+  - importlib-metadata >=3.6
   - python >=3.8
-  - typing_extensions >=4.7.0
+  - typing-extensions >=4.10.0
   constrains:
   - pytest >=7
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/typeguard
-  size: 34007
-  timestamp: 1711272969310
+  - pkg:pypi/typeguard?source=conda-forge-mapping
+  size: 34547
+  timestamp: 1721540525136
 - kind: conda
   name: types-python-dateutil
   version: 2.9.0.20240316
@@ -15830,75 +16297,76 @@ packages:
   - python >=3.6
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/types-python-dateutil
+  - pkg:pypi/types-python-dateutil?source=conda-forge-mapping
   size: 21769
   timestamp: 1710590028155
 - kind: conda
   name: types-pytz
-  version: 2024.1.0.20240203
+  version: 2024.1.0.20240417
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240203-pyhd8ed1ab_0.conda
-  sha256: 60f9e4c3a7d4ca50f97c9297ed4ee41d6a8cde213f9618e8364fe456bfcb6efa
-  md5: 14db65dcfc51e3efe97920dd99c5646e
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2024.1.0.20240417-pyhd8ed1ab_0.conda
+  sha256: cc3913a5504b867c748981ba302e82dbc2bda71837f4894d29db8f6cb490e25d
+  md5: 7b71ace1b99195041329427c435b8125
   depends:
   - python >=3.6
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/types-pytz
-  size: 18672
-  timestamp: 1706931876487
+  - pkg:pypi/types-pytz?source=conda-forge-mapping
+  size: 18725
+  timestamp: 1713337633292
 - kind: conda
   name: types-requests
-  version: 2.31.0.20240406
-  build: pyhd8ed1ab_0
+  version: 2.32.0.20240712
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.31.0.20240406-pyhd8ed1ab_0.conda
-  sha256: de93470fe64b2baa5f8ef16a6edf849bb93542f301ed343d0ab4d6fd6116d742
-  md5: b4bc9b6dbc54191100b518a18be6045e
+  url: https://conda.anaconda.org/conda-forge/noarch/types-requests-2.32.0.20240712-pyhd8ed1ab_1.conda
+  sha256: 89c5c55ac0bdf1772ba2dbe890e803c588d5b4bf4e624c34f2e15c8fe5c17693
+  md5: a0493fcf860b2ca37d1c1d0f2952d63b
   depends:
-  - python >=3.6
+  - python >=3.8
   - urllib3 >=2
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/types-requests
-  size: 26072
-  timestamp: 1712378106245
+  - pkg:pypi/types-requests?source=conda-forge-mapping
+  size: 26286
+  timestamp: 1721398305880
 - kind: conda
   name: typing-extensions
-  version: 4.11.0
+  version: 4.12.2
   build: hd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.11.0-hd8ed1ab_0.conda
-  sha256: aecbd9c601ba5a6c128da8975276fd817b968a9edc969b7ae97aee76e80a14a6
-  md5: 471e3988f8ca5e9eb3ce6be7eac3bcee
+  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
+  sha256: d3b9a8ed6da7c9f9553c5fd8a4fca9c3e0ab712fa5f497859f82337d67533b73
+  md5: 52d648bd608f5737b123f510bb5514b5
   depends:
-  - typing_extensions 4.11.0 pyha770c72_0
+  - typing_extensions 4.12.2 pyha770c72_0
   license: PSF-2.0
   license_family: PSF
   purls: []
-  size: 10093
-  timestamp: 1712330094282
+  size: 10097
+  timestamp: 1717802659025
 - kind: conda
   name: typing_extensions
-  version: 4.11.0
+  version: 4.12.2
   build: pyha770c72_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
-  sha256: a7e8714d14f854058e971a6ed44f18cc37cc685f98ddefb2e6b7899a0cc4d1a2
-  md5: 6ef2fc37559256cf682d8b3375e89b80
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
+  sha256: 0fce54f8ec3e59f5ef3bb7641863be4e1bf1279623e5af3d3fa726e8f7628ddb
+  md5: ebe6952715e1d5eb567eeebf25250fa7
   depends:
   - python >=3.8
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/typing-extensions
-  size: 37583
-  timestamp: 1712330089194
+  - pkg:pypi/typing-extensions?source=conda-forge-mapping
+  size: 39888
+  timestamp: 1717802653893
 - kind: conda
   name: typing_inspect
   version: 0.9.0
@@ -15915,7 +16383,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/typing-inspect
+  - pkg:pypi/typing-inspect?source=conda-forge-mapping
   size: 14906
   timestamp: 1685820229594
 - kind: conda
@@ -15932,7 +16400,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/typing-utils
+  - pkg:pypi/typing-utils?source=conda-forge-mapping
   size: 13829
   timestamp: 1622899345711
 - kind: conda
@@ -15993,26 +16461,6 @@ packages:
   size: 1283972
   timestamp: 1666630199266
 - kind: conda
-  name: ucx
-  version: 1.15.0
-  build: ha691c75_8
-  build_number: 8
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
-  sha256: 85b40ac6607c9e4e32bcb13e95da41ff48a10f813df0c1e74ff32412e1f7da35
-  md5: 3f9bc6137b240642504a6c9b07a10c25
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - rdma-core >=51.0
-  constrains:
-  - cuda-version >=11.2,<12
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 6842006
-  timestamp: 1712025621683
-- kind: conda
   name: ukkonen
   version: 1.0.1
   build: py312h0d7def4_4
@@ -16031,7 +16479,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ukkonen
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 17235
   timestamp: 1695549871621
 - kind: conda
@@ -16051,7 +16499,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ukkonen
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 13246
   timestamp: 1695549689363
 - kind: conda
@@ -16072,7 +16520,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ukkonen
+  - pkg:pypi/ukkonen?source=conda-forge-mapping
   size: 14050
   timestamp: 1695549556745
 - kind: conda
@@ -16089,124 +16537,125 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/uri-template
+  - pkg:pypi/uri-template?source=conda-forge-mapping
   size: 23999
   timestamp: 1688655976471
 - kind: conda
   name: uriparser
-  version: 0.9.7
-  build: h1537add_1
-  build_number: 1
+  version: 0.9.8
+  build: h5a68840_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.7-h1537add_1.conda
-  sha256: 9b185e00da9829592300359e23e2954188d21749fda675a08abbef728f19f25b
-  md5: 5f3b2772564e761bc2287b89b9e6b14b
+  url: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
+  sha256: ed0eed8ed0343d29cdbfaeb1bfd141f090af696547d69f91c18f46350299f00d
+  md5: 28b4cf9065681f43cc567410edf8243d
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
+  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 48056
-  timestamp: 1677713151746
+  size: 49181
+  timestamp: 1715010467661
 - kind: conda
   name: uriparser
-  version: 0.9.7
-  build: h59595ed_1
-  build_number: 1
+  version: 0.9.8
+  build: h6aefe2f_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.8-h6aefe2f_0.conda
+  sha256: fec8e52955fc314580a93dee665349bf430ce6df19019cea3fae7ec60f732bdd
+  md5: 649890a63cc818b24fbbf0572db221a5
+  depends:
+  - __osx >=10.9
+  - libcxx >=16
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 43396
+  timestamp: 1715010079800
+- kind: conda
+  name: uriparser
+  version: 0.9.8
+  build: hac33072_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-h59595ed_1.conda
-  sha256: ec997599b6dcfef34242c67b695c4704d9ba6cb0b9de8f390defa475a95cdb3f
-  md5: c5edf07141147789784f89d5b4e4a9ad
+  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+  sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+  md5: d71d3a66528853c0a1ac2c02d79a0284
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 47956
-  timestamp: 1709156503114
-- kind: conda
-  name: uriparser
-  version: 0.9.7
-  build: he965462_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-he965462_1.conda
-  sha256: 1f3563325ce2f9b28b6dfbc703f3cac4d36095d2103c40648338533f4cb80b63
-  md5: a342f2d5573ebdb1cba60ef2947c1b7f
-  depends:
-  - libcxx >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 42933
-  timestamp: 1709156585404
+  size: 48270
+  timestamp: 1715010035325
 - kind: conda
   name: urllib3
-  version: 2.2.1
-  build: pyhd8ed1ab_0
+  version: 2.2.2
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
-  sha256: d4009dcc9327684d6409706ce17656afbeae690d8522d3c9bc4df57649a352cd
-  md5: 08807a87fa7af10754d46f63b368e016
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+  sha256: 00c47c602c03137e7396f904eccede8cc64cc6bad63ce1fc355125df8882a748
+  md5: e804c43f58255e977093a2298e442bb8
   depends:
   - brotli-python >=1.0.9
+  - h2 >=4,<5
   - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.7
+  - python >=3.8
+  - zstandard >=0.18.0
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/urllib3
-  size: 94669
-  timestamp: 1708239595549
+  - pkg:pypi/urllib3?source=conda-forge-mapping
+  size: 95048
+  timestamp: 1719391384778
 - kind: conda
   name: vc
   version: '14.3'
-  build: hcf57466_18
-  build_number: 18
+  build: h8a93ad2_20
+  build_number: 20
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-hcf57466_18.conda
-  sha256: 447a8d8292a7b2107dcc18afb67f046824711a652725fc0f522c368e7a7b8318
-  md5: 20e1e652a4c740fa719002a8449994a2
+  url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h8a93ad2_20.conda
+  sha256: 23ac5feb15a9adf3ab2b8c4dcd63650f8b7ae860c5ceb073e49cf71d203eddef
+  md5: 8558f367e1d7700554f7cdb823c46faf
   depends:
-  - vc14_runtime >=14.38.33130
+  - vc14_runtime >=14.40.33810
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 16977
-  timestamp: 1702511255313
+  size: 17391
+  timestamp: 1717709040616
 - kind: conda
   name: vc14_runtime
-  version: 14.38.33130
-  build: h82b7239_18
-  build_number: 18
+  version: 14.40.33810
+  build: ha82c5b3_20
+  build_number: 20
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
-  sha256: bf94c9af4b2e9cba88207001197e695934eadc96a5c5e4cd7597e950aae3d8ff
-  md5: 8be79fdd2725ddf7bbf8a27a4c1f79ba
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_20.conda
+  sha256: af3cfa347e3d7c1277e9b964b0849a9a9f095bff61836cb3c3a89862fbc32e17
+  md5: e39cc4c34c53654ec939558993d9dc5b
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.38.33130.* *_18
+  - vs2015_runtime 14.40.33810.* *_20
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
   purls: []
-  size: 749868
-  timestamp: 1702511239004
+  size: 751934
+  timestamp: 1717709031266
 - kind: conda
   name: virtualenv
-  version: 20.25.1
+  version: 20.26.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
-  sha256: 1ced4445cf72cd9dc344ad04bdaf703a08cc428c8c46e4bda928ad79786ee153
-  md5: 8797a4e26be36880a603aba29c785352
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.26.3-pyhd8ed1ab_0.conda
+  sha256: f78961b194e33eed5fdccb668774651ec9423a043069fa7a4e3e2f853b08aa0c
+  md5: 284008712816c64c85bf2b7fa9f3b264
   depends:
   - distlib <1,>=0.3.7
   - filelock <4,>=3.12.2
@@ -16215,33 +16664,33 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/virtualenv
-  size: 3148218
-  timestamp: 1708602229963
+  - pkg:pypi/virtualenv?source=conda-forge-mapping
+  size: 4363507
+  timestamp: 1719150878323
 - kind: conda
   name: vs2015_runtime
-  version: 14.38.33130
-  build: hcb4865c_18
-  build_number: 18
+  version: 14.40.33810
+  build: h3bf8584_20
+  build_number: 20
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
-  sha256: a2fec221f361d6263c117f4ea6d772b21c90a2f8edc6f3eb0eadec6bfe8843db
-  md5: 10d42885e3ed84e575b454db30f1aa93
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
+  sha256: 0c2803f7a788c51f28235a7228dc2ab3f107b4b16ab0845a3e595c8c51e50a7a
+  md5: c21f1b4a3a30bbc3ef35a50957578e0e
   depends:
-  - vc14_runtime >=14.38.33130
+  - vc14_runtime >=14.40.33810
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 16988
-  timestamp: 1702511261442
+  size: 17395
+  timestamp: 1717709043353
 - kind: conda
   name: watchdog
-  version: 4.0.0
+  version: 4.0.1
   build: py312h2e8e312_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/watchdog-4.0.0-py312h2e8e312_0.conda
-  sha256: 4b1eeaecccadf55a5c322e25290d75c8bed7b0d5e25fa6dfa03fc16fc9919fc4
-  md5: 186ec4486a2c5d738c002067665b50be
+  url: https://conda.anaconda.org/conda-forge/win-64/watchdog-4.0.1-py312h2e8e312_0.conda
+  sha256: 35c657fd70de86e69dd8fcb04697df660da79410b4098a263acab55d363117ef
+  md5: 29cbd97528b7f7ce91a59186e391c0db
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -16249,17 +16698,17 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/watchdog
-  size: 152911
-  timestamp: 1707295573907
+  - pkg:pypi/watchdog?source=conda-forge-mapping
+  size: 162034
+  timestamp: 1716562347718
 - kind: conda
   name: watchdog
-  version: 4.0.0
+  version: 4.0.1
   build: py312h7900ff3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/watchdog-4.0.0-py312h7900ff3_0.conda
-  sha256: db3ef9753934826c008216b198f04a6637150e1d91d72733148c0822e4a042a2
-  md5: 1b87b82dd803565550e6358c0790f3d2
+  url: https://conda.anaconda.org/conda-forge/linux-64/watchdog-4.0.1-py312h7900ff3_0.conda
+  sha256: c4786da0c938a65cea07e2bb3fe76dbeed6968c322994c66395176307cf78425
+  md5: 7cc94a3b5e9698eecc2c39dbf7a173db
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -16267,27 +16716,28 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/watchdog
-  size: 136845
-  timestamp: 1707295261797
+  - pkg:pypi/watchdog?source=conda-forge-mapping
+  size: 136444
+  timestamp: 1716561872155
 - kind: conda
   name: watchdog
-  version: 4.0.0
-  build: py312hc2c2f20_0
+  version: 4.0.1
+  build: py312hbd25219_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/watchdog-4.0.0-py312hc2c2f20_0.conda
-  sha256: f333e1f11d60e096d8b0f2b7dbe313fc9ee22d6c09f0a0cc7d3c9fed56ee48dd
-  md5: ebd7ea0d23052393f0a62efe8a508e99
+  url: https://conda.anaconda.org/conda-forge/osx-64/watchdog-4.0.1-py312hbd25219_0.conda
+  sha256: f20d599605b43e670d2f44a6ad76eb916e9d0980c70ac4df2bc527b3f005590a
+  md5: 7cecf3b27b6a0ba239695d2992a1a177
   depends:
+  - __osx >=10.13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - pyyaml >=3.10
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/watchdog
-  size: 144711
-  timestamp: 1707295580304
+  - pkg:pypi/watchdog?source=conda-forge-mapping
+  size: 144881
+  timestamp: 1716561920161
 - kind: conda
   name: wcwidth
   version: 0.2.13
@@ -16302,26 +16752,26 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/wcwidth
+  - pkg:pypi/wcwidth?source=conda-forge-mapping
   size: 32709
   timestamp: 1704731373922
 - kind: conda
   name: webcolors
-  version: '1.13'
+  version: 24.6.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
-  sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
-  md5: 166212fe82dad8735550030488a01d03
+  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.6.0-pyhd8ed1ab_0.conda
+  sha256: 6377de3bc05b80f25c5fe75f180a81fc8a6aa601d4b228161f75f78862d00a0f
+  md5: 419f2f6cf90fc7a6feee657752cd0f7b
   depends:
   - python >=3.5
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/webcolors
-  size: 18186
-  timestamp: 1679900907305
+  - pkg:pypi/webcolors?source=conda-forge-mapping
+  size: 18291
+  timestamp: 1717667379821
 - kind: conda
   name: webencodings
   version: 0.5.1
@@ -16337,26 +16787,26 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/webencodings
+  - pkg:pypi/webencodings?source=conda-forge-mapping
   size: 15600
   timestamp: 1694681458271
 - kind: conda
   name: websocket-client
-  version: 1.7.0
+  version: 1.8.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
-  sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
-  md5: 50ad31e07d706aae88b14a4ac9c73f23
+  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 44a5e3b97feef24cd719f7851cca9af9799dc9c17d3e0298d5856baab2d682f5
+  md5: f372c576b8774922da83cda2b12f9d29
   depends:
   - python >=3.8
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/websocket-client
-  size: 46626
-  timestamp: 1701630814576
+  - pkg:pypi/websocket-client?source=conda-forge-mapping
+  size: 47066
+  timestamp: 1713923494501
 - kind: conda
   name: wheel
   version: 0.43.0
@@ -16372,7 +16822,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/wheel
+  - pkg:pypi/wheel?source=conda-forge-mapping
   size: 57963
   timestamp: 1711546009410
 - kind: conda
@@ -16390,7 +16840,7 @@ packages:
   - python >=3.6
   license: PUBLIC-DOMAIN
   purls:
-  - pkg:pypi/win-inet-pton
+  - pkg:pypi/win-inet-pton?source=conda-forge-mapping
   size: 8191
   timestamp: 1667051294134
 - kind: conda
@@ -16422,7 +16872,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt
+  - pkg:pypi/wrapt?source=conda-forge-mapping
   size: 59057
   timestamp: 1699533259706
 - kind: conda
@@ -16440,7 +16890,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt
+  - pkg:pypi/wrapt?source=conda-forge-mapping
   size: 62482
   timestamp: 1699532968076
 - kind: conda
@@ -16460,155 +16910,134 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt
+  - pkg:pypi/wrapt?source=conda-forge-mapping
   size: 61358
   timestamp: 1699533495284
 - kind: conda
   name: xarray
-  version: 2024.3.0
-  build: pyhd8ed1ab_0
+  version: 2024.6.0
+  build: pyhd8ed1ab_1
+  build_number: 1
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.3.0-pyhd8ed1ab_0.conda
-  sha256: 74e4cea340517ce7c51c36efc1d544d3a98fcdb62a429b6b1a59a1917b412c10
-  md5: 772d7ee42b65d0840130eabd5bd3fc17
+  url: https://conda.anaconda.org/conda-forge/noarch/xarray-2024.6.0-pyhd8ed1ab_1.conda
+  sha256: 782aaa095b246f18c2486826d2a71d886b2b4b99c08378f2bfda5d61877e509b
+  md5: a6775bba72ade3fd777ccac04902202c
   depends:
   - numpy >=1.23
-  - packaging >=22
-  - pandas >=1.5
+  - packaging >=23.1
+  - pandas >=2.0
   - python >=3.9
   constrains:
-  - bottleneck >=1.3
-  - sparse >=0.13
+  - sparse >=0.14
   - nc-time-axis >=1.4
-  - scipy >=1.8
-  - zarr >=2.12
-  - flox >=0.5
   - netcdf4 >=1.6.0
-  - cartopy >=0.20
-  - h5netcdf >=1.0
-  - dask-core >=2022.7
-  - cftime >=1.6
-  - numba >=0.55
-  - hdf5 >=1.12
-  - iris >=3.2
+  - pint >=0.22
+  - dask-core >=2023.4
   - toolz >=0.12
-  - h5py >=3.6
-  - distributed >=2022.7
-  - matplotlib-base >=3.5
-  - seaborn >=0.11
-  - pint >=0.19
+  - cartopy >=0.21
+  - bottleneck >=1.3
+  - iris >=3.4
+  - zarr >=2.14
+  - matplotlib-base >=3.7
+  - h5py >=3.8
+  - hdf5 >=1.12
+  - cftime >=1.6
+  - h5netcdf >=1.1
+  - flox >=0.7
+  - distributed >=2023.4
+  - seaborn >=0.12
+  - numba >=0.56
+  - scipy >=1.10
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/xarray
-  size: 765419
-  timestamp: 1711742257463
+  - pkg:pypi/xarray?source=conda-forge-mapping
+  size: 788402
+  timestamp: 1718302275503
 - kind: conda
   name: xcb-util
-  version: 0.4.0
-  build: hd590300_1
-  build_number: 1
+  version: 0.4.1
+  build: hb711507_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
-  sha256: 0c91d87f0efdaadd4e56a5f024f8aab20ec30f90aa2ce9e4ebea05fbc20f71ad
-  md5: 9bfac7ccd94d54fd21a0501296d60424
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+  sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
+  md5: 8637c3e5821654d0edf97e2b0404b443
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<1.17.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 19728
-  timestamp: 1684639166048
+  size: 19965
+  timestamp: 1718843348208
 - kind: conda
   name: xcb-util-image
   version: 0.4.0
-  build: h8ee46fc_1
-  build_number: 1
+  build: hb711507_2
+  build_number: 2
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
-  sha256: 92ffd68d2801dbc27afe223e04ae7e78ef605fc8575f107113c93c7bafbd15b0
-  md5: 9d7bcddf49cbf727730af10e71022c73
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - xcb-util >=0.4.0,<0.5.0a0
+  - libxcb >=1.16,<1.17.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 24474
-  timestamp: 1684679894554
+  size: 24551
+  timestamp: 1718880534789
 - kind: conda
   name: xcb-util-keysyms
-  version: 0.4.0
-  build: h8ee46fc_1
-  build_number: 1
+  version: 0.4.1
+  build: hb711507_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
-  sha256: 8451d92f25d6054a941b962179180728c48c62aab5bf20ac10fef713d5da6a9a
-  md5: 632413adcd8bc16b515cab87a2932913
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<1.17.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 14186
-  timestamp: 1684680497805
+  size: 14314
+  timestamp: 1718846569232
 - kind: conda
   name: xcb-util-renderutil
-  version: 0.3.9
-  build: hd590300_1
-  build_number: 1
+  version: 0.3.10
+  build: hb711507_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
-  sha256: 6987588e6fff5892056021c2ea52f7a0deefb2c7348e70d24750e2d60dabf009
-  md5: e995b155d938b6779da6ace6c6b13816
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.13
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<1.17.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 16955
-  timestamp: 1684639112393
+  size: 16978
+  timestamp: 1718848865819
 - kind: conda
   name: xcb-util-wm
-  version: 0.4.1
-  build: h8ee46fc_1
-  build_number: 1
+  version: 0.4.2
+  build: hb711507_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
-  sha256: 08ba7147c7579249b6efd33397dc1a8c2404278053165aaecd39280fee705724
-  md5: 90108a432fb5c6150ccfee3f03388656
+  url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<1.17.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 52114
-  timestamp: 1684679248466
-- kind: conda
-  name: xerces-c
-  version: 3.2.5
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-h63175ca_0.conda
-  sha256: 21328b0442f2f86ad5bf14481ed60f56a8ebb765a68d158a57ec6f32eb55762b
-  md5: b1e07902b6bb7833db8cc4ec32f32dc7
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 3574165
-  timestamp: 1703093650967
+  size: 51689
+  timestamp: 1718844051451
 - kind: conda
   name: xerces-c
   version: 3.2.5
@@ -16631,36 +17060,56 @@ packages:
 - kind: conda
   name: xerces-c
   version: 3.2.5
-  build: hbbe9ea5_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hbbe9ea5_0.conda
-  sha256: 10487c0b28ee2303570c6d0867000587a8c36836fffd4d634d8778c494d16965
-  md5: ade166000a13c81d9a75f65281e302b0
+  build: he0c23c2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_1.conda
+  sha256: d90517c4ea257096a021ccb42742607e9ee034492aba697db1095321a871a638
+  md5: 0a0d85bb98ea8ffb9948afe5bcbd63f7
   depends:
-  - icu >=73.2,<74.0a0
-  - libcurl >=8.5.0,<9.0a0
-  - libcxx >=15
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1346161
-  timestamp: 1703093374769
+  size: 3547000
+  timestamp: 1721032032254
+- kind: conda
+  name: xerces-c
+  version: 3.2.5
+  build: hfb503d4_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/xerces-c-3.2.5-hfb503d4_1.conda
+  sha256: 58c07f66e7a9b6853bc25663ce83098ae0ef2dc8f8ac383b9e708d9cd1349813
+  md5: 0a0c50f248ec412e3225e2683b49d6cb
+  depends:
+  - __osx >=10.13
+  - icu >=75.1,<76.0a0
+  - libcurl >=8.8.0,<9.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1348901
+  timestamp: 1721031740491
 - kind: conda
   name: xkeyboard-config
-  version: '2.41'
-  build: hd590300_0
+  version: '2.42'
+  build: h4ab18f5_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
-  sha256: 56955610c0747ea7cb026bb8aa9ef165ff41d616e89894538173b8b7dd2ee49a
-  md5: 81f740407b45e3f9047b3174fa94eb9e
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.42-h4ab18f5_0.conda
+  sha256: 240caab7d9d85154ef373ecbac3ff9fb424add2029dbb124e949c6cbab2996dd
+  md5: b193af204da1bfb8c13882d131a14bd2
   depends:
   - libgcc-ng >=12
-  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libx11 >=1.8.9,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 898045
-  timestamp: 1707104384997
+  size: 388998
+  timestamp: 1717817668629
 - kind: conda
   name: xorg-kbproto
   version: 1.0.7
@@ -16712,22 +17161,23 @@ packages:
 - kind: conda
   name: xorg-libx11
   version: 1.8.9
-  build: h8ee46fc_0
+  build: hb711507_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
-  sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
-  md5: 077b6e8ad6a3ddb741fce2496dd01bec
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-hb711507_1.conda
+  sha256: 66eabe62b66c1597c4a755dcd3f4ce2c78adaf7b32e25dfee45504d67d7735c1
+  md5: 4a6d410296d7e39f00bacdee7df046e9
   depends:
   - libgcc-ng >=12
-  - libxcb >=1.15,<1.16.0a0
+  - libxcb >=1.16,<1.17.0a0
   - xorg-kbproto
   - xorg-xextproto >=7.3.0,<8.0a0
   - xorg-xproto
   license: MIT
   license_family: MIT
   purls: []
-  size: 828060
-  timestamp: 1712415742569
+  size: 832198
+  timestamp: 1718846846409
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
@@ -16916,21 +17366,21 @@ packages:
   timestamp: 1607291557628
 - kind: conda
   name: xyzservices
-  version: 2024.4.0
+  version: 2024.6.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.4.0-pyhd8ed1ab_0.conda
-  sha256: 4e095631b52a78bbd9b53f28eb79b0c8f448d9509cf0451e99c2f3f85576f114
-  md5: 93dffc47dadbe36a1a644f3f50d4979d
+  url: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2024.6.0-pyhd8ed1ab_0.conda
+  sha256: da2e54cb68776e62a708cb6d5f026229d8405ff4cfd8a2446f7d386f07ebc5c1
+  md5: de631703d59e40af41c56c4b4e2928ab
   depends:
   - python >=3.8
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/xyzservices
-  size: 46179
-  timestamp: 1712210047952
+  - pkg:pypi/xyzservices?source=conda-forge-mapping
+  size: 46663
+  timestamp: 1717752234053
 - kind: conda
   name: xz
   version: 5.2.6
@@ -17022,31 +17472,52 @@ packages:
 - kind: conda
   name: zeromq
   version: 4.3.5
-  build: h59595ed_1
-  build_number: 1
+  build: h75354e8_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_1.conda
-  sha256: 3bec658f5c23abf5e200d98418add7a20ff7b45c928ad4560525bef899496256
-  md5: 7fc9d3288d2420bb3637647621018000
+  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
+  sha256: bc9aaee39e7be107d7daff237435dfd8f791aca460a98583a36a263615205262
+  md5: 03cc8d9838ad9dd0060ab532e81ccb21
   depends:
+  - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - libsodium >=1.0.18,<1.0.19.0a0
   - libstdcxx-ng >=12
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 343438
-  timestamp: 1709135220800
+  size: 353229
+  timestamp: 1715607188837
 - kind: conda
   name: zeromq
   version: 4.3.5
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_1.conda
-  sha256: c9089e80a724a4d21f9df4bcc99ccbddb93c8cce3f6b0c9cb74b4f98b641dfc2
-  md5: e8867cc4d023f41f54bd64a33436b0a1
+  build: hde137ed_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
+  sha256: 871625ce993e6c61649b14659a3d1d6011fbb242b7d6a25cadbc6300b2356f32
+  md5: e56609055da6c658aa329d42a6c6b9f2
   depends:
+  - __osx >=10.13
+  - krb5 >=1.21.2,<1.22.0a0
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls: []
+  size: 304498
+  timestamp: 1715607961981
+- kind: conda
+  name: zeromq
+  version: 4.3.5
+  build: he1f189c_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
+  sha256: 0f375034a88659f764ce837f324698a883da227fcb517561ffaf6a89474211b4
+  md5: b755eb545c2728b9a53729f02e627834
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
   - libsodium >=1.0.18,<1.0.19.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -17054,141 +17525,192 @@ packages:
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 4199151
-  timestamp: 1709135717106
-- kind: conda
-  name: zeromq
-  version: 4.3.5
-  build: h93d8f39_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
-  sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
-  md5: 4c055e46b394be36681fe476c1e2ee6e
-  depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libsodium >=1.0.18,<1.0.19.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  purls: []
-  size: 294253
-  timestamp: 1697057208271
+  size: 2707065
+  timestamp: 1715607874610
 - kind: conda
   name: zipp
-  version: 3.17.0
+  version: 3.19.2
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+  sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
+  md5: 49808e59df5535116f6878b2a820d6f4
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp
-  size: 18954
-  timestamp: 1695255262261
+  - pkg:pypi/zipp?source=conda-forge-mapping
+  size: 20917
+  timestamp: 1718013395428
 - kind: conda
   name: zlib
-  version: 1.2.13
-  build: h8a1eda9_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-  sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
-  md5: 75a8a98b1c4671c5d2897975731da42d
-  depends:
-  - libzlib 1.2.13 h8a1eda9_5
-  license: Zlib
-  license_family: Other
-  purls: []
-  size: 90764
-  timestamp: 1686575574678
-- kind: conda
-  name: zlib
-  version: 1.2.13
-  build: hcfcfb64_5
-  build_number: 5
+  version: 1.3.1
+  build: h2466b09_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
-  sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
-  md5: a318e8622e11663f645cc7fa3260f462
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
+  sha256: 76409556e6c7cb91991cd94d7fc853c9272c2872bd7e3573ff35eb33d6fca5be
+  md5: f8e0a35bf6df768ad87ed7bbbc36ab04
   depends:
-  - libzlib 1.2.13 hcfcfb64_5
+  - libzlib 1.3.1 h2466b09_1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Zlib
   license_family: Other
   purls: []
-  size: 107711
-  timestamp: 1686575474476
+  size: 108081
+  timestamp: 1716874767420
 - kind: conda
   name: zlib
-  version: 1.2.13
-  build: hd590300_5
-  build_number: 5
+  version: 1.3.1
+  build: h4ab18f5_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-  sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
-  md5: 68c34ec6149623be41a1933ab996a209
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
+  sha256: cee16ab07a11303de721915f0a269e8c7a54a5c834aa52f74b1cc3a59000ade8
+  md5: 9653f1bf3766164d0e65fa723cabbc54
   depends:
   - libgcc-ng >=12
-  - libzlib 1.2.13 hd590300_5
+  - libzlib 1.3.1 h4ab18f5_1
   license: Zlib
   license_family: Other
   purls: []
-  size: 92825
-  timestamp: 1686575231103
+  size: 93004
+  timestamp: 1716874213487
+- kind: conda
+  name: zlib
+  version: 1.3.1
+  build: h87427d6_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
+  sha256: 41bd5fef28b2755d637e3a8ea5c84010628392fbcf80c7e3d7370aaced7ee4fe
+  md5: 3ac9ef8975965f9698dbedd2a4cc5894
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 h87427d6_1
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 88782
+  timestamp: 1716874245467
+- kind: conda
+  name: zstandard
+  version: 0.23.0
+  build: py312h331e495_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h331e495_0.conda
+  sha256: c1d379d1062f23e3fbd3dd8548fc6cf61b23d6f96b11e78c4e01f4761580cb02
+  md5: fb62d40e45f51f7d6a7df47c9a12caf4
+  depends:
+  - __osx >=10.13
+  - cffi >=1.11
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=conda-forge-mapping
+  size: 411066
+  timestamp: 1721044218542
+- kind: conda
+  name: zstandard
+  version: 0.23.0
+  build: py312h3483029_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h3483029_0.conda
+  sha256: 7e1e105ea7eab2af591faebf743ff2493f53c313079e316419577925e4492b03
+  md5: eab52e88c858d87cf5a069f79d10bb50
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.11
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=conda-forge-mapping
+  size: 416708
+  timestamp: 1721044154409
+- kind: conda
+  name: zstandard
+  version: 0.23.0
+  build: py312h7606c53_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_0.conda
+  sha256: 907edf473419a5aff6151900d09bb3f2b2c2ede8964f20ae87cb6fae04d0cbb7
+  md5: c405924e081cb476495ffe72c88e92c2
+  depends:
+  - cffi >=1.11
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=conda-forge-mapping
+  size: 320649
+  timestamp: 1721044547910
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: h12be248_0
+  version: 1.5.6
+  build: h0ea2cb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 343428
-  timestamp: 1693151615801
+  size: 349143
+  timestamp: 1714723445995
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: h829000d_0
+  version: 1.5.6
+  build: h915ae27_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
-  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - __osx >=10.9
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 499383
-  timestamp: 1693151312586
+  size: 498900
+  timestamp: 1714723303098
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: hfc55251_0
+  version: 1.5.6
+  build: ha6fb4c9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  md5: 04b88013080254850d6c01ed54810589
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 545199
-  timestamp: 1693151163452
+  size: 554846
+  timestamp: 1714722996770

--- a/pixi.toml
+++ b/pixi.toml
@@ -77,7 +77,7 @@ bokeh_helpers = { path = "src/bokeh_helpers", editable = true }
 # ribasim = { path = "../Ribasim/python/ribasim", editable = true }
 
 [feature.prod.dependencies]
-ribasim = "==2024.9.0"
+ribasim = "==2024.10.0"
 
 [environments]
 default = { features = ["common", "prod"] }

--- a/src/peilbeheerst_model/Shortest_path/01_shortest_path_Hollandse_Delta.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/01_shortest_path_Hollandse_Delta.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Holandse Delta\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2bb462c-de8e-4bb7-8cb9-0b0fa4a78744",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d791aa6-f02a-4f02-98f3-8ee58081113c",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -528,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3ce7fec-3924-4d0a-be2b-0c9dea364bce",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57b2d1c7-5732-46b6-bdc1-9129c638d11d",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -546,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16f8245b-a13d-4ee0-bafd-4415215756a1",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -554,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140144ed-d4ad-40fb-a23c-54245c5d5e33",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/02_shortest_path_HHSK.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/02_shortest_path_HHSK.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# HHSK\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59146188-1742-4af0-bcfc-b7728c6d545a",
+   "id": "9",
    "metadata": {
     "tags": []
    },
@@ -522,7 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d58fac6e-e857-477e-980d-4280a4c6474e",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -530,7 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95bb5a73-5423-43c8-b574-47ff3f579a32",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -538,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "745bee38-d8c5-48f8-9c3a-c3b312705e40",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -546,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f6739ca-446b-4f66-9601-bd11d4c49b66",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -554,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f9adeef-1375-49a1-8187-748919c7f0ab",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -562,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c4bee1d-124a-4c98-9ac2-1a486792ebc3",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -570,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc11f212-7b6e-40a9-a575-0ca54166fb6a",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -578,7 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0e8711a-402d-43dc-85f3-284398a293be",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -586,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "541d0851-3c4f-49af-8674-a06e8e7411ca",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -594,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffe1f5f9-2152-4989-876f-d79c8940cc5c",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -602,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21acb4e0-04c8-4aed-9e69-80563fa8b8d3",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -610,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f9dd3b5-37b5-4aa8-8e1a-c4d0ba515196",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/03_shortest_path_HHNK.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/03_shortest_path_HHNK.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# HHNK\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -97,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13212628-133f-42dd-aeb5-c34bf1e8f435",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c4f967d-b685-4a49-a182-fbc9cca6ee7d",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -528,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1b488e5-78b6-45fb-afdc-2ca79ebcafab",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -536,7 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5263746-4dc9-49e1-acc6-8449976b315d",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -544,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60f5290d-301f-4e15-add5-0c9106df15af",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/04_shortest_path_Delfland.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/04_shortest_path_Delfland.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Delfland\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -97,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59146188-1742-4af0-bcfc-b7728c6d545a",
+   "id": "9",
    "metadata": {
     "tags": []
    },
@@ -521,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84b3ce94-f28b-45d6-b6cb-9b77dd3eaff5",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -529,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c4f967d-b685-4a49-a182-fbc9cca6ee7d",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -537,7 +537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ff512e8-41f3-41ef-9e05-55e175dedcb6",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/05_shortest_path_Scheldestromen.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/05_shortest_path_Scheldestromen.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Scheldestromen\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d04e7e2-63b5-491b-a986-cd3a84e25c29",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -99,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59146188-1742-4af0-bcfc-b7728c6d545a",
+   "id": "9",
    "metadata": {
     "tags": []
    },
@@ -523,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b6b8a23-9582-4a1f-9626-1b14e1970851",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -531,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0ec2b35-0ecf-41c3-9ae0-ec0a6f78f539",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -539,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca0b6913-e34a-4977-a098-90d07ea90d92",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -547,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "357e865b-a27a-4de3-ae1b-11731834f609",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -555,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70e4fa82-a1e3-445c-bbe5-ef44c7a73bf5",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -563,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "201a1c7c-6a8f-42af-a825-f0c905aa1c3e",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -571,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111c993e-e0cd-4ebf-8aac-58d324ca1551",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -579,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa83ad49-c972-4e55-9874-cbf654c9fc19",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/06_shortest_path_Zuiderzeeland.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/06_shortest_path_Zuiderzeeland.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Zuiderzeeland\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e945f279-54f4-4954-b212-0af6b663d896",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -99,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a73cacaf-62fe-4b21-8e49-0ff705738a8c",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,14 +255,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96661f45-afef-4306-a41c-095485f8c24c",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "9",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -271,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16810282-9a70-4093-8e54-5afa01c1cf25",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac1568c4-a8b8-4e9f-a37f-0eb9176059eb",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42fd8b2f-b56b-462e-b399-72e606a3d0ae",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -549,7 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e1f06bd-c787-4999-bda3-1209b128e7b3",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/07_shortest_path_WSRL.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/07_shortest_path_WSRL.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# WSRL\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -97,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26ff4598-f510-4cbd-9be2-55b7877eef6b",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31c7f876-5d69-44e6-92d9-7c78ba56c157",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -527,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25413b2b-afee-4596-a41d-b7e7f7af77c7",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -535,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b6b912e-978a-4fc0-a104-9d0e25046ea3",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -543,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24807ea4-2f03-474d-8fe7-99b47e6e6b4b",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -551,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcedee16-b88f-494f-bbec-91a38925015e",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -559,7 +559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e2d8943-c6da-4d32-9c96-9ae7c2b3d8d7",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/08_shortest_path_Wetterskip.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/08_shortest_path_Wetterskip.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Wetterskip\n",
@@ -15,7 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a3dd6e-9bdd-4e9c-90b9-5ddc472c015f",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cad7da9a-c301-472b-86d7-7ab2ca3efcb0",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -528,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b634e656-8880-4d46-b0b8-fe956494d2b1",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -536,7 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c4f967d-b685-4a49-a182-fbc9cca6ee7d",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -544,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79a7b82d-c7db-4ec5-aa08-9d2b209c11cc",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -552,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63c1171b-4bbc-4758-9d71-eb387dd4b6bd",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -560,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7df95885-2062-4b24-af4b-2a97aef31d9b",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/09_shortest_path_Rijnland.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/09_shortest_path_Rijnland.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Rijnland\n",
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -98,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -262,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e1d671b-e467-455b-993f-81269838270c",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9d49d31-c50d-4123-b4c7-00ff1f7b71b6",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "959e07be-797e-4cfb-a303-2bbb1a7a5a89",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -538,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "233e66a9-9887-4581-ad73-dc73a97cba73",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -546,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a6a0f39-d8b5-4392-ad3d-77ce1cbc4df1",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -554,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "727ed3bb-e0c7-47e9-a3d5-924e58927073",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -562,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f40f2a8f-23d2-4354-a30d-e2376a037867",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.ipynb
+++ b/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "924705f1-1daf-4219-88d9-21fab4b99cff",
+   "id": "0",
    "metadata": {},
    "source": [
     "# AGV\n",
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1af9481d-973d-4984-ab7f-49c1aaf3360b",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bafc03b1-cdd1-422b-bdba-009e9722b6b1",
+   "id": "2",
    "metadata": {},
    "source": [
     "### Load Data"
@@ -44,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0803592-1a07-461d-9432-937520958dbb",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51000003-77ac-4227-8d51-3845b7755d22",
+   "id": "4",
    "metadata": {},
    "source": [
     "### Select rhws"
@@ -73,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d09e1f8b-6c3b-473b-92ef-79f81973960e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bd2d0fe-6649-4368-8a83-c1e177fc34f7",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Define functions\n",
@@ -101,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "653be271-3e5d-4d57-a8eb-65bc8b128e9e",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63cb73d3-eea9-4a88-804a-ac35671bf75f",
+   "id": "8",
    "metadata": {},
    "source": [
     "# Shortest Path"
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8140d171-9b43-41f3-897e-3318f8550162",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03ce45a6-8886-4a5a-bff0-dc8fcf06fd24",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -532,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be6d7c8b-0646-4e4d-9ec3-476e47b06ffa",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -540,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad45df54-5444-49ab-83dd-c34f8ffe3861",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -548,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f7f47b2-d373-4999-84e5-a40747fc90c2",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -556,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7d2b7a3-ed32-4043-84a1-a63270ad95ce",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -564,7 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f124d72-cb6c-4ddb-99f0-5d0fd48c4a0f",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -572,7 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7143ef4b-27bb-4ae6-aaf1-fcce3183c6d8",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -580,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7bbe716-0a90-4983-a640-9f5982ff5c88",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -588,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "542fc6e1-b590-4f2d-b409-98a2017b36d2",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -596,7 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78f6252c-7fbc-4dc4-b872-7c75700d24bf",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -604,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fc7847d-656b-4cdb-a93e-0f7737f572e5",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -612,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103f49f7-18de-4b45-b3b0-45e4e7ee7197",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -620,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59146188-1742-4af0-bcfc-b7728c6d545a",
+   "id": "22",
    "metadata": {
     "tags": []
    },
@@ -871,7 +871,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d58fac6e-e857-477e-980d-4280a4c6474e",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -879,7 +879,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c8b4541-b929-445b-8013-6781a15a2901",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_WSRL.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_WSRL.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# WSRL"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## WSRL"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load Files"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c0d88a9-1141-4f86-8345-0eb4678eadc1",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed0d59f7-011b-4114-94ff-791d9c8ba514",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -128,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f40630a-2a94-42f7-8ee6-7b74bcde912e",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06e7be9e-6154-457e-b0ee-3c1c83a5d9f4",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +167,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2044eb8-c047-4830-8816-2e4af251020a",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2c9f5ef-364a-47b6-ae0c-ffc4e7072108",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad5df059-48f2-4a5d-a911-e924b6e44116",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Adjust globalid, code, nen3610id ['streefpeil'], ['peilgebied']"
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a9719a8-9003-42bf-88d8-dc0e14a6235c",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7099292c-fbe8-448b-bcb9-d512852168ba",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "517f54ec-74da-4247-9984-f3dbe770a508",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -247,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37606d1c-0408-4dc7-a4cc-72147b35aabd",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e56bed85-30fb-4aaa-bf2c-55a0432857f2",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0480ec4-0826-47b9-9e57-88a35d4ebd6f",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +291,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dbe4b9a-b7b2-429f-ae0c-408cc61134d8",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Create buffer layer that ensures spatial match between peilgebied and hws layers based on the buffer layer"
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e44043cf-0ea3-47ab-85ab-3af1c85dd3a7",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +318,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9628396-f882-419e-a265-424cfcb15b24",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Add buffer to ['peilgebied']"
@@ -326,7 +326,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd9a7f41-d404-4512-9639-777d8ac73bed",
+   "id": "23",
    "metadata": {},
    "source": [
     "## Add buffer to ['peilgebied','streefpeil']"
@@ -335,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac737828-1f7e-42ab-9f37-45e0fd1e189c",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f48bd18b-8f73-46fb-90be-2bb629cd7e00",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +361,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "997ba837-686c-4a6d-81a4-a92682428196",
+   "id": "26",
    "metadata": {},
    "source": [
     "## Store output"
@@ -370,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b7ca695-ba56-46a4-bd0f-ced939947deb",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_agv.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_agv.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Amstel Gooi en Vecht"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Amstel Gooi en Vecht"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load Files"
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1d63576-29bb-4157-b3fa-d6c7404e3ccf",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -131,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b89385dd-5d81-4bea-9627-7750b1842e9c",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20c9cd68-0b21-4a6e-8945-fadd79c7d2d7",
+   "id": "9",
    "metadata": {},
    "source": [
     "## RHWS is not included in AGV bron data, therefore create inverse difference layer to extract"
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86d6751e-068d-4563-ba7f-30b1b363db71",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09d49cea-cfba-454a-b29a-b22f93064617",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6edfd80-f81c-4659-9d8d-1dec3f91a23c",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa787842-0a11-4d0f-ba5e-04566370a9fb",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "361025ff-51b6-4a45-9fa5-d3d3698611dc",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Add rhws to ['peilgebied','streefpeil']"
@@ -233,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3164fa66-d75f-498e-bc88-56532faee31b",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89ba7b08-3b2a-4058-9946-e82e19bfe4e3",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "afef1983-b814-4d0d-bc07-ad88539a5459",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f005124-3aa6-4b04-baa1-6e38736cd2c6",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b735a861-3ef3-4db4-b9eb-fd89dc47aca7",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81991696-fd4d-490d-9129-98f091d64f91",
+   "id": "20",
    "metadata": {},
    "source": [
     "## Store output"
@@ -319,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b70f5533-bc4f-4554-a3f1-e0d4085fea90",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_delfland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_delfland.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Delfland"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Set Paths"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Load files"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5556d211-e92e-4ba3-85c2-4ff9bd33fbeb",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c70bb838-9d93-4d5a-ae12-2da18d145009",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fbca5734-774b-4327-bb0a-1c2a68afe982",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d28b061b-117d-4e71-b737-f759953951d9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fada8dca-0d9d-4619-b03e-403d3d19009a",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -177,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16fe0d25-7dd4-410a-9bec-5a69aced0614",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8061cb15-b0ba-47b7-afa0-caed45438ae4",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Add HWS to ['peilgebied', 'streefpeil']"
@@ -210,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c12f62cb-60b3-4a43-b26c-6ea1f36f4606",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68dad130-b22b-47f2-bb20-dc88f33d4614",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3634cbd6-d698-460b-95c3-0737d2d12388",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Create buffer layer that ensures spatial match between peilgebied and hws layers based on the buffer layer"
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8a24a33-7382-4fea-b45e-950dffb59f2c",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a7d781e-3fe5-4239-b8c1-5f61d4b87460",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Add buffer to ['peilgebied','streefpeil']"
@@ -274,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e22637f0-8fdd-4971-b602-7cf4bed8584a",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a40dac33-9a57-4a17-8303-89836afbc8ed",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52f756f2-cf33-408a-9104-4f7d95a5d4eb",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Write output"
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38b5a11a-bf29-4958-af68-baab619e5e51",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_rijnland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_rijnland.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Rijnland"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Rijnland"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load Files"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "623a0316-463e-444e-af95-d409c962fd21",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -117,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98c82db0-4036-4ffa-ae1b-4400f5c28a58",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "240d4f27-3149-49db-82c2-aeb208b8bdb8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08cf410b-78c1-47ab-b32c-e0ed60ebd7ec",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9739ed5-7eaa-4255-bf5d-04d419530de8",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -177,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73f6c0f2-8f3c-4b63-a36a-508bd0c0f1ce",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,14 +206,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d46f98a-f363-4b88-8c48-1e3ec421f9f7",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "ca30ba30-617e-4263-9c3c-ebd93b42ac08",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Add rhws to ['peilgebied','streefpeil']"
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3315f190-afef-4ed5-ae4b-3f7aa3ec6df2",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd6ea3c8-c159-43b9-bd28-b8cd54d790b1",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a23b8673-850f-4c3a-a1d2-d2a3aa148a7d",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8661eed7-0552-4f93-acad-62f1af2482d9",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7dd6604c-fe9e-4414-a477-d68978cf4c22",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bef23083-aaaa-409c-8527-46b5db303076",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -308,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ce0e159-be7d-477e-8b4a-211698dd0693",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -316,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be3fcd61-67eb-418b-8723-28738d034f9d",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "931f83ff-36e4-47e4-a7df-281e375e6c51",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -332,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dafe764-dc08-4444-9902-4c3b118ee4c7",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -340,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16c0af56-69e1-4e4a-b74a-9fe80faacecc",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -348,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b37a5f6-f2ba-40c7-9111-082a2afd2ed2",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -356,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7ec3300-8d06-403c-bb5e-41a6de329b2d",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0f978d1-4d00-4595-a62d-5503f320b6d7",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -372,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f09ef95-f0ff-4216-ac2e-a5b6a05b1ac0",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -380,14 +380,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fdfe9a6-21f8-41e7-8e5e-f1a9a91147d3",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "5556d211-e92e-4ba3-85c2-4ff9bd33fbeb",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Select waterschap boundaries"
@@ -396,7 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c70bb838-9d93-4d5a-ae12-2da18d145009",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +406,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3634cbd6-d698-460b-95c3-0737d2d12388",
+   "id": "33",
    "metadata": {},
    "source": [
     "### Create inverse layer"
@@ -415,7 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e183a1dd-c4dc-4518-8b1b-6052b55b547d",
+   "id": "34",
    "metadata": {
     "tags": []
    },
@@ -437,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8a24a33-7382-4fea-b45e-950dffb59f2c",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a19deee-0ce2-4928-abd7-462f5e218796",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e22637f0-8fdd-4971-b602-7cf4bed8584a",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +469,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c37b2c7b-8123-4dfb-a4c5-5d2ba817ba68",
+   "id": "38",
    "metadata": {},
    "source": [
     "### Calculate area of polygons and filter"
@@ -478,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a85b50f7-bc55-4442-8564-102b227b855a",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9a0fb83-cd34-402f-85c7-5cc88970ddbe",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59084cce-306c-42d7-942a-57c680c99172",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aaea472b-8336-4b94-899a-5fbcf9117b92",
+   "id": "42",
    "metadata": {},
    "source": [
     "### Add boezem when peilgebied is part of dm_netwerk"
@@ -525,7 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49bd0a1d-9b4b-4831-befd-050a288022ca",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00f7a36e-416c-46f6-8656-b5f2aea6e3ef",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +546,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78286e27-fa00-4cb6-83fe-d8f3b8eee453",
+   "id": "45",
    "metadata": {},
    "source": [
     "### Add HWS_BZM flag to boezem polygons"
@@ -555,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f90fe14-6bc8-46a3-aecf-72f5edee5c3e",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ab078c0-cca9-43f1-b9e3-2d86aec2a65c",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9ece8fc-5ed3-4c6e-810e-ce5ce35dc6b6",
+   "id": "48",
    "metadata": {},
    "source": [
     "### Merge boezem and peilgebied layers"
@@ -594,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2184f2b9-7383-41d8-a994-1986465076c8",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "024410a5-e3a9-4992-8c58-f63d78559a05",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc055918-71f0-48b2-923a-addb9541fff9",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a83e59e4-4333-485d-906c-ba95793c19bc",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba2624c6-10a1-4bec-a9ca-d287306f223d",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_wetterskip.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_wetterskip.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Wetterskip"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and make sure the peilgebieden neatly match the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Set Paths"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Load Files"
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc4a7b18-311d-4a29-ba13-df3d587e60b2",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -120,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5eae4c4-2d5a-4678-a5af-56e3626d29ec",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f141d0fe-6f1f-471f-acf1-4f11522bd15d",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Check Peilgebied and HWS layer overlap:\n",
@@ -146,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56faab44-3fda-43c4-8426-197fbb6c63a8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d4b936d-e24d-46b0-9c04-429290c39ade",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -180,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ad958c4-01ce-4fcb-9170-fa8bf0f7c7f0",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +198,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2187ad3d-4399-42b1-9d50-5183ff374326",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -207,7 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28509a06-79c9-4e68-9be7-dcf654494c90",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37bec5bb-70dd-4789-9f92-bcfcd571d790",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "535a4c9b-0393-499f-8db2-fbde84459a85",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2499b90-db91-49b7-9dc5-f43d2de46e3f",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Create buffer polygon between NHWS and peilgebied/RHWS"
@@ -260,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3ee584a-4ac9-47fd-8006-4be11e9d02a4",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a796dae1-e578-45c2-abc4-bd0f660f2175",
+   "id": "19",
    "metadata": {},
    "source": [
     "### Add buffer to ['peilgebied','streefpeil']"
@@ -287,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42af7580-3cdf-4d7c-9204-50bec3dc088d",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc785a36-81a6-4c79-affc-a0938d78beb5",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffb583ff-6707-48af-b3db-b35465eb949e",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Wetterskip data contains many duplicate peilgebieden"
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ca97726-e159-4cae-be86-b99232a80d56",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Calculate polygons that overlap with more than 90 % of their area"
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c234dbaf-5345-442e-9fe4-d458a8ed225c",
+   "id": "24",
    "metadata": {
     "jupyter": {
      "outputs_hidden": true
@@ -407,7 +407,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e377aaf-adcd-4a0d-b225-48705f0a7f97",
+   "id": "25",
    "metadata": {},
    "source": [
     "### Create list of duplicates for removal"
@@ -416,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d8b87a6-2e74-4b0e-9a2e-40734e38ec77",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +438,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f8737e0-aea1-49fb-8a48-8a8afc52f3f8",
+   "id": "27",
    "metadata": {},
    "source": [
     "### Remove duplicates"
@@ -447,7 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41cc52dc-a5ab-4879-ba6d-95edc7130479",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed9019dc-6278-4761-b30b-2a7f9b3757b9",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Store data"
@@ -466,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65bafa4a-7c96-4fae-870d-821aa638d322",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d305c771-459d-4240-b727-0a7f5ee2b409",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -486,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e0b6031e-e572-48b6-aff4-ffb474ddc045",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_zuiderzeeland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_zuiderzeeland.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {
     "tags": []
    },
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer:\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2434b6d-2898-45f8-a5cb-fbb9c2c2e77b",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Zuiderzeeland"
@@ -48,7 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load Files"
@@ -78,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b37e2158-618d-4dd0-a576-7cb32e41c0d2",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5e7495b-8517-4729-b586-7e1913dbbd83",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b93b71dd-7176-42ae-bf4e-f31a429b229a",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76cd16f7-c2cd-4ef7-b478-42359e0f8735",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7f16af4-fc46-4533-93b6-ee52d6d7687c",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5dcaab7b-5abe-431a-b890-9d19be3254f2",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied']"
@@ -210,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec5c9dde-2698-4a73-9fce-266a3c5e96d7",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51415106-fb75-4dad-97ba-4b046cb1f545",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Add HWS to ['streefpeil']"
@@ -236,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e61effa-42ae-46d7-879e-d7fa928ebd8d",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1c16adb-759d-41ae-b864-513aaafff8ac",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Create buffer layer that ensures spatial match between peilgebied and hws layers based on the buffer layer"
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1317fbfd-b713-4172-b1b0-c678c4e8d986",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +279,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7ca89cf-c74c-4c88-9c69-4dfdca718e54",
+   "id": "18",
    "metadata": {
     "tags": []
    },
@@ -290,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5033a40-2967-4cc1-9772-fef2be4169b0",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "970ab69a-6f3a-46ce-9882-aded5f98a39f",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31b4ba32-7f34-49a6-b256-966c24faf68a",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Store output"
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e589e19-a137-418b-b2a7-5b0c778766a6",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb0ed312-2aef-41f6-83c7-ead0e630aa39",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_HD.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_HD.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Hollandse Delta"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Delfland"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load Files"
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5556d211-e92e-4ba3-85c2-4ff9bd33fbeb",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -120,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c70bb838-9d93-4d5a-ae12-2da18d145009",
+   "id": "8",
    "metadata": {
     "tags": []
    },
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0ed9e9b-258b-4f16-8bcb-b9d412a8c8c3",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05757b4b-2f8e-48a6-a76c-9e06e23f20da",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "942d281a-aa46-4b57-af3a-f4e2df811b26",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5793dd3d-766d-46bd-811e-4c8b6e118d3a",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0e88867-184b-48b5-a10f-ba8816f10dcc",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ab1e249-a9cc-4728-bfce-d9c965da18df",
+   "id": "14",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -228,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e60dbbe9-1f27-4a71-b10b-1ecf3c53b060",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03ff37c8-16cc-4cdc-9a1b-ea10f06ea630",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e2ea1a8-4a26-4515-9613-11cbd828c0d5",
+   "id": "17",
    "metadata": {},
    "source": [
     "### Create buffer layer that ensures spatial match between peilgebied and hws layers based on the buffer layer"
@@ -271,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4c448fb-3cb3-451c-aa17-d336f02deb6b",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +283,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eb233361-1e89-4bfa-b2f4-22d66155db58",
+   "id": "19",
    "metadata": {},
    "source": [
     "## Add buffer to ['peilgebied','streefpeil']"
@@ -292,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75fc528f-5902-4a5d-bc7c-d0b700875832",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b345f335-bc12-4e99-8272-9e47cc325021",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dfea55d4-0bc9-485b-ac90-68b1dd8455b6",
+   "id": "22",
    "metadata": {},
    "source": [
     "## Store output"
@@ -336,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70b4b337-44a9-4ef4-aee2-f7431aae720c",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_HHNK.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_HHNK.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# HHNK"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2799e766-bbe4-4f8d-a780-051b36f773ae",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Set Paths"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25e2a7de-cb4b-4f6b-b2db-c675f481b939",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Load files"
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e7e929e-e302-4791-b4d2-3808d48cbb56",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -118,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c70bb838-9d93-4d5a-ae12-2da18d145009",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab931fb8-1011-49e9-88c0-e4b1cb09b217",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2740959-7a85-4947-950e-d8a64cb8ece2",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37f2ee9b-d819-4d7b-92a1-49fe681b4380",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -179,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5c819f1-dfae-4bf4-b14e-63902e433b1a",
+   "id": "12",
    "metadata": {
     "tags": []
    },
@@ -205,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c470216-2a8b-4a0a-9e0a-7877203df9dd",
+   "id": "13",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7dfdcfaf-4b9a-443f-b40c-65460af8352d",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a744a7e5-9ac9-4e47-8cf2-791206581786",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "161bb7c7-0ba5-4eb6-bab1-b513cfd330f7",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Create layer that ensures spatial match between peilgebied and hws layers based on the buffer layer"
@@ -257,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9d64a75-240f-4583-9b38-3e3b22a578a3",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7fc8e8ea-4f94-4d3e-8820-46a442903ee6",
+   "id": "18",
    "metadata": {},
    "source": [
     "## Add buffer to ['peilgebied','streefpeil']"
@@ -278,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac1121dc-342e-4960-9294-308b619de9d8",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "746d2ebd-7307-4745-8e0e-35c047126c27",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0d2cab6-6529-4f4a-972a-533de967e85a",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Write output"
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02fcfb58-7054-4517-97f3-224c9acb4d1f",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb843192-82da-4b4f-bb64-f475a4b52162",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_HHSK.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_HHSK.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# HHSK"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and make sure the peilgebieden allign witgh the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## HHSK"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "## Load Files"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5556d211-e92e-4ba3-85c2-4ff9bd33fbeb",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c70bb838-9d93-4d5a-ae12-2da18d145009",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "caba0e5d-0c01-4ff9-9d83-8790125ff85d",
+   "id": "9",
    "metadata": {},
    "source": [
     "## Check Peilgebied and HWS layer overlap:\n",
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3fd731a-1dc8-46cb-b4a3-f052eca43400",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c84ed19-d0a7-4a27-8e3d-03b132a502ac",
+   "id": "11",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat column"
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bae7259-c4fd-4f2a-beb4-ec92a924f210",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "037faf79-c747-405e-b2e5-a73acfed0aba",
+   "id": "13",
    "metadata": {
     "tags": []
    },
@@ -220,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cdb36b6-9c4a-42fd-95f6-17c6b4e5803f",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ed63b03-009a-4cde-8e64-e7f59bb8ca21",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49d80d89-6676-48cc-a1b3-33771f1a9250",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Create buffer polygon between NHWS and peilgebied/RHWS"
@@ -263,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d415acda-966c-4847-a4b6-a06b23f87218",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eaeccbcb-b0d6-4caa-9fb9-dc8a44016298",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Add buffer to ['peilgebied','streefpeil']"
@@ -290,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "852a9639-cdc4-4709-abb0-fded2aed5970",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fb401c1-3291-4bff-896e-1fc1478fe830",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f13c5886-7349-4396-87a2-6d400ce57953",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Fix duplicates hydroobjects"
@@ -336,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "803b640d-ec91-469d-b7aa-29b8b8576234",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05a65661-9821-4657-9351-22502ee9a58c",
+   "id": "23",
    "metadata": {},
    "source": [
     "### Store post-processed data"
@@ -382,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3425a4bd-f8b1-4dd3-b11b-4bb420c8a5bb",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_scheldestromen.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-processing_scheldestromen.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "690952c5-5037-476a-a660-d54fec614748",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Scheldestromen"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e9e378d7-8f05-4562-87b0-34978ba61554",
+   "id": "1",
    "metadata": {},
    "source": [
     "This script adds a new column \"peilgebied_cat\" and makes sure the peilgebieden allign with the HWS layer (Daniel):\n",
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c27c7a4-5733-46ea-970f-cd985b8c92cd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dc1f28d2-8499-4ebb-906e-1724bd334aac",
+   "id": "3",
    "metadata": {},
    "source": [
     "## Scheldestromen"
@@ -46,7 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e15206a7-6639-40bb-9942-f920085f53b4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bbafed8-355a-4ec9-90c9-eca9e3b9313d",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Load Files"
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f6dcf56-e8a4-4055-bc86-a6d33c91d8d8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fcd4cc6-3c75-462f-af3e-7693c9c5265f",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3e2faf6a-d645-44c7-8882-f6e613e73410",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Select waterschap boundaries and clip hws layer"
@@ -130,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d804374-1484-42d0-88a2-f6bec404349b",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0cc62e79-0fc4-48d3-b3b6-e4ded29c2e35",
+   "id": "10",
    "metadata": {},
    "source": [
     "## Peilgebied and HWS layer overlap:\n",
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a15df030-9a47-47bb-a09c-dd4b5dda65e2",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87df5559-330b-41e1-8355-cbcc5c33d0a5",
+   "id": "12",
    "metadata": {},
    "source": [
     "## Create peilgebied_cat columnm"
@@ -190,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfc95c53-1282-479b-8348-ad54085a49f6",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc35d69e-9ce6-423b-abda-0b8314a5ec22",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43ed5595-4741-4dc9-9c37-4ba790190281",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Add nhws to ['peilgebied','streefpeil']"
@@ -232,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b666fddd-e1b8-4e66-9a88-d87fb0df8749",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55368969-6fce-4597-a6a8-128f5a54bcb8",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d3ed0b2-0f05-4c51-b24f-4032059b1bc9",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Create buffer layer that ensures spatial match between peilgebied and hws layers based on the buffer layer"
@@ -275,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c6a1883-1647-493a-acad-411404f1daec",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +287,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c27471d-9fb3-4d38-bd63-b841cc41cbee",
+   "id": "20",
    "metadata": {
     "tags": []
    },
@@ -298,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39a1211a-bb76-4c4f-ac7e-2405d2729705",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77237ffe-7099-4872-8f1f-4ccc0cd84b6c",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf892c2f-bf67-4e5e-a2f1-20699fedcf88",
+   "id": "23",
    "metadata": {},
    "source": [
     "## Store output"
@@ -341,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17796202-2f3c-4175-8409-7c2294b76703",
+   "id": "24",
    "metadata": {
     "tags": []
    },

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/AmstelGooienVecht.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/AmstelGooienVecht.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d13f9ab1-f6e7-4958-96cc-343f0c2138f6",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad89ae02-4242-4aca-bd5a-c0c3fd8592ac",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09981d65-c7d2-4802-9fca-2ef490213b2c",
+   "id": "2",
    "metadata": {},
    "source": [
     "# Amstel, Gooi en Vecht"
@@ -42,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5fc0f1d-b2bf-4933-9472-96cb110e6111",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d54f0c7c-93a1-44bd-b0f9-fcf37279dc83",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8ca7d9a-fcd9-4154-9278-029f2a25b7b7",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c3e568b-79b0-4809-8274-a029cc61b534",
+   "id": "6",
    "metadata": {},
    "source": [
     "# Nalevering"
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31327447-601e-4f6a-b141-e97162433b37",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f68a9597-d088-40c2-88df-931aa281d000",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "951b70c4-740a-47db-9abf-7c5770aa24bb",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "320352cd-a10b-48ff-afc0-71023df12cb4",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fd2e22c-95a0-4877-b160-843b36ea56a3",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cb1e8f8-fc21-4b03-a6e9-d0c1eecd5701",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,14 +274,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74d6b456-154a-4c13-b53d-4d5e67122485",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "9276888c-0ba2-4f5d-8ecb-a26baa1747f0",
+   "id": "14",
    "metadata": {},
    "source": [
     "# Control, store"
@@ -290,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2554d9e-9957-47bd-8cef-e6bfd4220a61",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be767e93-6ab9-4a3d-a7ae-247eb3877617",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09e3e8eb-f52b-497b-a0ef-b8613d7771c1",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Delfland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Delfland.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "2",
    "metadata": {},
    "source": [
     "# Delfland"
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "636e86b9-bd75-4f8f-91eb-e757fba21fde",
+   "id": "3",
    "metadata": {
     "tags": []
    },
@@ -50,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "532b0b83-2139-4d48-8e42-883ed8e88325",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "341e9076-62bd-4d0f-aba9-835cdf93afeb",
+   "id": "5",
    "metadata": {},
    "source": [
     "### Adjust column names"
@@ -75,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "059f9113-bcd4-470a-abb6-4fd8ec193f4a",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54a863ea-caab-4be6-bca6-78c2ae91941f",
+   "id": "7",
    "metadata": {},
    "source": [
     "### Add column to determine the HWS_BZM"
@@ -172,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fda7f5c9-6949-4044-b04d-ba438d2b37d3",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42dc4ba1-3ccb-4b0f-a075-77aec9b85a07",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +215,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "12",
    "metadata": {},
    "source": [
     "### Store data"
@@ -224,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,14 +238,14 @@
   },
   {
    "cell_type": "raw",
-   "id": "d6b186d5-c907-4b19-9ee2-c7222476856a",
+   "id": "14",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fedb4c6e-49c2-44f4-88f0-0e1ce4802bc7",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/HHNK.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/HHNK.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "2",
    "metadata": {},
    "source": [
     "# Hollands Noorderkwartier"
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "636e86b9-bd75-4f8f-91eb-e757fba21fde",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "baf1ecdb-36e9-4370-ad9d-28dd4b7b0c6b",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3dbf5fe0-ac68-4270-b936-51dd5e7e8215",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -92,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "033468ab-b74c-468a-90b1-eac395ad8d17",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "805ffd9b-da23-46e3-977f-84575e32f225",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "341e9076-62bd-4d0f-aba9-835cdf93afeb",
+   "id": "8",
    "metadata": {},
    "source": [
     "### GPKG"
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b86f37d-16de-49db-969a-b233f1531abb",
+   "id": "9",
    "metadata": {
     "tags": []
    },
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdc5db0a-4f5f-464f-aa98-1cc7ea968680",
+   "id": "10",
    "metadata": {},
    "source": [
     "### .GDB"
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe5e6309-4370-4da7-bd2c-9c7f7f727545",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebd41c6f-24dc-4a56-b24c-65c33b707707",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6164c27-8292-4943-bc6e-83445ed956a9",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d72f3d5c-20ed-4ca6-a71f-ddca9cf93fee",
+   "id": "14",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -257,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffd4ea1b-e2a2-4e3b-a5cf-e820a4709c30",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56fa3a9e-2894-4676-9a47-29fbdadc96c5",
+   "id": "16",
    "metadata": {
     "tags": []
    },
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "064607bb-4c54-4dc2-b913-94dfcd18cfa0",
+   "id": "17",
    "metadata": {},
    "source": [
     "Some changes by hand have been made. The resulting shapefile contains the bordering BZM and HWS shapes, including streefpeil"
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e8c8649-cde9-40db-b155-d8d80ba65f6a",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "350baa05-21ab-48af-b4b9-cae7fef089a6",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Store data"
@@ -325,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "d6b186d5-c907-4b19-9ee2-c7222476856a",
+   "id": "22",
    "metadata": {},
    "source": [
     "Toevoegen aan notities:\n",

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/HHSK.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/HHSK.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {
     "tags": [
      "test"
@@ -32,7 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbbec2b5-c309-4a42-a914-dd33c2da3610",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7bb775e-cc57-4586-a13c-8d9ba05ace6b",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f39bd82-2fed-41d6-a4f7-979a9a2120bd",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "279c940f-4290-48d6-bd48-b1e79f8be16e",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ea5a43d-b2e6-42ef-8002-01c3377ed897",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32562573-3c78-4565-85be-1b7c03a023be",
+   "id": "7",
    "metadata": {},
    "source": [
     "## Only select status_object == 3"
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10efac14-fd47-4f61-9180-e89e864713c7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d91ef127-a46e-4ce7-b4fc-ec13d39b6820",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "10",
    "metadata": {},
    "source": [
     "# HHSK"
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62a8afeb-9d69-4df0-8e9a-0aa255543fb1",
+   "id": "11",
    "metadata": {
     "tags": []
    },
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8196e429-c7c1-40f1-9dd3-525699656dc7",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f19829d-6116-45d4-92ae-a0e27509afa3",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -205,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe221b99-ad03-4688-a656-9cb19e4f1a8b",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8c3e7f83-1aa8-4714-8ef5-7d0176097d94",
+   "id": "15",
    "metadata": {
     "tags": []
    },
@@ -236,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75bbbea1-5ef9-4935-ad8e-4f294eaf1c9f",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8495f3ba-98df-4eea-97a5-d09534e36885",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31841446-4e06-47b7-98a3-38d389df26df",
+   "id": "18",
    "metadata": {},
    "source": [
     "### Add the nageleverde peilgebieden to the original data"
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ee954f4-c333-4bb4-8dcc-b1e1cd7c2b57",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c37cfb5c-3b9e-4e57-b44c-3cbe610da093",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd7bfade-497b-40bd-8345-8dc4fd3d172b",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5631e7ba-f5a0-4eaf-942a-3b6535a4ba8b",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7df9baa4-7092-4401-be9a-fd3a451c38b0",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a03b9016-af7d-4c4e-a10b-1f2ea2ee9254",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9736e6e4-0e8f-4396-a1f4-3b4f3e9bf690",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5d16748-7262-4e43-baa2-f182cb8dd142",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0292ab77-acfd-4666-9c3b-b9bd8c1f1fec",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd21bcac-8d25-4d47-ad0a-c7338e6e6653",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88e9543c-2dbe-4ebf-9423-b38daeeaa004",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cdf901e-c4b4-4fb8-9f40-4731ff3c2d1d",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51df5dde-d374-4ae3-8d43-1c495581f021",
+   "id": "31",
    "metadata": {},
    "source": [
     "### Delete irrelevant data"
@@ -463,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42dc4ba1-3ccb-4b0f-a075-77aec9b85a07",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "375f1598-03c1-48a1-bb19-54790273dad0",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +490,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "34",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -499,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +508,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "36",
    "metadata": {},
    "source": [
     "### Store data"
@@ -517,7 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69cbb333-f66e-4ca8-880f-3242846c6a9b",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Hollandse_Delta.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Hollandse_Delta.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "2",
    "metadata": {},
    "source": [
     "# HD"
@@ -36,7 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "636e86b9-bd75-4f8f-91eb-e757fba21fde",
+   "id": "3",
    "metadata": {
     "tags": []
    },
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "532b0b83-2139-4d48-8e42-883ed8e88325",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "077f1c26-c738-48f7-b9df-bec5b7356c9a",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "341e9076-62bd-4d0f-aba9-835cdf93afeb",
+   "id": "6",
    "metadata": {},
    "source": [
     "### Adjust column names"
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d54bf05e-f563-44ec-9864-4774e2aecfc6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "059f9113-bcd4-470a-abb6-4fd8ec193f4a",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42dc4ba1-3ccb-4b0f-a075-77aec9b85a07",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "10",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -225,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2809cf79-d381-432b-8ddd-3497556f5d82",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Store data"
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52f17e20-95a7-493f-bff9-6600df570fe0",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Rijnland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Rijnland.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbbec2b5-c309-4a42-a914-dd33c2da3610",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7bb775e-cc57-4586-a13c-8d9ba05ace6b",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca6ddcd9-e960-4b5f-ba10-4d222c16a843",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "5",
    "metadata": {},
    "source": [
     "# Rijnland"
@@ -83,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01dda03c-5a50-4bde-a655-7ed14c85a8d3",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e58ee099-54b3-415b-8222-9545776a7a61",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "023a704c-685e-4fe9-9745-39a5ed461a03",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb236dc1-11b3-42c4-99e9-fecd568bec2b",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05098a9e-9b5a-487e-8b3e-7f3d82bda74e",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5339a8c5-8c43-4ccd-9008-103fc7e7058e",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "096a2293-cd78-4c8d-b0e8-bbbe559a8155",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bea1764-0459-4d49-9d48-c5b85a6c3480",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9efaf904-e94c-4c87-aeb6-c04d4f183e27",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1511cf73-aa2b-423f-be87-c95fb0d9bdbb",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bdd80ad-650c-4e9f-a3bd-d675c4544830",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb1f6f57-60e7-4122-9648-5a0883933dd1",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbb4827e-17ad-461f-8101-f97f38b2b31e",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67ba9685-90b6-4389-818f-a003d9d41dc8",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42dc4ba1-3ccb-4b0f-a075-77aec9b85a07",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ea24ea8-67ae-4cff-ac30-6492dcd80c41",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "22",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -322,7 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Store data"
@@ -340,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f198edc5-7466-4668-b980-adabdf7c7c94",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -348,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48b0320b-258c-44c8-aff2-83153db1a512",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -371,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "311db7da-e645-47f2-af06-0bdf23a5589b",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -379,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b93668e-c539-426a-9af2-99d36af00334",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -387,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a09e840-7204-4aac-b825-c66394c60775",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -395,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "622a1518-d12d-4b70-ac03-0d251ee09861",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -403,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0cf20d1-b76c-4e07-ab7b-9976313f8dad",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -411,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ace74b96-2316-4b02-b3ca-9e2b9d3c18aa",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -419,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92551bfe-2672-4c85-988e-e19a320b8cee",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -427,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70c906ed-d0b1-4ccb-b527-775d1c7e1e48",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -435,7 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed6d57c1-3127-43a2-9de0-29cbf5846bd1",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -443,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c562c790-2afa-493d-a86d-c438deae6470",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -451,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0090fd91-40eb-48e1-aa99-2360a13a708e",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Rivierenland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Rivierenland.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c2a1a6e-1255-4481-9d94-b0206f40e94d",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "3",
    "metadata": {},
    "source": [
     "# WSRL"
@@ -47,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "636e86b9-bd75-4f8f-91eb-e757fba21fde",
+   "id": "4",
    "metadata": {
     "tags": []
    },
@@ -62,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0f66000-73e6-4b06-b5a2-8308213c2461",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7469bb6f-dc28-43b3-b9cb-2d4505b5d5fd",
+   "id": "6",
    "metadata": {},
    "source": [
     "Additional data is given in another gpkg, which includes the peilgebieden"
@@ -97,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5018d1e6-f7ba-4e02-b01a-6d83a3a5e9a3",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc85db32-bb81-4f7f-9a38-2bd89b3fc658",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "341e9076-62bd-4d0f-aba9-835cdf93afeb",
+   "id": "9",
    "metadata": {},
    "source": [
     "### Adjust column names"
@@ -134,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0302db0-e7f0-4dd2-88b7-3dc9aadd581f",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f56f578-aca0-4957-89df-b6a3a08278a3",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6dce84db-36f3-4a1c-9f10-7c14d9e4a6ed",
+   "id": "12",
    "metadata": {
     "tags": []
    },
@@ -214,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "059f9113-bcd4-470a-abb6-4fd8ec193f4a",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0181e016-5103-4d66-b0fa-27ef59282f51",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96f0e8bf-89e3-4743-b047-d23791bdc5b4",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "500d4d64-c65b-4426-9f89-7f10e12a0514",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "363a8b04-a132-469a-b5c8-cde2e911a9c0",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfbf8612-93a9-4357-a3c9-cd3dd9d9bf71",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74734b29-5c4a-4e63-a873-88d8f6ebbd14",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42dc4ba1-3ccb-4b0f-a075-77aec9b85a07",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "21",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -383,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,14 +393,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d81fa34f-69aa-4d0e-9612-8ae36b959e0b",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "24",
    "metadata": {},
    "source": [
     "### Store data"
@@ -409,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,14 +423,14 @@
   },
   {
    "cell_type": "raw",
-   "id": "d6b186d5-c907-4b19-9ee2-c7222476856a",
+   "id": "26",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fedb4c6e-49c2-44f4-88f0-0e1ce4802bc7",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Scheldestromen.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Scheldestromen.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbbec2b5-c309-4a42-a914-dd33c2da3610",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7bb775e-cc57-4586-a13c-8d9ba05ace6b",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f39bd82-2fed-41d6-a4f7-979a9a2120bd",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a7d78f8-7605-4aba-b4c6-b17b81d4f5df",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c14883a-873b-44ee-b9d3-57d7da0b67c3",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "7",
    "metadata": {},
    "source": [
     "# Scheldestromen"
@@ -123,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbe8f365-8b00-4824-b04c-b976f9a43f05",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3f70ee4-d645-4114-b5e2-2dd573374d6e",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e58ee099-54b3-415b-8222-9545776a7a61",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "023a704c-685e-4fe9-9745-39a5ed461a03",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d5d490e-5bba-4d16-95a0-a17880adc0d9",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd21bcac-8d25-4d47-ad0a-c7338e6e6653",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88e9543c-2dbe-4ebf-9423-b38daeeaa004",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42dc4ba1-3ccb-4b0f-a075-77aec9b85a07",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "16",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -243,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9d38f6f-42df-45b4-a1d2-b1a779c104d8",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45564e81-4fcf-4479-b406-8142b4a64ad1",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "20",
    "metadata": {},
    "source": [
     "### Store data"
@@ -285,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,14 +299,14 @@
   },
   {
    "cell_type": "raw",
-   "id": "d6b186d5-c907-4b19-9ee2-c7222476856a",
+   "id": "22",
    "metadata": {},
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fedb4c6e-49c2-44f4-88f0-0e1ce4802bc7",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af637fd1-1d33-4eb2-92c7-51c29e477404",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Wetterskip.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Wetterskip.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48a939f4-8a39-4c24-b466-499eba37172d",
+   "id": "1",
    "metadata": {},
    "source": [
     "# Wetterskip Fryslan"
@@ -27,7 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b782b9c9-12b9-461b-8874-a59dad72e4bd",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b96e6dab-5341-480d-b077-5b05a2984aa7",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05d63407-5f32-41a9-afbb-ade51a17b7a4",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ccc56b93-ad7b-4b80-b197-21c6aa07e07c",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e3c5720-ff47-40c2-a3f0-e2e635414ed9",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21704eb9-844a-483f-b102-53313a08c3e9",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7eed68de-331a-4829-b78e-ab39db127d71",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b17739a1-76d0-4d8e-bbf9-2483cc81abe5",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54ee138a-5c47-414c-a550-68756f739c91",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "660832b6-d52f-4c17-9b15-510c265c0bea",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81d3df9b-574a-4bd7-860f-2ac4fda4bd4f",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddeaea28-d8ad-484d-880c-965cd4bd8faf",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f83cab3-fb65-4336-a0ed-36339c34c2dc",
+   "id": "14",
    "metadata": {
     "jp-MarkdownHeadingCollapsed": true,
     "tags": []
@@ -254,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2982e516-9b1f-4f4e-86cc-5131ff53925a",
+   "id": "15",
    "metadata": {
     "tags": []
    },
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "ba602947-7d4c-48b0-9651-683efffd0932",
+   "id": "16",
    "metadata": {},
    "source": [
     "There are some peilgebieden without peil. Merge the peilgebied praktijk and the peilgebiedvigerend. Then, take the difference between this merged peilgebied and the peilbesluit gebied. The leftover areas should get a streefpeil based on the layer of peilmerk."
@@ -286,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "868691a9-9659-4026-9588-2d9e73f04db5",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29513621-a948-408e-91cd-9255d55d539b",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47072d3d-5d87-40c3-bf57-198d618271ae",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "794c3ba1-d2ec-4ed7-9f7c-432fe189cc81",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7484c309-6a03-492b-a27c-fcf3ef837446",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25cfdd50-7216-48aa-a60a-b60710500790",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -380,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57d0bb94-fc26-4299-804e-8c6a17847c77",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Zuiderzeeland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/Zuiderzeeland.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "065338fd-62d6-480e-8c80-8bc4b101846b",
+   "id": "0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f5aaa20-7965-4aa7-bf24-79965d87edb1",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbbec2b5-c309-4a42-a914-dd33c2da3610",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7bb775e-cc57-4586-a13c-8d9ba05ace6b",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ffeed567-f858-4e46-83ff-89b7d7ea9b6d",
+   "id": "4",
    "metadata": {},
    "source": [
     "# Zuiderzeeland"
@@ -60,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "636e86b9-bd75-4f8f-91eb-e757fba21fde",
+   "id": "5",
    "metadata": {
     "tags": []
    },
@@ -87,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0d86e2c-d365-4a03-8276-d59f93367128",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "920dff3d-f81f-4e88-a8be-67fa2c60d41b",
+   "id": "7",
    "metadata": {},
    "source": [
     "ZZL: stuwen in KWKSOORT in overigekunstwerken.gpkg"
@@ -106,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28a99515-40c8-4a8e-b78f-0781869de8be",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e58ee099-54b3-415b-8222-9545776a7a61",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9a814bb-bf6a-4822-9447-c8fb0bbc57ae",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a55866b-ece5-45ce-836d-c8b1fc737c2b",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -181,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aec76a19-0893-48a0-b1af-c8c871d0557d",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +255,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21ccbba5-8e59-4134-9209-db988bc5c3d5",
+   "id": "13",
    "metadata": {},
    "source": [
     "### Check for the correct keys and columns"
@@ -264,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b064a376-0396-4c93-a2ad-eca3eea54598",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4e74b4c-17ba-4829-9531-248f4d74cfad",
+   "id": "15",
    "metadata": {},
    "source": [
     "### Store data"
@@ -282,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "556aea48-a819-4f70-8e22-6c843354a46d",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116f9f2a-ad97-44c5-9a2f-ba43c80e4b2d",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -305,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01a06379-58e7-4621-b998-4f95b947bd63",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -313,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f48ffb3f-11d0-41d7-9254-61b2c7873436",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
The notebook diffs are from `nbstripout` which runs as part of pre-commit. This should fix pre-commit CI.

This also directly upgrades ribasim from 2024.9 to 2024.10, as well as all other dependencies in our lockfile.