### PR TITLE
Fix ruff errors on main

### DIFF
--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.ipynb
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.ipynb
@@ -16,6 +16,7 @@
     "import peilbeheerst_model.ribasim_parametrization as ribasim_param\n",
     "import ribasim\n",
     "import ribasim.nodes\n",
+    "from peilbeheerst_model.add_storage_basins import AddStorageBasin\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.ipynb
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.ipynb
@@ -16,6 +16,7 @@
     "import peilbeheerst_model.ribasim_parametrization as ribasim_param\n",
     "import ribasim\n",
     "import ribasim.nodes\n",
+    "from peilbeheerst_model.add_storage_basins import AddStorageBasin\n",
     "from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor\n",
     "from ribasim import Node\n",
     "from ribasim.nodes import (\n",

--- a/src/peilbeheerst_model/Parametrize/Rijnland_nieuw.ipynb
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_nieuw.ipynb
@@ -16,6 +16,7 @@
     "import peilbeheerst_model.ribasim_parametrization as ribasim_param\n",
     "import ribasim\n",
     "import ribasim.nodes\n",
+    "from peilbeheerst_model.add_storage_basins import AddStorageBasin\n",
     "from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")"

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.ipynb
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.ipynb
@@ -16,6 +16,7 @@
     "import peilbeheerst_model.ribasim_parametrization as ribasim_param\n",
     "import ribasim\n",
     "import ribasim.nodes\n",
+    "from peilbeheerst_model.add_storage_basins import AddStorageBasin\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.ipynb
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.ipynb
@@ -11,10 +11,12 @@
     "import pathlib\n",
     "import warnings\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "import peilbeheerst_model.ribasim_parametrization as ribasim_param\n",
     "import ribasim\n",
     "import ribasim.nodes\n",
+    "from peilbeheerst_model.add_storage_basins import AddStorageBasin\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_WSRL.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_WSRL.ipynb
@@ -29,6 +29,7 @@
     "import geopandas as gpd\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import shapely\n",
     "from general_functions import read_gpkg_layers"
    ]
   },

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_WSRL.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_WSRL.ipynb
@@ -28,6 +28,7 @@
    "source": [
     "import geopandas as gpd\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "from general_functions import read_gpkg_layers"
    ]
   },

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_delfland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_delfland.ipynb
@@ -28,6 +28,7 @@
    "source": [
     "import geopandas as gpd\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "from general_functions import read_gpkg_layers"
    ]
   },

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_rijnland.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_rijnland.ipynb
@@ -231,7 +231,7 @@
     "\n",
     "gdf_rhws = gdf_rhws[[\"globalid\", \"code\", \"nen3610id\", \"peilgebied_cat\", \"geometry\"]]\n",
     "\n",
-    "Rijnland[\"peilgebied\"] = pd.concat([gdf_rhws, AVG[\"peilgebied\"]])"
+    "Rijnland[\"peilgebied\"] = pd.concat([gdf_rhws, Rijnland[\"peilgebied\"]])"
    ]
   },
   {

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/HHSK.ipynb
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/HHSK.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "from general_functions import read_gpkg_layers, show_layers_and_columns, store_data"
+    "from general_functions import burn_in_peilgebieden, read_gpkg_layers, show_layers_and_columns, store_data"
    ]
   },
   {
@@ -376,17 +376,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# streefpeilen_PG_v = pd.merge(left = HHSK['peilgebiedvigerend'],\n",
-    "#                              right = HHSK['streefpeil'],\n",
-    "#                              left_on = 'globalid',\n",
-    "#                              right_on = 'peilgebiedvigerendid',\n",
-    "#                              suffixes = ('', '_streefpeil'))[['code', 'nen3610id', 'globalid', 'waterhoogte', 'geometry']]\n",
+    "streefpeilen_PG_v = pd.merge(\n",
+    "    left=HHSK[\"peilgebiedvigerend\"],\n",
+    "    right=HHSK[\"streefpeil\"],\n",
+    "    left_on=\"globalid\",\n",
+    "    right_on=\"peilgebiedvigerendid\",\n",
+    "    suffixes=(\"\", \"_streefpeil\"),\n",
+    ")[[\"code\", \"nen3610id\", \"globalid\", \"waterhoogte\", \"geometry\"]]\n",
     "\n",
-    "# streefpeilen_PG_a = pd.merge(left = HHSK['peilafwijkinggebied'],\n",
-    "#                              right = HHSK['streefpeil'],\n",
-    "#                              left_on = 'globalid',\n",
-    "#                              right_on = 'peilafwijkinggebiedid',\n",
-    "#                              suffixes = ('', '_streefpeil'))[['code', 'nen3610id', 'globalid', 'waterhoogte', 'geometry']]\n",
+    "streefpeilen_PG_a = pd.merge(\n",
+    "    left=HHSK[\"peilafwijkinggebied\"],\n",
+    "    right=HHSK[\"streefpeil\"],\n",
+    "    left_on=\"globalid\",\n",
+    "    right_on=\"peilafwijkinggebiedid\",\n",
+    "    suffixes=(\"\", \"_streefpeil\"),\n",
+    ")[[\"code\", \"nen3610id\", \"globalid\", \"waterhoogte\", \"geometry\"]]\n",
     "\n",
     "# fig, ax = plt.subplots()\n",
     "# streefpeilen_PG_v.plot(ax = ax, color='cornflowerblue')\n",
@@ -411,9 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# peilgebied = burn_in_peilgebieden(base_layer = streefpeilen_PG_v,\n",
-    "#                                   overlay_layer = streefpeilen_PG_a,\n",
-    "#                                   plot = True)"
+    "peilgebied = burn_in_peilgebieden(base_layer=streefpeilen_PG_v, overlay_layer=streefpeilen_PG_a, plot=True)"
    ]
   },
   {


### PR DESCRIPTION
Fixes a part of #120. The goal for this PR is to resolve all 53 open ruff errors on main, without adding exceptions. Currently the commits in this PR bring it down to 29. The remaining errors are all of the form `F821 Undefined name`, where the name is:

- dm_netwerk_path
- gdf_rhws
- model_name
- output_folder
- ribasim_toml
- stored_trc

For various files. Will look with @rbruijnshkv to resolve the rest.