### PR TITLE
Disconnect ribasim_lumping for now

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -21,19 +21,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h8a0f778_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.2-h7970872_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.25-h4bc722e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-hc649ecc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h04a40c0_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-hc9bb02b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h3e50d33_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-h674cf7e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-hbe604ca_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-hc649ecc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-hc649ecc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-hba11562_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-he20dfa5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h15d0e8c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h8dac057_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.27-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h038f3f9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h570d160_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-ha1f794c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h0040ed1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hc14a930_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h558cea2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h038f3f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h038f3f9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-hd0b8a3b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-h7dc8893_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
@@ -54,7 +54,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py312h1671c18_0.conda
@@ -67,15 +67,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py312h8572e83_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.1-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.3-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.58.3-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.5-py312hca68cad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
@@ -83,10 +83,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/deno-1.41.0-hfc7925d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/deno-dom-0.1.35-hd9586b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.19.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.23.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
@@ -108,7 +108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py312h7eda2e2_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.2-py312h7eda2e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
@@ -120,7 +120,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
@@ -134,9 +134,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
@@ -169,10 +169,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h03aeac6_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h8756180_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
@@ -191,20 +191,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-hba09cee_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-h9d8aadb_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.2-hba09cee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.2-hdd6600c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.2-h5f34788_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.2-ha39a594_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.2-ha2ed5f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.2-h2ebfdf0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.2-h2b45729_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.2-h94e7027_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.2-h0fa2cb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.2-he047751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.2-he047751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.2-h9d8aadb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.2-h062f1c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h315aac3_2.conda
@@ -222,7 +222,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h482b261_0.conda
@@ -251,11 +251,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py312h03f37cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h98912ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py312h7900ff3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py312h854627b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py312h854627b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
@@ -285,7 +285,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.5-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
@@ -307,7 +307,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.08.0-hb0d391f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.4-ha8faf9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
@@ -338,7 +338,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.0-py312h7ab5c7e_0.conda
@@ -358,14 +358,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.20.0-py312hf008fa9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py312hbe4c86d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.1-py312hbe4c86d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.0-h3400bea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py312h775a589_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312hc2bc53b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312h499d17b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.5-py312h8413631_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.2-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.3-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -439,7 +439,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h3483029_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
@@ -447,7 +447,6 @@ environments:
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/peilbeheerst_model
-      - pypi: src/ribasim_lumping
       - pypi: src/ribasim_nl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
@@ -462,19 +461,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.25-h6309471_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.2-h5b118bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.25-hfdf4475_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h5b118bc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h671840a_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.7-h22e442e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hddd658a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-h3710d3a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.4-h89cdba3_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-h5b118bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h5b118bc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.5-h53ac995_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.379-h065e723_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.25-h4880c77_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.3-hf37c103_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.27-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hf37c103_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h324d61a_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.7-h3c4ec21_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hdc1c6f6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-h93740dc_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.4-hd06a241_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-hf37c103_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hf37c103_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.5-hfadd0b3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.379-hae762b9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.13.0-hf8dbe3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h60298e3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.12.0-h646f05d_0.conda
@@ -495,7 +494,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.0-py312h9620c06_0.conda
@@ -508,24 +507,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.1-py312h9230928_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.1-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.3-py312h41838bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dart-sass-1.58.3-h694c41f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.5-py312h28f332c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/deno-1.41.0-h86af993_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/deno-dom-0.1.35-h08cba0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.19.2-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.23.1-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
@@ -547,7 +546,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py312h29648be_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.2-py312h29648be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
@@ -558,7 +557,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -571,9 +570,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
@@ -604,10 +603,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h1496d7c_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hac325c4_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hac325c4_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hba007a9_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h2952479_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hac325c4_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hac325c4_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hba007a9_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
@@ -615,27 +614,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.9.1-hfcf2730_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.21-hfdf4475_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-h694c41f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.1-h4b9bb65_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.1-h5d197d2_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.1-h385febf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.1-h86719f3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.1-h513f0eb_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.1-hc5f35ca_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.1-h3b8d0bf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.1-h3127c03_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.1-h0da0525_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.1-h1b48671_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.1-h1b48671_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.1-ha63beff_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.1-h597966e_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.2-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.2-h4b9bb65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.2-h5d197d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.2-h385febf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.2-h86719f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.2-h513f0eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.2-hc5f35ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.2-h3b8d0bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.2-h3127c03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.2-ha7d2355_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.2-h1b48671_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.2-h1b48671_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.2-ha63beff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.2-h597966e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_2.conda
@@ -643,7 +642,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.28.0-h9e84e37_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
@@ -651,7 +650,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hf1b0f52_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hf1b0f52_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.4-h4501773_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
@@ -669,17 +668,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py312hdeb90da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py312h904eaf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py312h41838bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py312hb401068_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py312h0d5aeb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py312hb401068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py312h0d5aeb7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
@@ -707,7 +706,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.5-py312h8847cbe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-h22b2039_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py312h1171441_1.conda
@@ -729,7 +728,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.07.0-h744cbf2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.08.0-h744cbf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.4-h9b73963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
@@ -761,7 +760,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.1.0-py312h7a17523_0.conda
@@ -780,13 +779,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.20.0-py312ha47ea1c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.5.7-py312h8b25c6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.1-py312h8b25c6c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py312hc214ba5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.5-py312h594820c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.2-py312h41838bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.3-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -843,7 +842,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h331e495_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
@@ -851,7 +850,6 @@ environments:
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/peilbeheerst_model
-      - pypi: src/ribasim_lumping
       - pypi: src/ribasim_nl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
@@ -865,19 +863,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-he6981b3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.2-h0240d57_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.25-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-h0240d57_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h330dd76_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h065a16f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h3095dc9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h1efefa3_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h9116173_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-h0240d57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-h0240d57_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h55e8508_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h2205d66_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-h7db803d_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.3-ha1e9ad3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.27-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-ha1e9ad3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-hf2a634e_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h6bd9195_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h8d4122e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h827f298_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h21392f2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-ha1e9ad3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-ha1e9ad3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h1307057_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h21b9f41_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.13.0-haf5610f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h148e6f0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.12.0-hf03c1c4_0.conda
@@ -897,7 +895,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.0-py312h4389bb4_0.conda
@@ -910,25 +908,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py312h0d7def4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.3-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.58.3-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.5-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/deno-1.41.0-h1f5608b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/deno-dom-0.1.35-h8b8d39b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.19.2-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.23.1-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
@@ -950,7 +948,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py312h16ac12d_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.2-py312h16ac12d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
@@ -959,7 +957,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.2-h5a68840_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h232476a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
@@ -973,11 +971,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
@@ -1006,10 +1004,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h009c9d4_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h6e8cf4f_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
@@ -1022,32 +1020,32 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-h6b59ad6_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-hefbb53f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.2-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.2-h6b59ad6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.2-h0a0b71e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.2-hd2a089b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.2-h430f241_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.2-had131a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.2-hed4c6cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.2-h95b1a77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.2-h55e78d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.2-ha1c78db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.2-ha693a0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.2-ha693a0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.2-hefbb53f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.2-hd0e23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.3-h7025463_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.28.0-h5e7cea3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.28.0-he5eb982_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.4-hab9416b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
@@ -1076,11 +1074,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py312he70551f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py312h2e8e312_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py312h90004f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
@@ -1107,7 +1105,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.5-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.2-h784c2ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py312h72972c8_1.conda
@@ -1128,7 +1126,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.08.0-h686f694_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.4-hd835ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
@@ -1159,7 +1157,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py312h53d5487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py312h53d5487_0.conda
@@ -1180,13 +1178,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.20.0-py312h2615798_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.1-py312h7a6832a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py312h816cc57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.5-py312h3a88d77_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.2-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.3-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -1249,7 +1247,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
@@ -1257,7 +1255,6 @@ environments:
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/peilbeheerst_model
-      - pypi: src/ribasim_lumping
       - pypi: src/ribasim_nl
   dev:
     channels:
@@ -1280,19 +1277,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h8a0f778_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.2-h7970872_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.25-h4bc722e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-hc649ecc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h04a40c0_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-hc9bb02b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h3e50d33_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-h674cf7e_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-hbe604ca_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-hc649ecc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-hc649ecc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-hba11562_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-he20dfa5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h15d0e8c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h8dac057_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.27-h4bc722e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h038f3f9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h570d160_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-ha1f794c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h0040ed1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hc14a930_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h558cea2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h038f3f9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h038f3f9_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-hd0b8a3b_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-h7dc8893_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.13.0-h935415a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.8.0-hd126650_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.12.0-hd2e3451_0.conda
@@ -1313,7 +1310,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.7.4-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-hebfffa5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py312h1671c18_0.conda
@@ -1326,15 +1323,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.1-py312h8572e83_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.1-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-0.12.3-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.58.3-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.5-py312hca68cad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
@@ -1342,10 +1339,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/deno-1.41.0-hfc7925d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/deno-dom-0.1.35-hd9586b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.19.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.23.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
@@ -1367,7 +1364,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h743c826_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py312h7eda2e2_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.2-py312h7eda2e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
@@ -1379,7 +1376,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-9.0.0-hda332d3_1.conda
@@ -1393,9 +1390,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
@@ -1428,10 +1425,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.2-cxx17_he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.7.4-hfca40fe_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h03aeac6_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h8756180_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-23_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
@@ -1450,20 +1447,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h77fa898_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-hba09cee_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-h9d8aadb_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.2-hba09cee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.2-hdd6600c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.2-h5f34788_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.2-ha39a594_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.2-ha2ed5f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.2-h2ebfdf0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.2-h2b45729_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.2-h94e7027_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.2-h0fa2cb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.2-he047751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.2-he047751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.2-h9d8aadb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.2-h062f1c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h315aac3_2.conda
@@ -1481,7 +1478,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_hac2b453_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.4-h482b261_0.conda
@@ -1510,11 +1507,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.3.3-py312h03f37cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h98912ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py312h7900ff3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py312h854627b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py312h854627b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
@@ -1544,7 +1541,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.5-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4bc722e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
@@ -1566,7 +1563,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.08.0-hb0d391f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.4-ha8faf9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
@@ -1597,7 +1594,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.1.0-py312h7ab5c7e_0.conda
@@ -1616,14 +1613,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.20.0-py312hf008fa9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py312hbe4c86d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.1-py312hbe4c86d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.0-h3400bea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.5.1-py312h775a589_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312hc2bc53b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312h499d17b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.5-py312h8413631_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.2-py312h98912ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.3-py312h41a817b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-ha2e4443_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -1697,7 +1694,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h75354e8_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h3483029_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
@@ -1706,7 +1703,6 @@ environments:
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/peilbeheerst_model
-      - pypi: src/ribasim_lumping
       - pypi: src/ribasim_nl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
@@ -1721,19 +1717,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.25-h6309471_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.2-h5b118bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.25-hfdf4475_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h5b118bc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h671840a_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.7-h22e442e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hddd658a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-h3710d3a_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.4-h89cdba3_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-h5b118bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h5b118bc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.5-h53ac995_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.379-h065e723_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.25-h4880c77_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.3-hf37c103_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.27-hfdf4475_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hf37c103_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h324d61a_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.7-h3c4ec21_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hdc1c6f6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-h93740dc_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.4-hd06a241_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-hf37c103_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hf37c103_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.5-hfadd0b3_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.379-hae762b9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.13.0-hf8dbe3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-identity-cpp-1.8.0-h60298e3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.12.0-h646f05d_0.conda
@@ -1754,7 +1750,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.7.4-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h37bd5c4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.0-py312h9620c06_0.conda
@@ -1767,24 +1763,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.1-py312h9230928_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.1-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-0.12.3-py312h41838bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dart-sass-1.58.3-h694c41f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.5-py312h28f332c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/deno-1.41.0-h86af993_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/deno-dom-0.1.35-h08cba0f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.19.2-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.23.1-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
@@ -1806,7 +1802,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3ec172f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py312h29648be_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.2-py312h29648be_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
@@ -1817,7 +1813,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h2790a97_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -1830,9 +1826,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh707e725_0.conda
@@ -1863,10 +1859,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.2-cxx17_hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libarchive-3.7.4-h20e244c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h1496d7c_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hac325c4_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hac325c4_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hba007a9_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h2952479_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hac325c4_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hac325c4_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hba007a9_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-22_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
@@ -1874,27 +1870,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-22_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.9.1-hfcf2730_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.21-hfdf4475_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-h694c41f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.1-h4b9bb65_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.1-h5d197d2_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.1-h385febf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.1-h86719f3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.1-h513f0eb_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.1-hc5f35ca_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.1-h3b8d0bf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.1-h3127c03_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.1-h0da0525_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.1-h1b48671_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.1-h1b48671_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.1-ha63beff_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.1-h597966e_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.2-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.2-h4b9bb65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.2-h5d197d2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.2-h385febf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.2-h86719f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.2-h513f0eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.2-hc5f35ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.2-h3b8d0bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.2-h3127c03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.2-ha7d2355_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.2-h1b48671_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.2-h1b48671_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.2-ha63beff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.2-h597966e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.3-h736d271_2.conda
@@ -1902,7 +1898,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.28.0-h9e84e37_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.2-h384b2fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hd75f5a5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libkml-1.3.0-hfcbc525_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-22_osx64_openblas.conda
@@ -1910,7 +1906,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnetcdf-4.9.2-nompi_h7334405_114.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_h8869122_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hf1b0f52_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hf1b0f52_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.4-h4501773_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
@@ -1928,17 +1924,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.7-heaf3512_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzip-1.10.1-hc158999_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvmlite-0.43.0-py312hdeb90da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-4.3.3-py312h904eaf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lzo-2.10-h10d778d_1001.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py312h41838bb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py312hb401068_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py312h0d5aeb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py312hb401068_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py312h0d5aeb7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
@@ -1966,7 +1962,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openpyxl-3.1.5-py312h8847cbe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-h22b2039_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py312h1171441_1.conda
@@ -1988,7 +1984,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.07.0-h744cbf2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.08.0-h744cbf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.4-h9b73963_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
@@ -2020,7 +2016,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.1.0-py312h7a17523_0.conda
@@ -2038,13 +2034,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.20.0-py312ha47ea1c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.5.7-py312h8b25c6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.1-py312h8b25c6c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.5.1-py312hc214ba5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.5-py312h594820c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.2-py312h41838bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.3-py312hbd25219_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.1-he1e6707_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -2101,7 +2097,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hde137ed_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-h87427d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h331e495_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
@@ -2110,7 +2106,6 @@ environments:
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/peilbeheerst_model
-      - pypi: src/ribasim_lumping
       - pypi: src/ribasim_nl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_0.conda
@@ -2124,19 +2119,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/astunparse-1.6.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-he6981b3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.2-h0240d57_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.25-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-h0240d57_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h330dd76_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h065a16f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h3095dc9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h1efefa3_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h9116173_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-h0240d57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-h0240d57_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h55e8508_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h2205d66_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-h7db803d_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.3-ha1e9ad3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.27-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-ha1e9ad3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-hf2a634e_21.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h6bd9195_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h8d4122e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h827f298_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h21392f2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-ha1e9ad3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-ha1e9ad3_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h1307057_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h21b9f41_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.13.0-haf5610f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.8.0-h148e6f0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.12.0-hf03c1c4_0.conda
@@ -2156,7 +2151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.7.4-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h32b962e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.0-py312h4389bb4_0.conda
@@ -2169,25 +2164,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.1-py312h0d7def4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.12.3-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.58.3-h57928b3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.5-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/deno-1.41.0-h1f5608b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/deno-dom-0.1.35-h8b8d39b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/double-conversion-3.3.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.19.2-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.23.1-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_0.conda
@@ -2209,7 +2204,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-h8276f4a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.6.1-pyhff2d567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py312h16ac12d_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.2-py312h16ac12d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geocube-0.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_0.conda
@@ -2218,7 +2213,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.12.2-h5a68840_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.3-h232476a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-9.0.0-h2bedf89_1.conda
@@ -2232,11 +2227,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.2.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.2.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.26.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
@@ -2265,10 +2260,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.7.4-haf234dc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h009c9d4_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_7_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h6e8cf4f_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
@@ -2281,32 +2276,32 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-h6b59ad6_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-hefbb53f_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.2-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.2-h6b59ad6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.2-h0a0b71e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.2-hd2a089b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.2-h430f241_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.2-had131a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.2-hed4c6cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.2-h95b1a77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.2-h55e78d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.2-ha1c78db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.2-ha693a0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.2-ha693a0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.2-hefbb53f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.2-hd0e23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.3-h7025463_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.28.0-h5e7cea3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.28.0-he5eb982_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.1-default_h8125262_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-hcfcfb64_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1020.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-23_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_h92078aa_114.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_7_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-16.4-hab9416b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
@@ -2335,11 +2330,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.5-py312he70551f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py312h2e8e312_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py312h90004f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_0.tar.bz2
@@ -2366,7 +2361,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openpyxl-3.1.5-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.2-h784c2ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py312h72972c8_1.conda
@@ -2387,7 +2382,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.08.0-h686f694_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.4-hd835ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-3.8.0-pyha770c72_0.conda
@@ -2418,7 +2413,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py312h53d5487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py312h53d5487_0.conda
@@ -2438,13 +2433,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rioxarray-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.20.0-py312h2615798_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.1-py312h7a6832a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.5.1-py312h816cc57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-72.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.5-py312h3a88d77_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.2-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.3-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
@@ -2507,7 +2502,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-he1f189c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h7606c53_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
@@ -2516,7 +2511,6 @@ environments:
       - pypi: src/bokeh_helpers
       - pypi: src/hydamo
       - pypi: src/peilbeheerst_model
-      - pypi: src/ribasim_lumping
       - pypi: src/ribasim_nl
 packages:
 - kind: conda
@@ -2832,37 +2826,16 @@ packages:
 - kind: conda
   name: aws-c-auth
   version: 0.7.25
-  build: h6309471_4
-  build_number: 4
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.25-h6309471_4.conda
-  sha256: 1bc76a69f0342dde6943f4aeaf410d7ce97fd59e7fd01a3b6493265d46417535
-  md5: d5e750ceeb6b8e7a4091b72fc35fafcf
-  depends:
-  - __osx >=10.13
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - aws-c-http >=0.8.7,<0.8.8.0a0
-  - aws-c-io >=0.14.18,<0.14.19.0a0
-  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 93886
-  timestamp: 1723215237016
-- kind: conda
-  name: aws-c-auth
-  version: 0.7.25
-  build: h8a0f778_4
-  build_number: 4
+  build: h15d0e8c_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h8a0f778_4.conda
-  sha256: 06f0fd8fdcee90c45d3f711dae3f7439f5895e3ef0c498484a2a67c781eff748
-  md5: aa51e240a99df535e64e3472f54652c9
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.25-h15d0e8c_6.conda
+  sha256: 0680ca18238e17d319f87bb8390d116292592c6f5534c66404542665d6149fae
+  md5: e0d292ba383ac09598c664186c0144cd
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
@@ -2870,20 +2843,41 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 106691
-  timestamp: 1723215154132
+  size: 107286
+  timestamp: 1723725324766
 - kind: conda
   name: aws-c-auth
   version: 0.7.25
-  build: he6981b3_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-he6981b3_4.conda
-  sha256: 1d6c1e645ca6dbfe240b038cf69612b920af939db638d6c76672d1d709eb2522
-  md5: 24b3c39664741663f52423700f8a9d39
+  build: h4880c77_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.25-h4880c77_6.conda
+  sha256: 31085909daaea5bc3d8288577a4f63de57a4bd7ab6510d0946c03b70edc1745d
+  md5: 31c5fb2e092df17d88d315f1deca5af6
   depends:
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - __osx >=10.13
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - aws-c-http >=0.8.7,<0.8.8.0a0
+  - aws-c-io >=0.14.18,<0.14.19.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 94011
+  timestamp: 1723725415937
+- kind: conda
+  name: aws-c-auth
+  version: 0.7.25
+  build: h7db803d_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.25-h7db803d_6.conda
+  sha256: 9dcb467b8f6b33c44fb4644501bcfe8dd0df9cd066b27e725aae22688a3fda01
+  md5: c17d2724a6f73adcaaf39d1271ca20b1
+  depends:
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
@@ -2893,19 +2887,38 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 102694
-  timestamp: 1723215631851
+  size: 102584
+  timestamp: 1723725722832
 - kind: conda
   name: aws-c-cal
-  version: 0.7.2
-  build: h0240d57_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.2-h0240d57_1.conda
-  sha256: 2af1e06136c0e70e420c33ffcfa3d0c750612b52d63c1a2312e8d700286b937d
-  md5: c5efc4764f0ef900773ce65ce22b1d30
+  version: 0.7.3
+  build: h8dac057_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.3-h8dac057_2.conda
+  sha256: bfd4f73855e926e6c7c9db700a17ef3ddb0e848b85edd04d766d50a008835407
+  md5: 577509458a061ddc9b089602ac6e1e98
   depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - libgcc-ng >=12
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 47317
+  timestamp: 1723674520890
+- kind: conda
+  name: aws-c-cal
+  version: 0.7.3
+  build: ha1e9ad3_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.7.3-ha1e9ad3_2.conda
+  sha256: 1bb4570afeb28f6b4693b4cb037d823308b40020b779f42d508d42dab0b44eaa
+  md5: c763ff9c4c712558ef72a460e4a2dbae
+  depends:
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - openssl >=3.3.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -2913,53 +2926,34 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 46834
-  timestamp: 1723150669417
+  size: 47054
+  timestamp: 1723675012781
 - kind: conda
   name: aws-c-cal
-  version: 0.7.2
-  build: h5b118bc_1
-  build_number: 1
+  version: 0.7.3
+  build: hf37c103_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.2-h5b118bc_1.conda
-  sha256: c25ac0b41c728d8cab471517b97f65388b82f800123b275555605b37aea2e16a
-  md5: 0ece7b2462d35fc9de1bc2015e42a243
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.7.3-hf37c103_2.conda
+  sha256: b008a16ac17edb0f5ecae88ee512ca6a1d5fdee3e4068eb73bd9656e7844ee3c
+  md5: 741ce62d05d8f62a74644c75f0179615
   depends:
   - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 39014
-  timestamp: 1723150485190
-- kind: conda
-  name: aws-c-cal
-  version: 0.7.2
-  build: h7970872_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.7.2-h7970872_1.conda
-  sha256: 060d9fba6b18781aff862ca84b5b11f4681f6dc364c70856e5ab5d61cf5eb324
-  md5: f7f648ab6e51b66d2ada922498547732
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - libgcc-ng >=12
-  - openssl >=3.3.1,<4.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 47118
-  timestamp: 1723150410207
+  size: 39391
+  timestamp: 1723674565375
 - kind: conda
   name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   build: h2466b09_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.25-h2466b09_0.conda
-  sha256: ce2a6a0c430bb70f250ac58ca65fce111513e744d27acc0c408d8c5cb9f55e26
-  md5: 5d3cd0031dbfcd800f6f5a4122e84dc7
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.27-h2466b09_0.conda
+  sha256: 6d59ceca0f648ef0e6d6bce00dc3824a9340bf8fbffeafc80d4dbd230860579b
+  md5: 8355fbefc33c680fa1a96ba7d3365dfa
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -2967,105 +2961,125 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 233457
-  timestamp: 1722652430792
+  size: 235039
+  timestamp: 1723640170113
 - kind: conda
   name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   build: h4bc722e_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.25-h4bc722e_0.conda
-  sha256: af6dbf129de978b8960b1d130770878e5052d992232cbdd4ddf99d2ea705f931
-  md5: 8ae3ebc6f412a923466ae673a3b3953f
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.27-h4bc722e_0.conda
+  sha256: b1725a5ec43bcf606d6bdb248312aa51386b30339dd83a1f16edf620fe03d941
+  md5: 817119e8a21a45d325f65d0d54710052
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 236289
-  timestamp: 1722651969732
+  size: 236759
+  timestamp: 1723639577027
 - kind: conda
   name: aws-c-common
-  version: 0.9.25
+  version: 0.9.27
   build: hfdf4475_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.25-hfdf4475_0.conda
-  sha256: aa0034bf17d2b24642a9f861852d725f2ea4f9b14fb90ffc06405e1dc52138ab
-  md5: d76bf5c5229ee864ccae59bba017e0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.27-hfdf4475_0.conda
+  sha256: 3420001537d36a20c81c0a832f95feec849bc50cec4429025498498de8c6be0a
+  md5: 3248125bfac52e553ebb6d010176cc1a
   depends:
   - __osx >=10.13
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 225876
-  timestamp: 1722652021377
+  size: 225349
+  timestamp: 1723639748928
 - kind: conda
   name: aws-c-compression
   version: 0.2.18
-  build: h0240d57_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-h0240d57_8.conda
-  sha256: 9c7f3e6544987df22f8f5f38e14eac2d0d954659875e928f91a4d83b4857edca
-  md5: f8edfe3c145f2d12c7a94055238e3979
+  build: h038f3f9_10
+  build_number: 10
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h038f3f9_10.conda
+  sha256: d8911cff9a3a61af5dc2b30e6d5a3b79f269f0c6af2854a5315bc248c7b5f8a2
+  md5: 76b09778c1bd489de8691349fd4a73d0
   depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 19017
+  timestamp: 1723674561003
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.18
+  build: ha1e9ad3_10
+  build_number: 10
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-ha1e9ad3_10.conda
+  sha256: 4d9a6c0d98d2f70158cd8c35fffeeb163b6d9ed51cdf71b17c10b369d6b04d03
+  md5: 303ba17cb3c685e15ddc17e7f9774772
+  depends:
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 22565
-  timestamp: 1723151107259
+  size: 22487
+  timestamp: 1723675004991
 - kind: conda
   name: aws-c-compression
   version: 0.2.18
-  build: h5b118bc_8
-  build_number: 8
+  build: hf37c103_10
+  build_number: 10
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h5b118bc_8.conda
-  sha256: c24ac2c84431237423162804bda58d71e2afe0e8d40349b5195d610fa3ff2aca
-  md5: 9abd3cf6a8559f3cd3870aee63007134
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-hf37c103_10.conda
+  sha256: 03ea1d1d1c64f691610ed13e8435522af729819b1ae5698134a8a71103c2aafa
+  md5: 42578f83cdd0023f2fa09274cc219a44
   depends:
   - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 17991
-  timestamp: 1723150633995
-- kind: conda
-  name: aws-c-compression
-  version: 0.2.18
-  build: hc649ecc_8
-  build_number: 8
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-hc649ecc_8.conda
-  sha256: ef8666bd07183f32219e7de3faf26c16d6acdd42769be0bb15b3668d0c89deba
-  md5: b72e4162acb0cf997185fc1da432a63e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 19009
-  timestamp: 1723150618661
+  size: 17949
+  timestamp: 1723674703315
 - kind: conda
   name: aws-c-event-stream
   version: 0.4.2
-  build: h04a40c0_20
-  build_number: 20
+  build: h324d61a_21
+  build_number: 21
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h324d61a_21.conda
+  sha256: ab2d61092706426f9819230ef48a91d557f061694dc7e81b2c4b5c1a528bc9ff
+  md5: 13db8f3e82207ccf44502b4559da5ed0
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - aws-c-io >=0.14.18,<0.14.19.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 46641
+  timestamp: 1723711400871
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.4.2
+  build: h570d160_21
+  build_number: 21
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h04a40c0_20.conda
-  sha256: 7b0611ec00f0433db9163f1050cc0289abe380f43a499a7b09aed5976e94afa0
-  md5: 3c1a3aa8f0dd19e1a917b39620fda32c
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-h570d160_21.conda
+  sha256: 43fcaff53b6cbf554cae1949e421e15ee933570ddff4dd8d7522bc8e680cab37
+  md5: f6f77c408f324ed20bba4b32cb04d875
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
   - libgcc-ng >=12
@@ -3073,19 +3087,19 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 53682
-  timestamp: 1723177510411
+  size: 53514
+  timestamp: 1723711287620
 - kind: conda
   name: aws-c-event-stream
   version: 0.4.2
-  build: h330dd76_20
-  build_number: 20
+  build: hf2a634e_21
+  build_number: 21
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h330dd76_20.conda
-  sha256: 0580d2999a2ed936345aefd85fec917daef7bf75d0b066760b421692ac4f8f0f
-  md5: 7c396e1c1004e9a968cc77ebf6034a3c
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-hf2a634e_21.conda
+  sha256: cf6b72397b6bc6f201ce662695a6b6a12f4ecdca0ae90269a930c1f7d15292aa
+  md5: afde3d8ecc9caf1bc3d2b6396577ed71
   depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
   - ucrt >=10.0.20348.0
@@ -3094,40 +3108,40 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 54724
-  timestamp: 1723177958755
-- kind: conda
-  name: aws-c-event-stream
-  version: 0.4.2
-  build: h671840a_20
-  build_number: 20
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h671840a_20.conda
-  sha256: cf0876ec0c973ec040616ac77b05be1d79d077bf88e058b6f0c498db35b6d601
-  md5: 2eb9cb654f68fafe2cc22afbd2d16212
-  depends:
-  - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - aws-c-io >=0.14.18,<0.14.19.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 46357
-  timestamp: 1723177593432
+  size: 54798
+  timestamp: 1723711554331
 - kind: conda
   name: aws-c-http
   version: 0.8.7
-  build: h065a16f_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h065a16f_2.conda
-  sha256: d93c898fd33d1aba540f3fc67ff4f19c483c111fe65e3a27de224df1ab70bc67
-  md5: d97b893513c9f0e9c3fa65b2e9fac814
+  build: h3c4ec21_4
+  build_number: 4
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.7-h3c4ec21_4.conda
+  sha256: 0ef0e979b190f4a17ec272a8d679d1ec9f52a3887ac3cff60d7cde421e40fa3d
+  md5: 47710a3e44f5131db646d38aab891d81
   depends:
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - __osx >=10.13
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - aws-c-compression >=0.2.18,<0.2.19.0a0
+  - aws-c-io >=0.14.18,<0.14.19.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 164440
+  timestamp: 1723711297899
+- kind: conda
+  name: aws-c-http
+  version: 0.8.7
+  build: h6bd9195_4
+  build_number: 4
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.7-h6bd9195_4.conda
+  sha256: bf1af1c437c67429e83fefed87d63843d5935296b6ab75d9e744584049606353
+  md5: 7b80ad72c9a0f208eda3363e391b0106
+  depends:
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-compression >=0.2.18,<0.2.19.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - ucrt >=10.0.20348.0
@@ -3136,118 +3150,98 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 183105
-  timestamp: 1723178102709
+  size: 182267
+  timestamp: 1723711542833
 - kind: conda
   name: aws-c-http
   version: 0.8.7
-  build: h22e442e_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.7-h22e442e_2.conda
-  sha256: 6ab77886c207d4e983a9edd6da613cae82af880a053dbe05a3eeacb53bbf2744
-  md5: ce32f723ce4caf907ba85670f8152755
-  depends:
-  - __osx >=10.13
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - aws-c-compression >=0.2.18,<0.2.19.0a0
-  - aws-c-io >=0.14.18,<0.14.19.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 164244
-  timestamp: 1723177829809
-- kind: conda
-  name: aws-c-http
-  version: 0.8.7
-  build: hc9bb02b_2
-  build_number: 2
+  build: ha1f794c_4
+  build_number: 4
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-hc9bb02b_2.conda
-  sha256: 58a5830a4bb878568b231e3215d2eedfd713e1ee9ea58dbc5e54e1793ea017e5
-  md5: 1fa3da862ddcc9e9b0538fd58273a65e
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.7-ha1f794c_4.conda
+  sha256: 89f49970f60bd75a668273db036079615b3f8f4de4f67bf96e9e89d7977a1c73
+  md5: b506fe315f908ea9b94036a1e5de5e6e
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-compression >=0.2.18,<0.2.19.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - libgcc-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 197213
-  timestamp: 1723177819689
+  size: 197186
+  timestamp: 1723711186801
 - kind: conda
   name: aws-c-io
   version: 0.14.18
-  build: h3095dc9_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h3095dc9_2.conda
-  sha256: 7578e3f11648e3fd0ccd4f65ee09f0d69de55516b891c932a6212a10c694d396
-  md5: 0c3d97fd2baffa30fce84338d3e9bd19
-  depends:
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 161032
-  timestamp: 1723482456101
-- kind: conda
-  name: aws-c-io
-  version: 0.14.18
-  build: h3e50d33_2
-  build_number: 2
+  build: h0040ed1_5
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h3e50d33_2.conda
-  sha256: 8b94d550344392429931aa69f16c38cfd2dbb49ce1e5d2705cb10c8b735dd0ee
-  md5: 9b0aca26d579311a918a0f03047fc447
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h0040ed1_5.conda
+  sha256: 834f5bdf6ade6df5f437f5c81f8d5e28c7a4d591e13d5e81cfadc2682dd773d4
+  md5: 2f6316f09b3152fecc2d34ab69508e6a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - libgcc-ng >=12
   - s2n >=1.5.0,<1.5.1.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 159102
-  timestamp: 1723481752341
+  size: 158738
+  timestamp: 1723698313285
 - kind: conda
   name: aws-c-io
   version: 0.14.18
-  build: hddd658a_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hddd658a_2.conda
-  sha256: 25b7fb542ad15042d4e42538b4fd3ad98fef5e50ccdd743e03e0474301ad2f71
-  md5: dd6e6d2924fc7fe472908dfdc73aa1ce
+  build: h8d4122e_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.18-h8d4122e_5.conda
+  sha256: fd09a8b70cfa40507ceac9c8fa949da7c709c83ee0283290f2f11a01bcdf17ba
+  md5: 8cb89d13787c23f66bcc1f29351baa2a
   depends:
-  - __osx >=10.13
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 138461
-  timestamp: 1723481866356
+  size: 160344
+  timestamp: 1723698751903
+- kind: conda
+  name: aws-c-io
+  version: 0.14.18
+  build: hdc1c6f6_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hdc1c6f6_5.conda
+  sha256: 9f6b59a9672f49f0dbda71348aac28927256c42c36889d02693c50365ffb0047
+  md5: 5f557bf492424b940648da9d8c2277d9
+  depends:
+  - __osx >=10.13
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 138990
+  timestamp: 1723698324671
 - kind: conda
   name: aws-c-mqtt
   version: 0.10.4
-  build: h1efefa3_16
-  build_number: 16
+  build: h827f298_17
+  build_number: 17
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h1efefa3_16.conda
-  sha256: 4ca34b6277f62f0cc56da0e9bbff8529d7f749853c4ace9de6dd3833d1aac2e5
-  md5: 1de479e343cd06db94e05062ab9af2e0
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.4-h827f298_17.conda
+  sha256: 9804a9027ff17955953ef934c48e7344db43f8b0d90a7c45fa5afeecb4f8ae9e
+  md5: e623bc494578a42b34d439472e20a9b2
   depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - ucrt >=10.0.20348.0
@@ -3256,82 +3250,60 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 157467
-  timestamp: 1723193297143
+  size: 157632
+  timestamp: 1723726738411
 - kind: conda
   name: aws-c-mqtt
   version: 0.10.4
-  build: h3710d3a_16
-  build_number: 16
+  build: h93740dc_17
+  build_number: 17
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-h3710d3a_16.conda
-  sha256: f5ee04ec57c28aca7523beab62052bb75a6f91e19430f0a8c666cf70f6b07db2
-  md5: 60bb82553164fd9cb10bfafb6b61df65
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.4-h93740dc_17.conda
+  sha256: da059d67450af5aa87583f9ec231ed18ce481666f410e4964ffbde3ca0681a7f
+  md5: 3311cf7d8a088c450af9ee4b22972edd
   depends:
   - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 138348
-  timestamp: 1723192832275
+  size: 139161
+  timestamp: 1723726448430
 - kind: conda
   name: aws-c-mqtt
   version: 0.10.4
-  build: h674cf7e_16
-  build_number: 16
+  build: hc14a930_17
+  build_number: 17
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-h674cf7e_16.conda
-  sha256: 759a15d367ef69f24448ace52843c4999e1795710c4393ea86d7768b1934db93
-  md5: a96a7cd318b665b8784cbe7e67916f66
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.4-hc14a930_17.conda
+  sha256: bc176d82875700e0ee51ddaef188fd6ca2a44b2efc69e0cb434460319216049b
+  md5: f0e3f95a9f545d5975e8573f80cdb5fa
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - libgcc-ng >=12
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 163774
-  timestamp: 1723192743841
+  size: 163877
+  timestamp: 1723726327641
 - kind: conda
   name: aws-c-s3
   version: 0.6.4
-  build: h89cdba3_6
-  build_number: 6
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.4-h89cdba3_6.conda
-  sha256: 2bc2ac953500501abbfd3b8d9baee81ef7f91753733eb782fa488e748c9f6c46
-  md5: 3e2f8edf601210730c6f1613de9539cc
-  depends:
-  - __osx >=10.13
-  - aws-c-auth >=0.7.25,<0.7.26.0a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - aws-c-http >=0.8.7,<0.8.8.0a0
-  - aws-c-io >=0.14.18,<0.14.19.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 96890
-  timestamp: 1723207662384
-- kind: conda
-  name: aws-c-s3
-  version: 0.6.4
-  build: h9116173_6
-  build_number: 6
+  build: h21392f2_8
+  build_number: 8
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h9116173_6.conda
-  sha256: 49ca36fc4bae3cadeb703f4da0a8b0e6f5d5694b617fc1d34268f8537d5baf37
-  md5: 2e508c828a6b222906289373251043d5
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.6.4-h21392f2_8.conda
+  sha256: 8137069560d3778e790618a2817eb0c5da4e1a97cd5ff91c778e365b3147b737
+  md5: 15db0136544c378e00fd7158bf019a21
   depends:
   - aws-c-auth >=0.7.25,<0.7.26.0a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
@@ -3341,22 +3313,22 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 107716
-  timestamp: 1723208085431
+  size: 107820
+  timestamp: 1723739640662
 - kind: conda
   name: aws-c-s3
   version: 0.6.4
-  build: hbe604ca_6
-  build_number: 6
+  build: h558cea2_8
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-hbe604ca_6.conda
-  sha256: c184511cf6d733bbdfc80d68b3087d8743c735d7bb40176cef73d9521c8d921d
-  md5: a57d5bbd0559aed25766420bbd371aa0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.6.4-h558cea2_8.conda
+  sha256: 8206b63d89e1cf08a0e4bc4852cb15080bc9754df48acbc5e59fbe2ec50b3da8
+  md5: af03e7b03e929396fb80ffac1a676c89
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-c-auth >=0.7.25,<0.7.26.0a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
@@ -3365,180 +3337,179 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 111628
-  timestamp: 1723207613777
+  size: 111536
+  timestamp: 1723739247330
 - kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.19
-  build: h0240d57_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-h0240d57_0.conda
-  sha256: 2cd6632ec4fc50e868cb9b11acaa98405283cf7104136bbc16e22ab729cc2f98
-  md5: facd2e7d595af64ab74d0ffd0d70fb4f
-  depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 54917
-  timestamp: 1723176532090
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.19
-  build: h5b118bc_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-h5b118bc_0.conda
-  sha256: 4be90827a59b297f04238cf2970ca7039d64c2e06b1a1d7799e332143e8c2e7a
-  md5: 9b41d2dd02f9a56e2fb78e6d7f66fddf
-  depends:
-  - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 50982
-  timestamp: 1723176233601
-- kind: conda
-  name: aws-c-sdkutils
-  version: 0.1.19
-  build: hc649ecc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-hc649ecc_0.conda
-  sha256: dc1eaf29c3a4092ae653b3ce80d5c8dfdc73a20d70c62c25f6a0faff059cd3a1
-  md5: f1d4b80dfc062bc55cecc20148eb925a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 56083
-  timestamp: 1723176096906
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
-  build: h0240d57_8
-  build_number: 8
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-h0240d57_8.conda
-  sha256: 7ee5937729c1ee8fc05022c73423749a0486bbd6fe7f01e958532a5f7ee9d1ed
-  md5: f419be1f5cfd2645fa7f68bf410c8548
-  depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 52214
-  timestamp: 1723163987764
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
-  build: h5b118bc_8
+  name: aws-c-s3
+  version: 0.6.4
+  build: hd06a241_8
   build_number: 8
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h5b118bc_8.conda
-  sha256: 03d957215e7277d17742e46b4a11e523f619f4e2a2c80b3323469636cd0b3ff8
-  md5: 1b8bd81a2d96c873877f582215cb0145
-  depends:
-  - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 48670
-  timestamp: 1723163853774
-- kind: conda
-  name: aws-checksums
-  version: 0.1.18
-  build: hc649ecc_8
-  build_number: 8
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-hc649ecc_8.conda
-  sha256: 63ccb2a0b471dac505e95d6a623b041e00e8a2a734fd33fd101f7d3a0018becf
-  md5: 178504fd14f8486ce3153fa16371ceef
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - libgcc-ng >=12
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 49998
-  timestamp: 1723163750630
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.27.5
-  build: h53ac995_5
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.5-h53ac995_5.conda
-  sha256: c2dc1f9fd2e19c9d896cb2859e161d82d1d5ba9e4992e70566db8bc14e77863d
-  md5: 39e26358a446c7e2844f1da5e1d6e2c1
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.6.4-hd06a241_8.conda
+  sha256: 06764f43c21ecad9be0a546d4a8b798e353ede7058674c70ab4d259458b0e42e
+  md5: 192a67ed8897b6cfb844d83da17f3f36
   depends:
   - __osx >=10.13
   - aws-c-auth >=0.7.25,<0.7.26.0a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - aws-c-http >=0.8.7,<0.8.8.0a0
+  - aws-c-io >=0.14.18,<0.14.19.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 96550
+  timestamp: 1723739435090
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.19
+  build: h038f3f9_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.19-h038f3f9_2.conda
+  sha256: 5612c9cad56662db50a1bcc2d8dca1fe273f7abad6f670fef328e4044beabc75
+  md5: 6861cab6cddb5d713cb3db95c838d30f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 55878
+  timestamp: 1723691348466
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.19
+  build: ha1e9ad3_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.19-ha1e9ad3_2.conda
+  sha256: c87e00f73686c3b43f0a2d6ff480f28d2a8f07811bad5e406bbe0ca8240bbba4
+  md5: da087023762ab6dc62fd1d374b6cc30f
+  depends:
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 54992
+  timestamp: 1723691803596
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.19
+  build: hf37c103_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.19-hf37c103_2.conda
+  sha256: 7c1d055c1f67e4572de18e9daec81b74f59a6f77c2213746dab3cf12b5be253f
+  md5: a8f45839733a97c206cd5df6945c4a27
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 50490
+  timestamp: 1723691467686
+- kind: conda
+  name: aws-checksums
+  version: 0.1.18
+  build: h038f3f9_10
+  build_number: 10
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h038f3f9_10.conda
+  sha256: a94547ff766fb420c368bb8d4fd1c8d99b13088d176c43ad7bb7458ef47e45bc
+  md5: 4bf9c8fcf2bb6793c55e5c5758b9b011
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 49839
+  timestamp: 1723691467978
+- kind: conda
+  name: aws-checksums
+  version: 0.1.18
+  build: ha1e9ad3_10
+  build_number: 10
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-ha1e9ad3_10.conda
+  sha256: d992544ad6ab4fc55bae80bdff9ab6c9d71b021c91297e835e3999b9cab4645c
+  md5: 93c84eec0955253bf07b5fbff95c6200
+  depends:
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 52177
+  timestamp: 1723691948336
+- kind: conda
+  name: aws-checksums
+  version: 0.1.18
+  build: hf37c103_10
+  build_number: 10
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-hf37c103_10.conda
+  sha256: e42c8e70a71e9bd7a228328a5b51efae0c15bd8ef7ed26fae238461a8335f699
+  md5: 86fb971912f9222b14b0b3e695c52461
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 48683
+  timestamp: 1723691504517
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.27.5
+  build: h1307057_7
+  build_number: 7
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h1307057_7.conda
+  sha256: 8812a9e7e789521626df6a488d94524d13d18559d7a96069802057765e85bd50
+  md5: 4b49f5b85db0ad1b87f8a1ab1f7de4a0
+  depends:
+  - aws-c-auth >=0.7.25,<0.7.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
   - aws-c-mqtt >=0.10.4,<0.10.5.0a0
   - aws-c-s3 >=0.6.4,<0.6.5.0a0
   - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
-  - libcxx >=16
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 290343
-  timestamp: 1723235660535
-- kind: conda
-  name: aws-crt-cpp
-  version: 0.27.5
-  build: h55e8508_5
-  build_number: 5
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.27.5-h55e8508_5.conda
-  sha256: 3e8cd7ad1e13eb204443f44de13d5e9041c656102da5728c8b030f2c4953d8b5
-  md5: 1432fe717f2d651606acd0f8b52277a9
-  depends:
-  - aws-c-auth >=0.7.25,<0.7.26.0a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
-  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-c-http >=0.8.7,<0.8.8.0a0
-  - aws-c-io >=0.14.18,<0.14.19.0a0
-  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
-  - aws-c-s3 >=0.6.4,<0.6.5.0a0
-  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 254293
-  timestamp: 1723235803498
+  size: 254234
+  timestamp: 1723755473861
 - kind: conda
   name: aws-crt-cpp
   version: 0.27.5
-  build: hba11562_5
-  build_number: 5
+  build: hd0b8a3b_7
+  build_number: 7
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-hba11562_5.conda
-  sha256: 6c2d72591495d68b17d6f428b32517a9b59b710eafdc8200e627780812886e6f
-  md5: 3b97f88120ba6bc6c53b428954a15895
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.27.5-hd0b8a3b_7.conda
+  sha256: c2d149777484817c09ec01f4cc4b35c5c2c678b347436c5b44b237bb07926e58
+  md5: 059dc1576393ab4b807e74f90e5db6d9
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-c-auth >=0.7.25,<0.7.26.0a0
-  - aws-c-cal >=0.7.2,<0.7.3.0a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-c-http >=0.8.7,<0.8.8.0a0
   - aws-c-io >=0.14.18,<0.14.19.0a0
@@ -3550,43 +3521,45 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 345928
-  timestamp: 1723235386758
+  size: 345538
+  timestamp: 1723755126477
 - kind: conda
-  name: aws-sdk-cpp
-  version: 1.11.379
-  build: h065e723_2
-  build_number: 2
+  name: aws-crt-cpp
+  version: 0.27.5
+  build: hfadd0b3_7
+  build_number: 7
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.379-h065e723_2.conda
-  sha256: 4c35cae6be1dbce28a555b014513f511d47005b98aecb3252f00087215dbbef8
-  md5: b9f139d1a5247fdbcbd2b102433d2960
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.27.5-hfadd0b3_7.conda
+  sha256: 0c1940f584eb1997829b532b9653a165b30efcc8aa624320d710329275ff91d2
+  md5: 2b9c297b37768ef5164f57044a10693b
   depends:
   - __osx >=10.13
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-auth >=0.7.25,<0.7.26.0a0
+  - aws-c-cal >=0.7.3,<0.7.4.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
-  - aws-checksums >=0.1.18,<0.1.19.0a0
-  - aws-crt-cpp >=0.27.5,<0.27.6.0a0
-  - libcurl >=8.9.1,<9.0a0
+  - aws-c-http >=0.8.7,<0.8.8.0a0
+  - aws-c-io >=0.14.18,<0.14.19.0a0
+  - aws-c-mqtt >=0.10.4,<0.10.5.0a0
+  - aws-c-s3 >=0.6.4,<0.6.5.0a0
+  - aws-c-sdkutils >=0.1.19,<0.1.20.0a0
   - libcxx >=16
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 2700929
-  timestamp: 1723471903012
+  size: 290536
+  timestamp: 1723755230863
 - kind: conda
   name: aws-sdk-cpp
   version: 1.11.379
-  build: h2205d66_2
-  build_number: 2
+  build: h21b9f41_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h2205d66_2.conda
-  sha256: 4c64f829f589fdb36e77ecc63f9c289d69052be2b7b4d7a6dfe22d842bc6f0cd
-  md5: 6abcadee194e8becd912c9a0b75eddc0
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.379-h21b9f41_3.conda
+  sha256: c53cceee2087da0fff642d66b008cac914552a9c0026cf9fc23efea86a6efd50
+  md5: 13821fb121b16aa0e0cc7f18b8d9f5a9
   depends:
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
   - aws-crt-cpp >=0.27.5,<0.27.6.0a0
@@ -3597,20 +3570,20 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 2766410
-  timestamp: 1723472583120
+  size: 2756951
+  timestamp: 1723787192284
 - kind: conda
   name: aws-sdk-cpp
   version: 1.11.379
-  build: he20dfa5_2
-  build_number: 2
+  build: h7dc8893_3
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-he20dfa5_2.conda
-  sha256: a43661e14ad9d51c0c9330effbc86d9960096484181402dd43bd9617c803f67b
-  md5: 25a12549e0aeeaa2718035c3e54ff520
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.379-h7dc8893_3.conda
+  sha256: 96f9e805f00ee56c8e5c9cbb04bb8360e15ea5c22e88d36a8377cefefb936894
+  md5: c077ea74db96ebfd3366a2bae0701448
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-c-common >=0.9.25,<0.9.26.0a0
+  - aws-c-common >=0.9.27,<0.9.28.0a0
   - aws-c-event-stream >=0.4.2,<0.4.3.0a0
   - aws-checksums >=0.1.18,<0.1.19.0a0
   - aws-crt-cpp >=0.27.5,<0.27.6.0a0
@@ -3622,8 +3595,32 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 2917924
-  timestamp: 1723471330992
+  size: 2906830
+  timestamp: 1723786045735
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.379
+  build: hae762b9_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.379-hae762b9_3.conda
+  sha256: 2079d4eba178919607cc817a620c68b7693e18fb4e5ac3bd0da0aeb1ec034fbf
+  md5: 66fa6729fc9979a5c92b112555b10be0
+  depends:
+  - __osx >=10.13
+  - aws-c-common >=0.9.27,<0.9.28.0a0
+  - aws-c-event-stream >=0.4.2,<0.4.3.0a0
+  - aws-checksums >=0.1.18,<0.1.19.0a0
+  - aws-crt-cpp >=0.27.5,<0.27.6.0a0
+  - libcurl >=8.9.1,<9.0a0
+  - libcxx >=16
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.1,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 2734389
+  timestamp: 1723786790239
 - kind: conda
   name: azure-core-cpp
   version: 1.13.0
@@ -4436,21 +4433,21 @@ packages:
   timestamp: 1615209567874
 - kind: conda
   name: cachetools
-  version: 5.4.0
+  version: 5.5.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.4.0-pyhd8ed1ab_0.conda
-  sha256: 02f52917d6724960629c20dbdf9f8def95b1784acd600763ea41af47d905afbd
-  md5: c55fbbc5bac8e9efbba71c0d1ed57713
+  url: https://conda.anaconda.org/conda-forge/noarch/cachetools-5.5.0-pyhd8ed1ab_0.conda
+  sha256: 0abdbbfc2e9c21079a943f42a2dcd950b1a8093ec474fc017e83da0ec4e6cbf4
+  md5: 5bad039db72bd8f134a5cff3ebaa190d
   depends:
   - python >=3.7
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/cachetools?source=hash-mapping
-  size: 14722
-  timestamp: 1721092006298
+  - pkg:pypi/cachetools?source=compressed-mapping
+  size: 14727
+  timestamp: 1724028288793
 - kind: conda
   name: cairo
   version: 1.18.0
@@ -4831,13 +4828,13 @@ packages:
   timestamp: 1710320435158
 - kind: conda
   name: contextily
-  version: 1.6.0
+  version: 1.6.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.0-pyhd8ed1ab_0.conda
-  sha256: 3e70e8cdffc1b6134076f720e864caa29250160a2c4f726dbf557210554fbf46
-  md5: a3e5ccece003758e379be05cb5a08dff
+  url: https://conda.anaconda.org/conda-forge/noarch/contextily-1.6.1-pyhd8ed1ab_0.conda
+  sha256: e721843c13ffbdab3b22ad9c90479318117a29e830b33461bbf1ec01413e85a6
+  md5: 85b4886eca5c18c89e10a2c1fb4af7dc
   depends:
   - geopy
   - joblib
@@ -4851,9 +4848,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/contextily?source=hash-mapping
-  size: 20675
-  timestamp: 1710889182405
+  - pkg:pypi/contextily?source=compressed-mapping
+  size: 20535
+  timestamp: 1723612205680
 - kind: conda
   name: contourpy
   version: 1.2.1
@@ -5093,79 +5090,79 @@ packages:
   timestamp: 1683598364427
 - kind: conda
   name: dask
-  version: 2024.8.0
+  version: 2024.8.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.0-pyhd8ed1ab_0.conda
-  sha256: 00b84f6303b70f1e0902ce01b7a664bd7a04280d186f0c8af02dfff4b07d724e
-  md5: 795f3557b117402208fe1e0e20d943ed
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.8.1-pyhd8ed1ab_0.conda
+  sha256: 1d6a54316fc58cb3be63750dd9144087d2b6e9d3ee35a8077f25d6f2fd87cadd
+  md5: 95277bf15c984015cb76f85a629d622e
   depends:
   - bokeh >=2.4.2,!=3.0.*
   - cytoolz >=0.11.0
-  - dask-core >=2024.8.0,<2024.8.1.0a0
+  - dask-core >=2024.8.1,<2024.8.2.0a0
   - dask-expr >=1.1,<1.2
-  - distributed >=2024.8.0,<2024.8.1.0a0
+  - distributed >=2024.8.1,<2024.8.2.0a0
   - jinja2 >=2.10.3
   - lz4 >=4.3.2
   - numpy >=1.21
   - pandas >=2.0
   - pyarrow >=7.0
   - pyarrow-hotfix
-  - python >=3.9
+  - python >=3.10
   constrains:
   - openssl !=1.1.1e
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/dask?source=compressed-mapping
-  size: 7387
-  timestamp: 1722985330580
+  size: 7359
+  timestamp: 1723855241340
 - kind: conda
   name: dask-core
-  version: 2024.8.0
+  version: 2024.8.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.0-pyhd8ed1ab_0.conda
-  sha256: e4fc0235e03931d2d28d50f193c9a2c7b5ae8a70728dfd5a954f1d2cc7acfd92
-  md5: bf68bf9ff9a18f1b17aa8c817225aee0
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.8.1-pyhd8ed1ab_0.conda
+  sha256: 12aedcd752ae4113c348bf3b8dc1ebdc4aa59d9d2741f3b32a62214d490fe985
+  md5: 8fe3858b19843234b331d8459db3a7a1
   depends:
   - click >=8.1
-  - cloudpickle >=1.5.0
+  - cloudpickle >=3.0.0
   - fsspec >=2021.09.0
   - importlib_metadata >=4.13.0
   - packaging >=20.0
   - partd >=1.4.0
-  - python >=3.9
+  - python >=3.10
   - pyyaml >=5.3.1
   - toolz >=0.10.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/dask?source=compressed-mapping
-  size: 880801
-  timestamp: 1722976704493
+  size: 884957
+  timestamp: 1723847729382
 - kind: conda
   name: dask-expr
-  version: 1.1.10
+  version: 1.1.11
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.10-pyhd8ed1ab_0.conda
-  sha256: dfdcba9779b01f6f1048b78b0357f466bf08ab3466be52c03a571ce64a6b7f3c
-  md5: 88efd31bf04d9f7a2ac7d02ab568d37d
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-expr-1.1.11-pyhd8ed1ab_0.conda
+  sha256: 60269fbb234fa2eab8b919b607b4514abb60f30d206552e27c9043367a1dfb4a
+  md5: e66672d843c0bfc65f2e4f9badaf6ba9
   depends:
-  - dask-core 2024.8.0
+  - dask-core 2024.8.1
   - pandas >=2
   - pyarrow
-  - python >=3.9
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/dask-expr?source=compressed-mapping
-  size: 184908
-  timestamp: 1722982755863
+  size: 185254
+  timestamp: 1723851662768
 - kind: conda
   name: dbus
   version: 1.13.6
@@ -5393,30 +5390,30 @@ packages:
   timestamp: 1702383349284
 - kind: conda
   name: distributed
-  version: 2024.8.0
+  version: 2024.8.1
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.0-pyhd8ed1ab_0.conda
-  sha256: ecc6061749213572490b8f118bdfc24729350c302d6b6baaf20d398f814708f5
-  md5: f9a7fbaeb79d4b57d1ed742930b4eec4
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.8.1-pyhd8ed1ab_0.conda
+  sha256: 23410253f3226cf29a69a07cd4148ec2ef520c62b36ea60a2c51e4154b1ae3b4
+  md5: 5e5a5b4d85a972250b52cb54452085fd
   depends:
   - click >=8.0
-  - cloudpickle >=1.5.0
-  - cytoolz >=0.10.1
-  - dask-core >=2024.8.0,<2024.8.1.0a0
+  - cloudpickle >=2.0.0
+  - cytoolz >=0.11.2
+  - dask-core >=2024.8.1,<2024.8.2.0a0
   - jinja2 >=2.10.3
   - locket >=1.0.0
-  - msgpack-python >=1.0.0
+  - msgpack-python >=1.0.2
   - packaging >=20.0
-  - psutil >=5.7.2
-  - python >=3.9
-  - pyyaml >=5.3.1
+  - psutil >=5.8.0
+  - python >=3.10
+  - pyyaml >=5.4.1
   - sortedcontainers >=2.0.5
   - tblib >=1.6.0
-  - toolz >=0.10.0
-  - tornado >=6.0.4
-  - urllib3 >=1.24.3
+  - toolz >=0.11.2
+  - tornado >=6.2.0
+  - urllib3 >=1.26.5
   - zict >=3.0.0
   constrains:
   - openssl !=1.1.1e
@@ -5424,8 +5421,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/distributed?source=compressed-mapping
-  size: 799976
-  timestamp: 1722982630801
+  size: 801253
+  timestamp: 1723851507373
 - kind: conda
   name: double-conversion
   version: 3.3.0
@@ -5478,45 +5475,45 @@ packages:
   timestamp: 1643888357950
 - kind: conda
   name: esbuild
-  version: 0.19.2
+  version: 0.23.1
   build: h57928b3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.19.2-h57928b3_0.conda
-  sha256: 7a6354b23d03a4eaff672e4d20cf4a6c554da31be506050055af97f4b023a8b9
-  md5: 7250cb4e9c20f9f7acdf4b523844ad90
+  url: https://conda.anaconda.org/conda-forge/win-64/esbuild-0.23.1-h57928b3_0.conda
+  sha256: 987d31dda73564de7a38b51b12f42f9ba23ac356a60614729b46bda3b53acc50
+  md5: 20023013c76ef62e689fa34b8e51199a
   license: MIT
   license_family: MIT
   purls: []
-  size: 3430198
-  timestamp: 1693244283213
+  size: 3708244
+  timestamp: 1724050551357
 - kind: conda
   name: esbuild
-  version: 0.19.2
+  version: 0.23.1
   build: h694c41f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.19.2-h694c41f_0.conda
-  sha256: 3c52971d424630e4e5e749208c144bd070b94ae404aa8ea72ae20c9e5300517d
-  md5: 61cc0fd0aa08d9a37b2df02b88c00203
+  url: https://conda.anaconda.org/conda-forge/osx-64/esbuild-0.23.1-h694c41f_0.conda
+  sha256: 0828b2997ce2671ff1c55145037574e941a02569a2dbbc475eb68696779a19f4
+  md5: 1c23b8c781689627dd6ded1ec90d1ea3
   constrains:
   - __osx>=10.12
   license: MIT
   license_family: MIT
   purls: []
-  size: 3465734
-  timestamp: 1693243810332
+  size: 3701817
+  timestamp: 1724050164186
 - kind: conda
   name: esbuild
-  version: 0.19.2
+  version: 0.23.1
   build: ha770c72_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.19.2-ha770c72_0.conda
-  sha256: bb6dee100b3f62ee088a212834c9d47ad158f3fc678ff595e402803db5fab871
-  md5: 8fa87b764cf6143cb66e9cc3548b186a
+  url: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.23.1-ha770c72_0.conda
+  sha256: 8d62023e9066d40ac99dec68b8ced2e123f4ffeb4288a4c716c1d397cdf115ed
+  md5: 7e6d8acdf44ce73a7fd2f36e83f4f2ec
   license: MIT
   license_family: MIT
   purls: []
-  size: 3376650
-  timestamp: 1693243729127
+  size: 3634821
+  timestamp: 1724050078722
 - kind: conda
   name: et_xmlfile
   version: 1.1.0
@@ -6169,15 +6166,14 @@ packages:
   timestamp: 1719515065535
 - kind: conda
   name: gdal
-  version: 3.9.1
-  build: py312h16ac12d_11
-  build_number: 11
+  version: 3.9.2
+  build: py312h16ac12d_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.1-py312h16ac12d_11.conda
-  sha256: 36795d468298d5f27191e9dbe31c25b54a0a80f5f72b70ddd9433b323bf2ae09
-  md5: 8324a27870e45e0a60b1cfeee0c6a2eb
+  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.9.2-py312h16ac12d_0.conda
+  sha256: 731397cc0c20d0d6bfffbf4eef9452dc44c72112e37d45f85f0392dd9b65ff78
+  md5: e1c0f151032531482eff718d1cc0f116
   depends:
-  - libgdal-core 3.9.1.*
+  - libgdal-core 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libxml2 >=2.12.7,<3.0a0
   - numpy >=1.19,<3
@@ -6190,21 +6186,20 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=compressed-mapping
-  size: 1637775
-  timestamp: 1722900200350
+  size: 1631798
+  timestamp: 1723840488189
 - kind: conda
   name: gdal
-  version: 3.9.1
-  build: py312h29648be_11
-  build_number: 11
+  version: 3.9.2
+  build: py312h29648be_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.1-py312h29648be_11.conda
-  sha256: 7638d876c829e51298d9f1a1455a87e3986f58ec0e29c733005bd26c039101db
-  md5: 18e787b6444ae3680a096541d2bd0609
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.9.2-py312h29648be_0.conda
+  sha256: baf58f017cf4a0ad17a51648e259631fd288996dd8563d2887a262cce5a0511c
+  md5: 64122edb42acc4ec068eccbb891b6e54
   depends:
   - __osx >=10.13
   - libcxx >=16
-  - libgdal-core 3.9.1.*
+  - libgdal-core 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libxml2 >=2.12.7,<3.0a0
   - numpy >=1.19,<3
@@ -6214,21 +6209,20 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=compressed-mapping
-  size: 1677048
-  timestamp: 1723057578141
+  size: 1676335
+  timestamp: 1723839692636
 - kind: conda
   name: gdal
-  version: 3.9.1
-  build: py312h7eda2e2_11
-  build_number: 11
+  version: 3.9.2
+  build: py312h7eda2e2_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.1-py312h7eda2e2_11.conda
-  sha256: e2a517a295fc75159d588c0db2916576257b68a6113a2b985a3bc08da5b41537
-  md5: 7a40644d29c00c2ae81d19422ad19936
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.9.2-py312h7eda2e2_0.conda
+  sha256: 7d4bc28c1e243e82ee07097de1184eec1208593006c325c7cbe807ceeca5740c
+  md5: 92dfbc773e70ce5a5728135378da5766
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  - libgdal-core 3.9.1.*
+  - libgdal-core 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libstdcxx-ng >=12
   - libxml2 >=2.12.7,<3.0a0
@@ -6239,8 +6233,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=compressed-mapping
-  size: 1692288
-  timestamp: 1722899129205
+  size: 1699202
+  timestamp: 1723839179852
 - kind: conda
   name: geocube
   version: 0.5.2
@@ -6598,23 +6592,22 @@ packages:
   timestamp: 1711634622644
 - kind: conda
   name: griffe
-  version: 0.48.0
+  version: 1.1.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.48.0-pyhd8ed1ab_0.conda
-  sha256: 528411c09a2a7bd0a6590601f89ca9a21fe9fb908a67e87d889d2a86205dd850
-  md5: 73aafef908b0b8948d739e11ebf92d32
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-1.1.0-pyhd8ed1ab_0.conda
+  sha256: 5a23282aa11b5b2e5df0202769a3654936d5f905a80779f3ac021e4074069616
+  md5: da6d3a480566b6bbccc608c436db7696
   depends:
   - astunparse >=1.6
   - colorama >=0.4
   - python >=3.8
-  license: MIT
-  license_family: MIT
+  license: ISC
   purls:
-  - pkg:pypi/griffe?source=hash-mapping
-  size: 101827
-  timestamp: 1721049777473
+  - pkg:pypi/griffe?source=compressed-mapping
+  size: 95827
+  timestamp: 1723945410234
 - kind: conda
   name: h11
   version: 0.14.0
@@ -7016,21 +7009,21 @@ packages:
   timestamp: 1721856614564
 - kind: conda
   name: importlib-resources
-  version: 6.4.0
+  version: 6.4.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.0-pyhd8ed1ab_0.conda
-  sha256: 38db827f445ae437a15d50a94816ae67a48285d0700f736af3eb90800a71f079
-  md5: dcbadab7a68738a028e195ab68ab2d2e
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.4.3-pyhd8ed1ab_0.conda
+  sha256: 4611a7ef21e4bf1b7e67493aacdf69d37e9ca972d7e0f197627316e0790e168b
+  md5: b8fd70ef9ad7a171ce220f4bf3201883
   depends:
-  - importlib_resources >=6.4.0,<6.4.1.0a0
+  - importlib_resources >=6.4.3,<6.4.4.0a0
   - python >=3.8
   license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 9657
-  timestamp: 1711041029062
+  purls:
+  - pkg:pypi/importlib-resources?source=compressed-mapping
+  size: 9521
+  timestamp: 1724060191769
 - kind: conda
   name: importlib_metadata
   version: 8.2.0
@@ -7049,24 +7042,23 @@ packages:
   timestamp: 1721856618848
 - kind: conda
   name: importlib_resources
-  version: 6.4.0
+  version: 6.4.3
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.0-pyhd8ed1ab_0.conda
-  sha256: c6ae80c0beaeabb342c5b041f19669992ae6e937dbec56ced766cb035900f9de
-  md5: c5d3907ad8bd7bf557521a1833cf7e6d
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.3-pyhd8ed1ab_0.conda
+  sha256: 310ce095eada15a5cb5611c26e2c1caacd02f894452642b787db44ef86d668bf
+  md5: 82b36c572ecc0d42c612203769e19de5
   depends:
   - python >=3.8
   - zipp >=3.1.0
   constrains:
-  - importlib-resources >=6.4.0,<6.4.1.0a0
+  - importlib-resources >=6.4.3,<6.4.4.0a0
   license: Apache-2.0
-  license_family: APACHE
   purls:
-  - pkg:pypi/importlib-resources?source=hash-mapping
-  size: 33056
-  timestamp: 1711041009039
+  - pkg:pypi/importlib-resources?source=compressed-mapping
+  size: 32045
+  timestamp: 1724060180208
 - kind: conda
   name: iniconfig
   version: 2.0.0
@@ -7086,18 +7078,18 @@ packages:
   timestamp: 1673103208955
 - kind: conda
   name: intel-openmp
-  version: 2024.2.0
-  build: h57928b3_980
-  build_number: 980
+  version: 2024.2.1
+  build: h57928b3_1083
+  build_number: 1083
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.0-h57928b3_980.conda
-  sha256: e3ddfb67e0a922868e68f83d0b56755ff1c280ffa959a0c5ee6a922aaf7022b0
-  md5: 9c28c39e64871a0adef7d1195bd58655
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
+  sha256: 0fd2b0b84c854029041b0ede8f4c2369242ee92acc0092f8407b1fe9238a8209
+  md5: 2d89243bfb53652c182a7c73182cce4f
   license: LicenseRef-IntelSimplifiedSoftwareOct2022
   license_family: Proprietary
   purls: []
-  size: 1860328
-  timestamp: 1721088141110
+  size: 1852356
+  timestamp: 1723739573141
 - kind: conda
   name: ipykernel
   version: 6.29.5
@@ -8230,12 +8222,55 @@ packages:
 - kind: conda
   name: libarrow
   version: 17.0.0
-  build: h009c9d4_7_cpu
-  build_number: 7
+  build: h2952479_8_cpu
+  build_number: 8
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h2952479_8_cpu.conda
+  sha256: 176e9d4269392c1056d2873bc7342a3707ae76e69a0c28244e1eb849d178d8f6
+  md5: c72368f864d0c02dd690b95c37330cc3
+  depends:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.27.5,<0.27.6.0a0
+  - aws-sdk-cpp >=1.11.379,<1.11.380.0a0
+  - azure-core-cpp >=1.13.0,<1.13.1.0a0
+  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
+  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
+  - azure-storage-files-datalake-cpp >=12.11.0,<12.11.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.7.1,<0.8.0a0
+  - libabseil * cxx17*
+  - libabseil >=20240116.2,<20240117.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=17
+  - libgoogle-cloud >=2.28.0,<2.29.0a0
+  - libgoogle-cloud-storage >=2.28.0,<2.29.0a0
+  - libre2-11 >=2023.9.1,<2024.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - orc >=2.0.2,<2.0.3.0a0
+  - re2
+  - snappy >=1.2.1,<1.3.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 5906936
+  timestamp: 1723787555959
+- kind: conda
+  name: libarrow
+  version: 17.0.0
+  build: h6e8cf4f_8_cpu
+  build_number: 8
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h009c9d4_7_cpu.conda
-  sha256: ee2cd257ffdb6ace2e3989261562f3e71dd032414e8e8668fdb8065e5f84d974
-  md5: de9fcb1a5fcb0071ef97547cb387c99e
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-17.0.0-h6e8cf4f_8_cpu.conda
+  sha256: 678017b1f42a0d7413e967e4cd8c6ddde4fc5fd54ec539fe4ab8b28c469c255b
+  md5: 62ff39484dee01fdcde69bd40de4cd9b
   depends:
   - aws-crt-cpp >=0.27.5,<0.27.6.0a0
   - aws-sdk-cpp >=1.11.379,<1.11.380.0a0
@@ -8252,7 +8287,7 @@ packages:
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.1,<2.0.2.0a0
+  - orc >=2.0.2,<2.0.3.0a0
   - re2
   - snappy >=1.2.1,<1.3.0a0
   - ucrt >=10.0.20348.0
@@ -8261,21 +8296,22 @@ packages:
   - zstd >=1.5.6,<1.6.0a0
   constrains:
   - arrow-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 5111517
-  timestamp: 1723542348657
+  size: 5155629
+  timestamp: 1723787774579
 - kind: conda
   name: libarrow
   version: 17.0.0
-  build: h03aeac6_7_cpu
-  build_number: 7
+  build: h8756180_8_cpu
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h03aeac6_7_cpu.conda
-  sha256: 745e9f84761da075f0bbe0f0279f0b74aeb1c29811e3eaa9d46f8de1ad897887
-  md5: 25225d90d4fb125c5fbb6f87cc1aa309
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-17.0.0-h8756180_8_cpu.conda
+  sha256: 8ec8b6b036e96e3b3336b2a0ba6031c12366a44a102db1dc1a2f390d3114a70f
+  md5: 7fac330a6725172a912cc484a0f93825
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-crt-cpp >=0.27.5,<0.27.6.0a0
@@ -8299,240 +8335,208 @@ packages:
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.1,<2.0.2.0a0
+  - orc >=2.0.2,<2.0.3.0a0
   - re2
   - snappy >=1.2.1,<1.3.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
-  license: Apache-2.0
-  purls: []
-  size: 8426146
-  timestamp: 1723541363316
-- kind: conda
-  name: libarrow
-  version: 17.0.0
-  build: h1496d7c_7_cpu
-  build_number: 7
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-17.0.0-h1496d7c_7_cpu.conda
-  sha256: e62f3cd45b6aa94f1eb6232600249d9d5dcb680bc2854fcca15dc3c7c50af894
-  md5: be0534bed8a979674e528dec5ef89fb7
-  depends:
-  - __osx >=10.13
-  - aws-crt-cpp >=0.27.5,<0.27.6.0a0
-  - aws-sdk-cpp >=1.11.379,<1.11.380.0a0
-  - azure-core-cpp >=1.13.0,<1.13.1.0a0
-  - azure-identity-cpp >=1.8.0,<1.8.1.0a0
-  - azure-storage-blobs-cpp >=12.12.0,<12.12.1.0a0
-  - azure-storage-files-datalake-cpp >=12.11.0,<12.11.1.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - glog >=0.7.1,<0.8.0a0
-  - libabseil * cxx17*
-  - libabseil >=20240116.2,<20240117.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcxx >=17
-  - libgoogle-cloud >=2.28.0,<2.29.0a0
-  - libgoogle-cloud-storage >=2.28.0,<2.29.0a0
-  - libre2-11 >=2023.9.1,<2024.0a0
-  - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - orc >=2.0.1,<2.0.2.0a0
-  - re2
-  - snappy >=1.2.1,<1.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  constrains:
   - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
-  - parquet-cpp <0.0a0
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 5915515
-  timestamp: 1723541344913
+  size: 8423523
+  timestamp: 1723787570616
 - kind: conda
   name: libarrow-acero
   version: 17.0.0
-  build: hac325c4_7_cpu
-  build_number: 7
+  build: hac325c4_8_cpu
+  build_number: 8
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hac325c4_7_cpu.conda
-  sha256: f487992826886f107be925fd01815f9fb6e5b2b8a2c94a089419d029a466d771
-  md5: be82d3380561e0e1da14ba4b75e3a48f
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-17.0.0-hac325c4_8_cpu.conda
+  sha256: 03b050f81e80357acc85a4bad183a4b4405c6f483e6226b59df7046219063d97
+  md5: 0959238adfeefd5d4faa56f969c086a1
   depends:
   - __osx >=10.13
-  - libarrow 17.0.0 h1496d7c_7_cpu
+  - libarrow 17.0.0 h2952479_8_cpu
   - libcxx >=17
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 515097
-  timestamp: 1723541474559
+  size: 514783
+  timestamp: 1723787684450
 - kind: conda
   name: libarrow-acero
   version: 17.0.0
-  build: he02047a_7_cpu
-  build_number: 7
+  build: he02047a_8_cpu
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_7_cpu.conda
-  sha256: d0f5d0ae8266d83de7b1398c061d5b499c6899742029d80a262f34d3b613012d
-  md5: 64ba31c035986db4e46f98410607498e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-17.0.0-he02047a_8_cpu.conda
+  sha256: b4d5546c8c7a1dc4476fa88c97f0bca9720f6ece1f60873625989d900f1eb85b
+  md5: 1151aa2dcc30d03c775b8233334f7d24
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 17.0.0 h03aeac6_7_cpu
+  - libarrow 17.0.0 h8756180_8_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 597957
-  timestamp: 1723541399030
+  size: 598342
+  timestamp: 1723787612766
 - kind: conda
   name: libarrow-acero
   version: 17.0.0
-  build: he0c23c2_7_cpu
-  build_number: 7
+  build: he0c23c2_8_cpu
+  build_number: 8
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_7_cpu.conda
-  sha256: d3b6d7f16e3ad80c4838d29ae04dc2e98a6c7490f98dbdcd61879577df3f0c3c
-  md5: 0e9e900f3b3d9e3601bc1103bc8a3e66
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-17.0.0-he0c23c2_8_cpu.conda
+  sha256: b41eac77c0ae102072d02d115a02d20220bc7cc71cdecf908be39c3937750906
+  md5: bdb442cf59fa7003345ebe441c73f7c3
   depends:
-  - libarrow 17.0.0 h009c9d4_7_cpu
+  - libarrow 17.0.0 h6e8cf4f_8_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 445138
-  timestamp: 1723542436366
+  size: 444981
+  timestamp: 1723787846964
 - kind: conda
   name: libarrow-dataset
   version: 17.0.0
-  build: hac325c4_7_cpu
-  build_number: 7
+  build: hac325c4_8_cpu
+  build_number: 8
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hac325c4_7_cpu.conda
-  sha256: 1e7bc6895012afedb690ea6de42d231edb14a8f34a6f0bd66639f6ca6d5013ee
-  md5: 59dce108401cac7d0a83575f2dfea820
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-17.0.0-hac325c4_8_cpu.conda
+  sha256: d88f29865bdabb1c7c393376187e203695d24f5a9bc21f49f211f43e3de72cfc
+  md5: 3065f53e69e73473965722303421b207
   depends:
   - __osx >=10.13
-  - libarrow 17.0.0 h1496d7c_7_cpu
-  - libarrow-acero 17.0.0 hac325c4_7_cpu
+  - libarrow 17.0.0 h2952479_8_cpu
+  - libarrow-acero 17.0.0 hac325c4_8_cpu
   - libcxx >=17
-  - libparquet 17.0.0 hf1b0f52_7_cpu
+  - libparquet 17.0.0 hf1b0f52_8_cpu
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 505976
-  timestamp: 1723542421443
+  size: 507423
+  timestamp: 1723788598288
 - kind: conda
   name: libarrow-dataset
   version: 17.0.0
-  build: he02047a_7_cpu
-  build_number: 7
+  build: he02047a_8_cpu
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_7_cpu.conda
-  sha256: 8ff60afa166498ec5372e851c80a7616c3298c1ac4bcfb386767c62c0acf6a35
-  md5: ad26d57360f2019840af562ddf3cb7d2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-17.0.0-he02047a_8_cpu.conda
+  sha256: 46b95328d961bbf21bd337a9015384218a37e31e3f4c5fe4320682af15a3ea47
+  md5: 7e06a68fda280d149d9a43bae84dd374
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 17.0.0 h03aeac6_7_cpu
-  - libarrow-acero 17.0.0 he02047a_7_cpu
+  - libarrow 17.0.0 h8756180_8_cpu
+  - libarrow-acero 17.0.0 he02047a_8_cpu
   - libgcc-ng >=12
-  - libparquet 17.0.0 haa1307c_7_cpu
+  - libparquet 17.0.0 haa1307c_8_cpu
   - libstdcxx-ng >=12
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 580192
-  timestamp: 1723541462660
+  size: 580241
+  timestamp: 1723787687906
 - kind: conda
   name: libarrow-dataset
   version: 17.0.0
-  build: he0c23c2_7_cpu
-  build_number: 7
+  build: he0c23c2_8_cpu
+  build_number: 8
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_7_cpu.conda
-  sha256: 71e8115bdf27c6018ef6e979a20cf012b0690c37d5e5dc23ecdfb8e9fd260323
-  md5: 8061090285b4938e67d540e0b9ff5db4
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-17.0.0-he0c23c2_8_cpu.conda
+  sha256: 7c71e7780aa9929c54fe346624f1771e5ac1a8319c039bbcc8b0348dac8982ec
+  md5: 75aaac52a012ee897bfb6f78fa0593bc
   depends:
-  - libarrow 17.0.0 h009c9d4_7_cpu
-  - libarrow-acero 17.0.0 he0c23c2_7_cpu
-  - libparquet 17.0.0 ha915800_7_cpu
+  - libarrow 17.0.0 h6e8cf4f_8_cpu
+  - libarrow-acero 17.0.0 he0c23c2_8_cpu
+  - libparquet 17.0.0 ha915800_8_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 427490
-  timestamp: 1723542689795
+  size: 427138
+  timestamp: 1723788063640
 - kind: conda
   name: libarrow-substrait
   version: 17.0.0
-  build: h1f0e801_7_cpu
-  build_number: 7
+  build: h1f0e801_8_cpu
+  build_number: 8
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_7_cpu.conda
-  sha256: 84ed8cebf00e27e2642295c633e7d45ec919b66ae3ec848d7a50d95156c131bd
-  md5: 401e5d425e17ecdb2720e61027d28e17
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-17.0.0-h1f0e801_8_cpu.conda
+  sha256: b865fba2df586b491a3ef53e412703dc755cdc4769d620b1f092ce88fd798c09
+  md5: a3a7034bff5cce176f84f23e9dcf84be
   depends:
   - libabseil * cxx17*
   - libabseil >=20240116.2,<20240117.0a0
-  - libarrow 17.0.0 h009c9d4_7_cpu
-  - libarrow-acero 17.0.0 he0c23c2_7_cpu
-  - libarrow-dataset 17.0.0 he0c23c2_7_cpu
+  - libarrow 17.0.0 h6e8cf4f_8_cpu
+  - libarrow-acero 17.0.0 he0c23c2_8_cpu
+  - libarrow-dataset 17.0.0 he0c23c2_8_cpu
   - libprotobuf >=4.25.3,<4.25.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 382545
-  timestamp: 1723542805709
+  size: 382514
+  timestamp: 1723788163377
 - kind: conda
   name: libarrow-substrait
   version: 17.0.0
-  build: hba007a9_7_cpu
-  build_number: 7
+  build: hba007a9_8_cpu
+  build_number: 8
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hba007a9_7_cpu.conda
-  sha256: 2662cd595a6481ca969b35001ef6f6bc972b7f54b6c318ec8fe81c74cae8be10
-  md5: 25fc8f3fab8e483a9a8ebdc20ad41e30
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-17.0.0-hba007a9_8_cpu.conda
+  sha256: 8fbe57c403f94e7f4fd30e1950f69420ca2ef721464e78e10a8ea8147fc52043
+  md5: b9e043a6830b11a5e5e6656805de1dbb
   depends:
   - __osx >=10.13
   - libabseil * cxx17*
   - libabseil >=20240116.2,<20240117.0a0
-  - libarrow 17.0.0 h1496d7c_7_cpu
-  - libarrow-acero 17.0.0 hac325c4_7_cpu
-  - libarrow-dataset 17.0.0 hac325c4_7_cpu
+  - libarrow 17.0.0 h2952479_8_cpu
+  - libarrow-acero 17.0.0 hac325c4_8_cpu
+  - libarrow-dataset 17.0.0 hac325c4_8_cpu
   - libcxx >=17
   - libprotobuf >=4.25.3,<4.25.4.0a0
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 478980
-  timestamp: 1723542567075
+  size: 478529
+  timestamp: 1723788757471
 - kind: conda
   name: libarrow-substrait
   version: 17.0.0
-  build: hc9a23c6_7_cpu
-  build_number: 7
+  build: hc9a23c6_8_cpu
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_7_cpu.conda
-  sha256: 88177f0e86b87579e1fbb3f7c8bc9a128d364d342efb971f65df2f514ddb96f3
-  md5: a0207293ee147d04b46b44d60266d964
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-17.0.0-hc9a23c6_8_cpu.conda
+  sha256: c1801c153039cee5d24d2f333fab2b5c402883934930cf3946f9b67d0c9070ea
+  md5: 613b7846b912a62c4f3e50afc1635707
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
   - libabseil >=20240116.2,<20240117.0a0
-  - libarrow 17.0.0 h03aeac6_7_cpu
-  - libarrow-acero 17.0.0 he02047a_7_cpu
-  - libarrow-dataset 17.0.0 he02047a_7_cpu
+  - libarrow 17.0.0 h8756180_8_cpu
+  - libarrow-acero 17.0.0 he02047a_8_cpu
+  - libarrow-dataset 17.0.0 he02047a_8_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.25.3,<4.25.4.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 546205
-  timestamp: 1723541492516
+  size: 546426
+  timestamp: 1723787723163
 - kind: conda
   name: libblas
   version: 3.9.0
@@ -8998,19 +9002,19 @@ packages:
 - kind: conda
   name: libcxx
   version: 18.1.8
-  build: heced48a_2
-  build_number: 2
+  build: heced48a_4
+  build_number: 4
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_2.conda
-  sha256: e4df0dfd5fcc1e4ece36fb6b09f44436584df961c5cdbf328581522ff8d033b6
-  md5: 8c8198f9e93fcc0fd359ff37b4a8cd2d
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-heced48a_4.conda
+  sha256: e6ad2e71bc9f2ee8fdcce7596baf5041941f69be5ffef478aaffd673f0691daf
+  md5: 7e13da1296840905452340fca10a625b
   depends:
   - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 1221836
-  timestamp: 1722895766052
+  size: 1268903
+  timestamp: 1723637719063
 - kind: conda
   name: libdeflate
   version: '1.21'
@@ -9304,97 +9308,93 @@ packages:
   timestamp: 1719538896937
 - kind: conda
   name: libgdal
-  version: 3.9.1
-  build: h57928b3_11
-  build_number: 11
+  version: 3.9.2
+  build: h57928b3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.1-h57928b3_11.conda
-  sha256: f1d3cbc33bb9030e6aa998b550ef6dce030a176f5fc316133a31c53f7402420d
-  md5: c1bf9ecee80b2a5b5537a1b74ee62f39
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.9.2-h57928b3_0.conda
+  sha256: 6abe6109ac5b6f224d3d68c19193bb253d3e57f1b811fd5cc68c646a51521c12
+  md5: 783316600dfb816aa970af85ca22d68c
   depends:
-  - libgdal-core 3.9.1.*
-  - libgdal-fits 3.9.1.*
-  - libgdal-grib 3.9.1.*
-  - libgdal-hdf4 3.9.1.*
-  - libgdal-hdf5 3.9.1.*
-  - libgdal-jp2openjpeg 3.9.1.*
-  - libgdal-kea 3.9.1.*
-  - libgdal-netcdf 3.9.1.*
-  - libgdal-pdf 3.9.1.*
-  - libgdal-pg 3.9.1.*
-  - libgdal-postgisraster 3.9.1.*
-  - libgdal-tiledb 3.9.1.*
-  - libgdal-xls 3.9.1.*
+  - libgdal-core 3.9.2.*
+  - libgdal-fits 3.9.2.*
+  - libgdal-grib 3.9.2.*
+  - libgdal-hdf4 3.9.2.*
+  - libgdal-hdf5 3.9.2.*
+  - libgdal-jp2openjpeg 3.9.2.*
+  - libgdal-kea 3.9.2.*
+  - libgdal-netcdf 3.9.2.*
+  - libgdal-pdf 3.9.2.*
+  - libgdal-pg 3.9.2.*
+  - libgdal-postgisraster 3.9.2.*
+  - libgdal-tiledb 3.9.2.*
+  - libgdal-xls 3.9.2.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 421746
-  timestamp: 1722903533539
+  size: 423164
+  timestamp: 1723843893315
 - kind: conda
   name: libgdal
-  version: 3.9.1
-  build: h694c41f_11
-  build_number: 11
+  version: 3.9.2
+  build: h694c41f_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.1-h694c41f_11.conda
-  sha256: 92a1f71354298b31ababd756684f06b2adbe234cd3e647e693cae07a695cc2f2
-  md5: 53ee64d70bced5c4c0408634a9aaf4cb
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.9.2-h694c41f_0.conda
+  sha256: 60f4201e7b76658c850eb4a677ee7e21f32ba07477eaef6fe319ff066e4e036e
+  md5: ffa824f80eefd79b4d0791c5fde6cab3
   depends:
-  - libgdal-core 3.9.1.*
-  - libgdal-fits 3.9.1.*
-  - libgdal-grib 3.9.1.*
-  - libgdal-hdf4 3.9.1.*
-  - libgdal-hdf5 3.9.1.*
-  - libgdal-jp2openjpeg 3.9.1.*
-  - libgdal-kea 3.9.1.*
-  - libgdal-netcdf 3.9.1.*
-  - libgdal-pdf 3.9.1.*
-  - libgdal-pg 3.9.1.*
-  - libgdal-postgisraster 3.9.1.*
-  - libgdal-tiledb 3.9.1.*
-  - libgdal-xls 3.9.1.*
+  - libgdal-core 3.9.2.*
+  - libgdal-fits 3.9.2.*
+  - libgdal-grib 3.9.2.*
+  - libgdal-hdf4 3.9.2.*
+  - libgdal-hdf5 3.9.2.*
+  - libgdal-jp2openjpeg 3.9.2.*
+  - libgdal-kea 3.9.2.*
+  - libgdal-netcdf 3.9.2.*
+  - libgdal-pdf 3.9.2.*
+  - libgdal-pg 3.9.2.*
+  - libgdal-postgisraster 3.9.2.*
+  - libgdal-tiledb 3.9.2.*
+  - libgdal-xls 3.9.2.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 421475
-  timestamp: 1723060423178
+  size: 422331
+  timestamp: 1723842785993
 - kind: conda
   name: libgdal
-  version: 3.9.1
-  build: ha770c72_11
-  build_number: 11
+  version: 3.9.2
+  build: ha770c72_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.1-ha770c72_11.conda
-  sha256: 287c8a14c6273b3f68007bd1a284ead2ed9155ed270ec249b4659880119b54db
-  md5: 80c879dc94effb21cc8989da2a16e95b
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.9.2-ha770c72_0.conda
+  sha256: b528270713d4896bf691feb8f6296bb788d80040ac5da425aba566c97c52d020
+  md5: b79bd8b6b31b361a5f14c69806bf11ae
   depends:
-  - libgdal-core 3.9.1.*
-  - libgdal-fits 3.9.1.*
-  - libgdal-grib 3.9.1.*
-  - libgdal-hdf4 3.9.1.*
-  - libgdal-hdf5 3.9.1.*
-  - libgdal-jp2openjpeg 3.9.1.*
-  - libgdal-kea 3.9.1.*
-  - libgdal-netcdf 3.9.1.*
-  - libgdal-pdf 3.9.1.*
-  - libgdal-pg 3.9.1.*
-  - libgdal-postgisraster 3.9.1.*
-  - libgdal-tiledb 3.9.1.*
-  - libgdal-xls 3.9.1.*
+  - libgdal-core 3.9.2.*
+  - libgdal-fits 3.9.2.*
+  - libgdal-grib 3.9.2.*
+  - libgdal-hdf4 3.9.2.*
+  - libgdal-hdf5 3.9.2.*
+  - libgdal-jp2openjpeg 3.9.2.*
+  - libgdal-kea 3.9.2.*
+  - libgdal-netcdf 3.9.2.*
+  - libgdal-pdf 3.9.2.*
+  - libgdal-pg 3.9.2.*
+  - libgdal-postgisraster 3.9.2.*
+  - libgdal-tiledb 3.9.2.*
+  - libgdal-xls 3.9.2.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 421432
-  timestamp: 1722900721909
+  size: 422239
+  timestamp: 1723840384755
 - kind: conda
   name: libgdal-core
-  version: 3.9.1
-  build: h4b9bb65_11
-  build_number: 11
+  version: 3.9.2
+  build: h4b9bb65_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.1-h4b9bb65_11.conda
-  sha256: d4b54c42fba27a9fb5ab8dae95cb9be146396cc26a470dded5076a46dc25b8c7
-  md5: 5d497c0840c8844ab50e9063d37aae65
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.9.2-h4b9bb65_0.conda
+  sha256: 49cda99e669aab7bf61a5181ed158580c122c55e3cad0cd4ec55800923097741
+  md5: 888e92e405c46a459ef17a77db609f3b
   depends:
   - __osx >=10.13
   - blosc >=1.21.6,<2.0a0
@@ -9426,21 +9426,20 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - libgdal 3.9.1.*
+  - libgdal 3.9.2.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 8912493
-  timestamp: 1723057059439
+  size: 8926233
+  timestamp: 1723839455978
 - kind: conda
   name: libgdal-core
-  version: 3.9.1
-  build: h6b59ad6_11
-  build_number: 11
+  version: 3.9.2
+  build: h6b59ad6_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.1-h6b59ad6_11.conda
-  sha256: b0f263f6afa8ad3e00f3edb1771142388b2d8ce5dc990487d11cc5df333f5668
-  md5: 60d204d0c0273dabe906f58264037569
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.9.2-h6b59ad6_0.conda
+  sha256: 776fdab4f7aae2c2a0500a86726cb35986852d80cf98e4f64c56fadf8d5dd8d2
+  md5: 28e547961c714bce30c4341b2b097304
   depends:
   - blosc >=1.21.6,<2.0a0
   - geos >=3.12.2,<3.12.3.0a0
@@ -9471,21 +9470,20 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - libgdal 3.9.1.*
+  - libgdal 3.9.2.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 7997350
-  timestamp: 1722899723460
+  size: 7993361
+  timestamp: 1723839990488
 - kind: conda
   name: libgdal-core
-  version: 3.9.1
-  build: hba09cee_11
-  build_number: 11
+  version: 3.9.2
+  build: hba09cee_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.1-hba09cee_11.conda
-  sha256: d4be97134610ff3a222874f672db76fdf5c56e4a586546ea53aeaa64a68573df
-  md5: b525df1c074f391fbcfbf6de41154382
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.9.2-hba09cee_0.conda
+  sha256: 62c646983b15d21ce617390512e167756bb665587f18e9d93187c6abdba714a0
+  md5: b008d746ae76241d861f78176bb21e67
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
@@ -9519,21 +9517,20 @@ packages:
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.6,<1.6.0a0
   constrains:
-  - libgdal 3.9.1.*
+  - libgdal 3.9.2.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 10206260
-  timestamp: 1722898858969
+  size: 10240822
+  timestamp: 1723838979244
 - kind: conda
   name: libgdal-fits
-  version: 3.9.1
-  build: h0a0b71e_11
-  build_number: 11
+  version: 3.9.2
+  build: h0a0b71e_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.1-h0a0b71e_11.conda
-  sha256: d3458f148548ad374de7c0ff560ed49dee28eccfbdcff742caee82b194577a06
-  md5: 46417f5952ca958e109b6d14ca769b2a
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.9.2-h0a0b71e_0.conda
+  sha256: 0b8864c02ef99805d316e04c47417028e5cbdd65567ec46abae2a0018f3d4174
+  md5: 07fedf0779d906450c27a547cc694505
   depends:
   - cfitsio >=4.4.1,<4.4.2.0a0
   - libgdal-core >=3.9
@@ -9544,17 +9541,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 495714
-  timestamp: 1722901839212
+  size: 497101
+  timestamp: 1723842238547
 - kind: conda
   name: libgdal-fits
-  version: 3.9.1
-  build: h5d197d2_11
-  build_number: 11
+  version: 3.9.2
+  build: h5d197d2_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.1-h5d197d2_11.conda
-  sha256: a4485912e8ff1e5d3a4475eb769955e8ba1a7094923551b35836ddbd9aa69a9c
-  md5: 940445218e8dcf679fc587c62a49aea0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-fits-3.9.2-h5d197d2_0.conda
+  sha256: e7a901faefe99b0057068b187fff40c87974e90e9d09e2ed815528f858ce9e24
+  md5: 0c04699c282efe90e2a821326cdd19a8
   depends:
   - __osx >=10.13
   - cfitsio >=4.4.1,<4.4.2.0a0
@@ -9564,17 +9560,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 467573
-  timestamp: 1723058795713
+  size: 467917
+  timestamp: 1723841156520
 - kind: conda
   name: libgdal-fits
-  version: 3.9.1
-  build: hdd6600c_11
-  build_number: 11
+  version: 3.9.2
+  build: hdd6600c_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.1-hdd6600c_11.conda
-  sha256: ad67985038e987284cd10d901e086d1dd0f955ae7ce1e229fcb4cbf29ef12e3e
-  md5: 0871f081fde06b0fba25e8a18cf84510
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.9.2-hdd6600c_0.conda
+  sha256: 20898cb7bf3a456481ff0aa979f7b3b7ef46f666ba3155ff7ae3c6822583e993
+  md5: bc8affb58edbc6fddd3e5bc9724f7507
   depends:
   - __glibc >=2.17,<3.0.a0
   - cfitsio >=4.4.1,<4.4.2.0a0
@@ -9585,17 +9580,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 475290
-  timestamp: 1722899933720
+  size: 476516
+  timestamp: 1723839776557
 - kind: conda
   name: libgdal-grib
-  version: 3.9.1
-  build: h385febf_11
-  build_number: 11
+  version: 3.9.2
+  build: h385febf_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.1-h385febf_11.conda
-  sha256: d906df8d9c46f7338b3b31dffe6ac4784f7d8530b22717381b2c28b9eea717d6
-  md5: 108ec93fb9c4ffbb2e4c34b72366ac98
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.9.2-h385febf_0.conda
+  sha256: 7652783793614ae7bb6f27591e1625be66eee13ef39d46b716c1498b4643e6ab
+  md5: 798a4219bfc732715154f93377ce53b5
   depends:
   - __osx >=10.13
   - libaec >=1.1.3,<2.0a0
@@ -9605,17 +9599,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 662577
-  timestamp: 1723058944503
+  size: 662915
+  timestamp: 1723841284058
 - kind: conda
   name: libgdal-grib
-  version: 3.9.1
-  build: h5f34788_11
-  build_number: 11
+  version: 3.9.2
+  build: h5f34788_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.1-h5f34788_11.conda
-  sha256: 82bf14f629742c2c817020af734023d1cf45702251af93d1bf6a677076c8922e
-  md5: 31de2a91c892ad97e162e3d033cf1f4e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.9.2-h5f34788_0.conda
+  sha256: a90080b794c2e11377dcc804932068f143b8f9bdf3191a5b5747346e3dac538c
+  md5: dba6d64b956bb475916f385ab8a010b6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libaec >=1.1.3,<2.0a0
@@ -9626,17 +9619,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 722820
-  timestamp: 1722900004461
+  size: 720550
+  timestamp: 1723839829373
 - kind: conda
   name: libgdal-grib
-  version: 3.9.1
-  build: hd2a089b_11
-  build_number: 11
+  version: 3.9.2
+  build: hd2a089b_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.1-hd2a089b_11.conda
-  sha256: db468456a1f927e3092c60677b622e3e292b6a5e63e95aeed5db4967f380d9fa
-  md5: 2fb0357c7ac79a29455c884dde2a56c4
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.9.2-hd2a089b_0.conda
+  sha256: 2b50535a67d59c944585364dd6ce30fad437015c7b3d156914bd6e7bef7664f0
+  md5: 7cdc726554fb14c5408f9481d42428ea
   depends:
   - libaec >=1.1.3,<2.0a0
   - libgdal-core >=3.9
@@ -9647,17 +9639,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 677126
-  timestamp: 1722901983679
+  size: 678811
+  timestamp: 1723842377557
 - kind: conda
   name: libgdal-hdf4
-  version: 3.9.1
-  build: h430f241_11
-  build_number: 11
+  version: 3.9.2
+  build: h430f241_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.1-h430f241_11.conda
-  sha256: 200bd011ce181a1f56971904e8bc544fa2ec6f67bb882ffd59cd67b4ed238cc4
-  md5: 002ce68285cb5486bc3b00f76c87509a
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.9.2-h430f241_0.conda
+  sha256: 1a6f014b5ec5bec23c27704211660fb35c5160700d269170fb8623c860cd0a3b
+  md5: 93316cdd55ba4b9e8d496eec7184f3eb
   depends:
   - hdf4 >=4.2.15,<4.2.16.0a0
   - libaec >=1.1.3,<2.0a0
@@ -9669,17 +9660,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 561041
-  timestamp: 1722902125782
+  size: 562497
+  timestamp: 1723842519401
 - kind: conda
   name: libgdal-hdf4
-  version: 3.9.1
-  build: h86719f3_11
-  build_number: 11
+  version: 3.9.2
+  build: h86719f3_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.1-h86719f3_11.conda
-  sha256: afce1a2eb5cad3fa863c5d0b59a12fe79e1b9ce8eb6e38b7852d98fbdeb8919a
-  md5: 51a00f74cc6049274246833dc711125e
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.9.2-h86719f3_0.conda
+  sha256: 5042ef12eb0b6929c691088cbb32b863f2c0a2a5af7054ca3bef0d35f74bd90f
+  md5: c69fe5787c0148b1fea4b6b17f56e874
   depends:
   - __osx >=10.13
   - hdf4 >=4.2.15,<4.2.16.0a0
@@ -9690,17 +9680,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 589749
-  timestamp: 1723059093247
+  size: 590333
+  timestamp: 1723841406613
 - kind: conda
   name: libgdal-hdf4
-  version: 3.9.1
-  build: ha39a594_11
-  build_number: 11
+  version: 3.9.2
+  build: ha39a594_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.1-ha39a594_11.conda
-  sha256: 2b8ec0bb65a9f6e45969fd0212862a2762b90ac758a388c8341f8722079747b1
-  md5: cb80fca0b3a00e82c997b2cced713d0f
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.9.2-ha39a594_0.conda
+  sha256: e8ab76f289d3d29399bfae46f0c1c7f82b38b18b3b1aa260f0ca13a5a13c7a37
+  md5: 4a1f093874e443f96fc5864117dd742a
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf4 >=4.2.15,<4.2.16.0a0
@@ -9712,17 +9701,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 575565
-  timestamp: 1722900069073
+  size: 577028
+  timestamp: 1723839878916
 - kind: conda
   name: libgdal-hdf5
-  version: 3.9.1
-  build: h513f0eb_11
-  build_number: 11
+  version: 3.9.2
+  build: h513f0eb_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.1-h513f0eb_11.conda
-  sha256: 87537910d20d552ca001f4561cba74fbafccf4570032f2d509dfdb7cb84ea120
-  md5: d27a0be1e298e5d71f1ec77969c963a5
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.9.2-h513f0eb_0.conda
+  sha256: f9fa2e2ec38595d3b615d653aef3cc9ae50ef8bff6df604bcbd58b37d3d06cb2
+  md5: 954c616bf75cf43b4fe02483fe5de530
   depends:
   - __osx >=10.13
   - hdf5 >=1.14.3,<1.14.4.0a0
@@ -9732,17 +9720,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 599292
-  timestamp: 1723059242005
+  size: 599621
+  timestamp: 1723841551985
 - kind: conda
   name: libgdal-hdf5
-  version: 3.9.1
-  build: ha2ed5f0_11
-  build_number: 11
+  version: 3.9.2
+  build: ha2ed5f0_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.1-ha2ed5f0_11.conda
-  sha256: fab2e22f9927b4cc5a73e1aa51369d79b1d7aeb0aec0630edf65ac741f2cc96e
-  md5: c4b8ce970c5c2961f4603cea8f3e894f
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.9.2-ha2ed5f0_0.conda
+  sha256: cf41e68c22b5a69eb64291f72083f3d643430110b8314bc992b1920275389044
+  md5: 0b2c3f29eed90f34dd2d633c5a54a047
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf5 >=1.14.3,<1.14.4.0a0
@@ -9753,17 +9740,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 638536
-  timestamp: 1722900146231
+  size: 639683
+  timestamp: 1723839938366
 - kind: conda
   name: libgdal-hdf5
-  version: 3.9.1
-  build: had131a1_11
-  build_number: 11
+  version: 3.9.2
+  build: had131a1_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.1-had131a1_11.conda
-  sha256: c5d4698e8987afdafe652764039dec1545e48e8e2f3d29279ba4fe5797c9e8e9
-  md5: 70570dbdf05e3c0b6f33474d80a31368
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.9.2-had131a1_0.conda
+  sha256: 9f937bcf5e6af19413e0c2b516fc7e04b53860f96c2bca3f9c685b68e61b3101
+  md5: 47bd857cbe4ce8f4d4386ef123d6b36d
   depends:
   - hdf5 >=1.14.3,<1.14.4.0a0
   - libgdal-core >=3.9
@@ -9774,17 +9760,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 612066
-  timestamp: 1722902280959
+  size: 613331
+  timestamp: 1723842672082
 - kind: conda
   name: libgdal-jp2openjpeg
-  version: 3.9.1
-  build: h2ebfdf0_11
-  build_number: 11
+  version: 3.9.2
+  build: h2ebfdf0_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.1-h2ebfdf0_11.conda
-  sha256: 5b159f87a5180886172b20e3657fd5598b41a6193cbdfdef9265fc3da8243132
-  md5: b021c7fab0390dd29e8daea326e5d178
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.9.2-h2ebfdf0_0.conda
+  sha256: cf7ddcb3550f0042270eb8390ed214fcf95b087394beda229842bce4471cf48f
+  md5: 3bc2bc4dbef54a3a0d18e8caca7daf0f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
@@ -9795,17 +9780,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 466794
-  timestamp: 1722900202023
+  size: 468035
+  timestamp: 1723839975969
 - kind: conda
   name: libgdal-jp2openjpeg
-  version: 3.9.1
-  build: hc5f35ca_11
-  build_number: 11
+  version: 3.9.2
+  build: hc5f35ca_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.1-hc5f35ca_11.conda
-  sha256: 495ff05647dfa14f2328d937c1a7a0a5370564dabff4ef96003fedc7c7ad1d5f
-  md5: 9d94d0678b3d89b3a7491ab38576c4cb
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.9.2-hc5f35ca_0.conda
+  sha256: 7e45a734b5a89748162b61d801f6cb9aee34705a2d39cdd57bca1e0095a4fed9
+  md5: b189322fcb4879fc4277b4af45c8353c
   depends:
   - __osx >=10.13
   - libcxx >=16
@@ -9815,17 +9799,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 463405
-  timestamp: 1723059370823
+  size: 463991
+  timestamp: 1723841680350
 - kind: conda
   name: libgdal-jp2openjpeg
-  version: 3.9.1
-  build: hed4c6cb_11
-  build_number: 11
+  version: 3.9.2
+  build: hed4c6cb_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.1-hed4c6cb_11.conda
-  sha256: ed656bb2cabfbbd948dca061e18ca6a32690c9a2265a69d8117e867bd772fd3f
-  md5: 32f4ad60e44a4c723dbf712d3f87c542
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.9.2-hed4c6cb_0.conda
+  sha256: 620caa37b38448311e069f56385512b8eb79c823be5e64e01443e16c6ed296d8
+  md5: 4f443cd47ae1e17c9e1e218fe0f8840c
   depends:
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
@@ -9836,67 +9819,64 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 496204
-  timestamp: 1722902413311
+  size: 497668
+  timestamp: 1723842799814
 - kind: conda
   name: libgdal-kea
-  version: 3.9.1
-  build: h2b45729_11
-  build_number: 11
+  version: 3.9.2
+  build: h2b45729_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.1-h2b45729_11.conda
-  sha256: c7b035d1062c429a9c14ceacb1f570c3a5fdb5243c845e1ad0ec0da7b1034e19
-  md5: 9b45809fc45971c2d2d3ad05a8187eb7
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.9.2-h2b45729_0.conda
+  sha256: 4211ea682c8604a34f45a1d56529af745264afa89eed13cd1d9ced114e7dd5b9
+  md5: afac39347e003f869972582ea1a36616
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf5 >=1.14.3,<1.14.4.0a0
   - kealib >=1.5.3,<1.6.0a0
   - libgcc-ng >=12
   - libgdal-core >=3.9
-  - libgdal-hdf5 3.9.1.*
+  - libgdal-hdf5 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 479085
-  timestamp: 1722900634233
+  size: 480105
+  timestamp: 1723840316708
 - kind: conda
   name: libgdal-kea
-  version: 3.9.1
-  build: h3b8d0bf_11
-  build_number: 11
+  version: 3.9.2
+  build: h3b8d0bf_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.1-h3b8d0bf_11.conda
-  sha256: d241d598d14285afd10623cb73e382247c0b178649df890fe8204a78df078abe
-  md5: 85f1ad23bca555928a70a1218902ae07
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-kea-3.9.2-h3b8d0bf_0.conda
+  sha256: f053cbb60600d081d3eca8ad4c322da0ffe1de1f78fd483b9d45a1f9af1178f3
+  md5: 5971aa24e604517eb3f6312c01268df2
   depends:
   - __osx >=10.13
   - hdf5 >=1.14.3,<1.14.4.0a0
   - kealib >=1.5.3,<1.6.0a0
   - libcxx >=16
   - libgdal-core >=3.9
-  - libgdal-hdf5 3.9.1.*
+  - libgdal-hdf5 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 474843
-  timestamp: 1723060253226
+  size: 474894
+  timestamp: 1723842624126
 - kind: conda
   name: libgdal-kea
-  version: 3.9.1
-  build: h95b1a77_11
-  build_number: 11
+  version: 3.9.2
+  build: h95b1a77_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.1-h95b1a77_11.conda
-  sha256: eac721d7045cff791e4dd9e18c227b0bb6d3bc61deb55e195265801ea35c3007
-  md5: eee48d435bfcfc7dbae97c4b11b7456c
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.9.2-h95b1a77_0.conda
+  sha256: 67be3e486b2af5c48457f631d7fcbd07772c25575686aaf722c7db236f76130b
+  md5: f574f592b5a150889a71593dc4ed8896
   depends:
   - hdf5 >=1.14.3,<1.14.4.0a0
   - kealib >=1.5.3,<1.6.0a0
   - libgdal-core >=3.9
-  - libgdal-hdf5 3.9.1.*
+  - libgdal-hdf5 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -9904,47 +9884,45 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 516753
-  timestamp: 1722903375185
+  size: 517965
+  timestamp: 1723843742596
 - kind: conda
   name: libgdal-netcdf
-  version: 3.9.1
-  build: h3127c03_11
-  build_number: 11
+  version: 3.9.2
+  build: h3127c03_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.1-h3127c03_11.conda
-  sha256: a0c157b0ce5b99c7d962afe2381234d4aa804bef585bdf65831b4061c712035a
-  md5: e345d9f694829a421f36604b4a5e5dc6
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.9.2-h3127c03_0.conda
+  sha256: cf9cd8c8b47cc1c57446041ce40ef023d4dd28732df1e4140e7bbb45e1dfdd72
+  md5: edef4782574a4d9690b2c60fc49e4fa1
   depends:
   - __osx >=10.13
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
   - libcxx >=16
   - libgdal-core >=3.9
-  - libgdal-hdf4 3.9.1.*
-  - libgdal-hdf5 3.9.1.*
+  - libgdal-hdf4 3.9.2.*
+  - libgdal-hdf5 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 688673
-  timestamp: 1723060417086
+  size: 689033
+  timestamp: 1723842779421
 - kind: conda
   name: libgdal-netcdf
-  version: 3.9.1
-  build: h55e78d3_11
-  build_number: 11
+  version: 3.9.2
+  build: h55e78d3_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.1-h55e78d3_11.conda
-  sha256: 6dd83f94e8ac5abaec42fb5ea5b1e92afee4c3e033ec43d2d638f812be932f6c
-  md5: f6b877f092eedea28d445d2d8993a596
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.9.2-h55e78d3_0.conda
+  sha256: cd4dfc0e49e07e0760c7989e8265f9d3a9e816cb16d6898417ec8702d5e6decf
+  md5: a64621d72542c38d3dc62632f334a8d2
   depends:
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
   - libgdal-core >=3.9
-  - libgdal-hdf4 3.9.1.*
-  - libgdal-hdf5 3.9.1.*
+  - libgdal-hdf4 3.9.2.*
+  - libgdal-hdf5 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - ucrt >=10.0.20348.0
@@ -9953,194 +9931,123 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 665361
-  timestamp: 1722903528440
+  size: 666629
+  timestamp: 1723843888623
 - kind: conda
   name: libgdal-netcdf
-  version: 3.9.1
-  build: h94e7027_11
-  build_number: 11
+  version: 3.9.2
+  build: h94e7027_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.1-h94e7027_11.conda
-  sha256: 96633c15dc6fe3ff51dc1e1da01a706ca70f3fa2157071d349bcd482ead47796
-  md5: 9f21ab0ce49016006e7924f1b325079f
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.9.2-h94e7027_0.conda
+  sha256: ee089ef3995807d874b2be4f266af5871ebea3c9c11c1b4cc8709955b7a1bf89
+  md5: 9b5b3c36cdfa48914a6aefca4fbd21fc
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.3,<1.14.4.0a0
   - libgcc-ng >=12
   - libgdal-core >=3.9
-  - libgdal-hdf4 3.9.1.*
-  - libgdal-hdf5 3.9.1.*
+  - libgdal-hdf4 3.9.2.*
+  - libgdal-hdf5 3.9.2.*
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
   purls: []
-  size: 731020
-  timestamp: 1722900717625
+  size: 731831
+  timestamp: 1723840381035
 - kind: conda
   name: libgdal-pdf
-  version: 3.9.1
-  build: h0da0525_11
-  build_number: 11
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.1-h0da0525_11.conda
-  sha256: bc359985ff184da6c8cf7f0026d7fdc445446aaa28350efcbf64d7bff6ceed4d
-  md5: 7cac731cccb65a0a633a296fd02c18f0
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libgdal-core >=3.9
-  - libkml >=1.3.0,<1.4.0a0
-  - poppler >=24.7.0,<24.8.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 608142
-  timestamp: 1723059529782
-- kind: conda
-  name: libgdal-pdf
-  version: 3.9.1
-  build: h261eb30_11
-  build_number: 11
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.1-h261eb30_11.conda
-  sha256: cf13f4b8b3232951b8e840d5caee409700d25ff8c68f5f1b3fe586bb393b6f6c
-  md5: b81d42826cb98df2bbdeb06dd8558f4b
-  depends:
-  - libgdal-core >=3.9
-  - libkml >=1.3.0,<1.4.0a0
-  - poppler >=24.7.0,<24.8.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 624349
-  timestamp: 1722902588391
-- kind: conda
-  name: libgdal-pdf
-  version: 3.9.1
-  build: h562c687_11
-  build_number: 11
+  version: 3.9.2
+  build: h0fa2cb4_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.1-h562c687_11.conda
-  sha256: 1e7fd035415516d7e9057ed138156dae1cc9a1898c8f4f5cc86932743f87663e
-  md5: d6d46b0f3e2d219c35e11add4e550215
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.9.2-h0fa2cb4_0.conda
+  sha256: 2ed5b3330a3a32512bf071de64f07fc5c434da2eb14915e97a4e9b9e1afb9793
+  md5: e05562e39f9d87beaf8ff75da9b3af52
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
   - libstdcxx-ng >=12
-  - poppler >=24.7.0,<24.8.0a0
+  - poppler >=24.8.0,<24.9.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 663128
-  timestamp: 1722900295085
+  size: 664476
+  timestamp: 1723840044891
 - kind: conda
-  name: libgdal-pg
-  version: 3.9.1
-  build: h1b48671_11
-  build_number: 11
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.1-h1b48671_11.conda
-  sha256: 15ecf46f1a428a79faf1eec677b26583dbbf76ad38ea7720e80434b39c96a405
-  md5: d6865e4de04b5af6b815a67c5ef21647
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libgdal-core >=3.9
-  - libkml >=1.3.0,<1.4.0a0
-  - libpq >=16.3,<17.0a0
-  - postgresql
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 506345
-  timestamp: 1723059672798
-- kind: conda
-  name: libgdal-pg
-  version: 3.9.1
-  build: ha693a0f_11
-  build_number: 11
+  name: libgdal-pdf
+  version: 3.9.2
+  build: ha1c78db_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.1-ha693a0f_11.conda
-  sha256: d4d7d36a9c0880dbc2abbdd41bc03ae0678e931a561dd32983362d10e99cf0b0
-  md5: ce625349aafc75d0137e4edc1c9b3a44
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.9.2-ha1c78db_0.conda
+  sha256: 042bf63099ffb8c292cb9e0f8201832882f797f4eafbe74550108893ed6fbc16
+  md5: 7f30514e9cc9d0dac3306ebdcaf8ac96
   depends:
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
-  - libpq >=16.3,<17.0a0
-  - postgresql
+  - poppler >=24.8.0,<24.9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 531639
-  timestamp: 1722902737971
+  size: 625975
+  timestamp: 1723842971120
 - kind: conda
-  name: libgdal-pg
-  version: 3.9.1
-  build: he047751_11
-  build_number: 11
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.1-he047751_11.conda
-  sha256: 639bed3219be4300c9660bfa6ca6dcc8650046b78882b520820705d19fbbe3e6
-  md5: b5db9c4b8b9ed46e1f4bbac224456977
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libgdal-core >=3.9
-  - libkml >=1.3.0,<1.4.0a0
-  - libpq >=16.3,<17.0a0
-  - libstdcxx-ng >=12
-  - postgresql
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 523764
-  timestamp: 1722900358244
-- kind: conda
-  name: libgdal-postgisraster
-  version: 3.9.1
-  build: h1b48671_11
-  build_number: 11
+  name: libgdal-pdf
+  version: 3.9.2
+  build: ha7d2355_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.1-h1b48671_11.conda
-  sha256: b9cb26f8832dfe4f7dd3920013899c65b54b3afc6e657a5b05b76bf9d7062896
-  md5: 5271e2756a46f593569efffcdbddcf92
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pdf-3.9.2-ha7d2355_0.conda
+  sha256: 41b12419c68ad274489b3a20c0bc71620c1992b25b4f2fcf5d30ec6b47eac5a4
+  md5: 341eafadf0536f3fba35516182f8d8da
   depends:
   - __osx >=10.13
   - libcxx >=16
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
-  - libpq >=16.3,<17.0a0
+  - poppler >=24.8.0,<24.9.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 609616
+  timestamp: 1723841824853
+- kind: conda
+  name: libgdal-pg
+  version: 3.9.2
+  build: h1b48671_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-pg-3.9.2-h1b48671_0.conda
+  sha256: 736ad8a0b8841b8ad4ce166499affe1c820ba6ff3c4dc85564f9e6859aca151f
+  md5: f2d026e614b3ed73afb0b054452f9ca1
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.4,<17.0a0
   - postgresql
   license: MIT
   license_family: MIT
   purls: []
-  size: 468522
-  timestamp: 1723059806532
+  size: 506451
+  timestamp: 1723841961792
 - kind: conda
-  name: libgdal-postgisraster
-  version: 3.9.1
-  build: ha693a0f_11
-  build_number: 11
+  name: libgdal-pg
+  version: 3.9.2
+  build: ha693a0f_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.1-ha693a0f_11.conda
-  sha256: 553f1f13e3fa4fed560fb08faade1e1039571eaba946cfac7a97e20550903417
-  md5: df9197e0c33fa1b7c5f6072e49d04669
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.9.2-ha693a0f_0.conda
+  sha256: be39296adbf0a232e7e63a1ae6a079e00aa237648caaf1592e10ab07566ade54
+  md5: df007d35fdf928f91ea2c32323769e74
   depends:
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
-  - libpq >=16.3,<17.0a0
+  - libpq >=16.4,<17.0a0
   - postgresql
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -10148,39 +10055,99 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 503500
-  timestamp: 1722902896839
+  size: 532068
+  timestamp: 1723843119430
 - kind: conda
-  name: libgdal-postgisraster
-  version: 3.9.1
-  build: he047751_11
-  build_number: 11
+  name: libgdal-pg
+  version: 3.9.2
+  build: he047751_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.1-he047751_11.conda
-  sha256: 2f135ffcba27ec557b259fee7d4b5e1cf9bab7acb8e06b12ab36b793f2147876
-  md5: 336cea7d55ddf1a74967c77a994741a6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.9.2-he047751_0.conda
+  sha256: 495ba816e1bdeab9f324666a60236436af325c27d0bda0169913062ce25ffd39
+  md5: ffc6cb208a39a3eb764032d31a14faa8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
-  - libpq >=16.3,<17.0a0
+  - libpq >=16.4,<17.0a0
   - libstdcxx-ng >=12
   - postgresql
   license: MIT
   license_family: MIT
   purls: []
-  size: 477920
-  timestamp: 1722900423869
+  size: 524778
+  timestamp: 1723840095806
+- kind: conda
+  name: libgdal-postgisraster
+  version: 3.9.2
+  build: h1b48671_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-postgisraster-3.9.2-h1b48671_0.conda
+  sha256: 6c8858cbfbc2f65196fcaf76db5f6f68a6b6075e95cbe94798437537fb6442f4
+  md5: dde648bd5ce1f9039f09c941e80e715e
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.4,<17.0a0
+  - postgresql
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 469429
+  timestamp: 1723842125336
+- kind: conda
+  name: libgdal-postgisraster
+  version: 3.9.2
+  build: ha693a0f_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.9.2-ha693a0f_0.conda
+  sha256: b2d37e814425ca1bacc7d378ee6d7499379bc06d2145174ce655b0a15deabda0
+  md5: 04f104d188bea8c2013fc6b0036a64d3
+  depends:
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.4,<17.0a0
+  - postgresql
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 504839
+  timestamp: 1723843279030
+- kind: conda
+  name: libgdal-postgisraster
+  version: 3.9.2
+  build: he047751_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.9.2-he047751_0.conda
+  sha256: 98210defde1734576d5c28950f234af28042f3e0fa386e7c1168893bd55d6e04
+  md5: 3fa13117dde6d031e11c7dceba70307e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libgdal-core >=3.9
+  - libkml >=1.3.0,<1.4.0a0
+  - libpq >=16.4,<17.0a0
+  - libstdcxx-ng >=12
+  - postgresql
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 479176
+  timestamp: 1723840147573
 - kind: conda
   name: libgdal-tiledb
-  version: 3.9.1
-  build: h9d8aadb_11
-  build_number: 11
+  version: 3.9.2
+  build: h9d8aadb_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.1-h9d8aadb_11.conda
-  sha256: f35ba07a8288c03d6ecea60f070eb6a62f15cd2310ade01c0c7eaf34d8a7f79e
-  md5: bc31aaa4ffc8c362b263b56e97aa1184
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.9.2-h9d8aadb_0.conda
+  sha256: 5b1569d11ca306956176cb3efa2b7700ceebfe31a2a3d55a21bfb97f670cdc05
+  md5: fe5cc1e3fb1ff4b9ce7f6c14c1a90930
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
@@ -10191,17 +10158,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 671063
-  timestamp: 1722900514737
+  size: 671547
+  timestamp: 1723840222090
 - kind: conda
   name: libgdal-tiledb
-  version: 3.9.1
-  build: ha63beff_11
-  build_number: 11
+  version: 3.9.2
+  build: ha63beff_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.1-ha63beff_11.conda
-  sha256: 6bf91e575dde0a9fd24196d41033145b8d27673a5449a5925871172f6676ec89
-  md5: a6c2cee021bf3d22673c16ecc6f6d17a
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-tiledb-3.9.2-ha63beff_0.conda
+  sha256: 0b81a6b963b417609f584a118304293e09219a48e9447385c3ebb4757baad5f6
+  md5: 7dc59f75a0ce5c00575ce07ebb8613d1
   depends:
   - __osx >=10.13
   - libcxx >=16
@@ -10211,17 +10177,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 628168
-  timestamp: 1723059962122
+  size: 628861
+  timestamp: 1723842320643
 - kind: conda
   name: libgdal-tiledb
-  version: 3.9.1
-  build: hefbb53f_11
-  build_number: 11
+  version: 3.9.2
+  build: hefbb53f_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.1-hefbb53f_11.conda
-  sha256: 0466979248c80fe707d79d552bd6bb54325161d1ba7aad0348bc075ff938f936
-  md5: cdde09fa6e02c45ba08a7532b32c2b53
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.9.2-hefbb53f_0.conda
+  sha256: 42da0b1faed24aabbf1ebe263d0b0ec79698584cb3a8be9d139b2e982b1fe372
+  md5: 04a2ecccb1cd6c418242ab7724b75f6f
   depends:
   - libgdal-core >=3.9
   - libkml >=1.3.0,<1.4.0a0
@@ -10232,17 +10197,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 626903
-  timestamp: 1722903091811
+  size: 628563
+  timestamp: 1723843463220
 - kind: conda
   name: libgdal-xls
-  version: 3.9.1
-  build: h062f1c4_11
-  build_number: 11
+  version: 3.9.2
+  build: h062f1c4_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.1-h062f1c4_11.conda
-  sha256: b142ea7b80c6d8a7d82472c88dccd380daac6ecee1f4f26e70e7c066d457c9ab
-  md5: 3a5613fedb4673d222edba91cdedc129
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.9.2-h062f1c4_0.conda
+  sha256: e073a131c15902e10fdb303b3d038ba5943833f0bce2e85bcdff42f8b1a294c1
+  md5: 20770850c35b44c305147e5b502a7ac8
   depends:
   - __glibc >=2.17,<3.0.a0
   - freexl >=2.0.0,<3.0a0
@@ -10253,17 +10217,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 433245
-  timestamp: 1722900567715
+  size: 434267
+  timestamp: 1723840265117
 - kind: conda
   name: libgdal-xls
-  version: 3.9.1
-  build: h597966e_11
-  build_number: 11
+  version: 3.9.2
+  build: h597966e_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.1-h597966e_11.conda
-  sha256: fce77cc2fb2832ea214978cb630f60581cba7f744bc77609578984c8194ae4b5
-  md5: 4fb78d71d65c884e02ad344f0dd8c43f
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-xls-3.9.2-h597966e_0.conda
+  sha256: 551a31b3ba06ed9f1addf25bc73bfbc81f0ea19458fe0e33a0c1c0b6f579eb83
+  md5: 5defa44a81597e6c8ae8000b46b604d4
   depends:
   - __osx >=10.13
   - freexl >=2.0.0,<3.0a0
@@ -10273,17 +10236,16 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 431281
-  timestamp: 1723060090228
+  size: 431833
+  timestamp: 1723842473320
 - kind: conda
   name: libgdal-xls
-  version: 3.9.1
-  build: hd0e23a6_11
-  build_number: 11
+  version: 3.9.2
+  build: hd0e23a6_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.1-hd0e23a6_11.conda
-  sha256: 7fe8f7c23d61270c66bae570fea8c2f18e2779a2a3a853d0b5b16361cb409de5
-  md5: a93eb5d0034c50126e12421ed7b65f1e
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.9.2-hd0e23a6_0.conda
+  sha256: 3627ab430a898aec0f8228b6172b1f89d9e4458935b9704a9f3d389238af8c25
+  md5: 3060a72f5eca3c4dc3878b35215eb425
   depends:
   - freexl >=2.0.0,<3.0a0
   - libgdal-core >=3.9
@@ -10294,8 +10256,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 464810
-  timestamp: 1722903228576
+  size: 466107
+  timestamp: 1723843600322
 - kind: conda
   name: libgfortran
   version: 5.0.0
@@ -10732,33 +10694,34 @@ packages:
 - kind: conda
   name: libintl
   version: 0.22.5
-  build: h5728263_2
-  build_number: 2
+  build: h5728263_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
-  sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
-  md5: aa622c938af057adc119f8b8eecada01
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
   depends:
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
   purls: []
-  size: 95745
-  timestamp: 1712516102666
+  size: 95568
+  timestamp: 1723629479451
 - kind: conda
   name: libintl
   version: 0.22.5
-  build: h5ff76d1_2
-  build_number: 2
+  build: hdfe23c8_3
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
-  sha256: 280aaef0ed84637ee869012ad9ad9ed208e068dd9b8cf010dafeea717dad7203
-  md5: 3fb6774cb8cdbb93a6013b67bcf9716d
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-hdfe23c8_3.conda
+  sha256: 0dbb662440a73e20742f12d88e51785a5a5117b8b150783a032b8818a8c043af
+  md5: 52d4d643ed26c07599736326c46bf12f
   depends:
+  - __osx >=10.13
   - libiconv >=1.17,<2.0a0
   license: LGPL-2.1-or-later
   purls: []
-  size: 74307
-  timestamp: 1712512790983
+  size: 88086
+  timestamp: 1723626826235
 - kind: conda
   name: libjpeg-turbo
   version: 3.0.0
@@ -11178,62 +11141,65 @@ packages:
 - kind: conda
   name: libparquet
   version: 17.0.0
-  build: ha915800_7_cpu
-  build_number: 7
+  build: ha915800_8_cpu
+  build_number: 8
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_7_cpu.conda
-  sha256: a84c8174e168146f6a50d96ea89bb80e440615b55301badfb86f49544d527a6e
-  md5: d79854c11a34dc6b2f81153c0222394a
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-17.0.0-ha915800_8_cpu.conda
+  sha256: 485c7787e97a4ade061c8ca77a93c58d2329f61843e8e5c3782d62a5171e7450
+  md5: d1f5e781ecd7a985e576b6c824bf1183
   depends:
-  - libarrow 17.0.0 h009c9d4_7_cpu
+  - libarrow 17.0.0 h6e8cf4f_8_cpu
   - libthrift >=0.20.0,<0.20.1.0a0
   - openssl >=3.3.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 805292
-  timestamp: 1723542633494
+  size: 805336
+  timestamp: 1723788013786
 - kind: conda
   name: libparquet
   version: 17.0.0
-  build: haa1307c_7_cpu
-  build_number: 7
+  build: haa1307c_8_cpu
+  build_number: 8
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_7_cpu.conda
-  sha256: 93ccb279a9a60fc1c713bbf5eb224eb1eeedadac3f6114a7c00a3880e2a4b172
-  md5: 7448f406b12fc479eb5a7dbf485c0428
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-17.0.0-haa1307c_8_cpu.conda
+  sha256: 982504e37b8176e9b6e6ca984ce1f5946d5b2d6ae4a63ca04309668cdd0cb2e7
+  md5: 7a1e06213539848b4d4b624a0f6307b8
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 17.0.0 h03aeac6_7_cpu
+  - libarrow 17.0.0 h8756180_8_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libthrift >=0.20.0,<0.20.1.0a0
   - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 1172305
-  timestamp: 1723541446949
+  size: 1171833
+  timestamp: 1723787669273
 - kind: conda
   name: libparquet
   version: 17.0.0
-  build: hf1b0f52_7_cpu
-  build_number: 7
+  build: hf1b0f52_8_cpu
+  build_number: 8
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hf1b0f52_7_cpu.conda
-  sha256: 8b151f2baa714fcadce6a9ba850c85fed22052c7820d0ca0bad7385539a5d22d
-  md5: 42526e90fa96546088c012c54fcc9d70
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-17.0.0-hf1b0f52_8_cpu.conda
+  sha256: 751656c1e2a516e50eb9df838784569543c4c5613d64689baefc4dc5d0111698
+  md5: cb4b2b2048ad593a660a4415e8a3c9d5
   depends:
   - __osx >=10.13
-  - libarrow 17.0.0 h1496d7c_7_cpu
+  - libarrow 17.0.0 h2952479_8_cpu
   - libcxx >=17
   - libthrift >=0.20.0,<0.20.1.0a0
   - openssl >=3.3.1,<4.0a0
   license: Apache-2.0
+  license_family: APACHE
   purls: []
-  size: 925548
-  timestamp: 1723542336644
+  size: 926034
+  timestamp: 1723788527100
 - kind: conda
   name: libpciaccess
   version: '0.18'
@@ -12305,11 +12271,12 @@ packages:
 - kind: conda
   name: llvm-openmp
   version: 18.1.8
-  build: h15ab845_0
+  build: h15ab845_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_0.conda
-  sha256: 0fd74128806bd839c7a9aa343faf265b94aece84f75f67f14b6246936138e61e
-  md5: 2c3c6c8aaf8728f87326964a82fdc7d8
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.8-h15ab845_1.conda
+  sha256: 06a245abb6e6d8d6662a35ad162eacb39f431349edf7cea9b1ff73b2da213c58
+  md5: ad0afa524866cc1c08b436865d0ae484
   depends:
   - __osx >=10.13
   constrains:
@@ -12317,8 +12284,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 300682
-  timestamp: 1718887195436
+  size: 300358
+  timestamp: 1723605369115
 - kind: conda
   name: llvmlite
   version: 0.43.0
@@ -12638,13 +12605,13 @@ packages:
   timestamp: 1608166099896
 - kind: conda
   name: mapclassify
-  version: 2.7.0
+  version: 2.8.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.7.0-pyhd8ed1ab_0.conda
-  sha256: 7b0be62b175db5cc36bcca1b995fccd4a22cd1ffdf612edc188f329087f048f7
-  md5: 014ab9453f9e9fb915937b46830d48e8
+  url: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.0-pyhd8ed1ab_0.conda
+  sha256: e24778b8e965ae188ef268c52f4b55e340b6a194db57481f640f7d2b0a6e57a2
+  md5: 61730f7e741f2d98441bfa44979f2a33
   depends:
   - networkx >=2.7
   - numpy >=1.23
@@ -12655,9 +12622,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/mapclassify?source=hash-mapping
-  size: 57466
-  timestamp: 1721848501218
+  - pkg:pypi/mapclassify?source=compressed-mapping
+  size: 56342
+  timestamp: 1723589782579
 - kind: conda
   name: markdown-it-py
   version: 3.0.0
@@ -12739,15 +12706,14 @@ packages:
   timestamp: 1706900374745
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py312h2e8e312_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h2e8e312_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.1-py312h2e8e312_2.conda
-  sha256: 1f0954a769507fe01fad59bbb47c18ecaa6419aae7ce8fb9b2a684b6c8b16174
-  md5: 62ea4aefc82a31be9c99f39b63fae7d1
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.9.2-py312h2e8e312_0.conda
+  sha256: 2ad3b3e80dd897efa7c04c614399baf4f79a08ade8d8e514b0866727d9d03056
+  md5: f87a4701dbbf6dcdb559f2dc5b3b0b95
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - pyside6 >=6.7.2
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -12756,19 +12722,18 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 9238
-  timestamp: 1722733859811
+  size: 9152
+  timestamp: 1723760944640
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py312h7900ff3_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h7900ff3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.1-py312h7900ff3_2.conda
-  sha256: 1029855a86d4d10b3b7b85fff87eccbc8d894c6077006db442e8bc2fabba79c2
-  md5: 0cb46cee2785e2d9dd29a5f36f5a1de7
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.2-py312h7900ff3_0.conda
+  sha256: b728fe3bb3525fc2a2d37b81e5fee1c697fa6ce380da8c1dbd4378ff0a3bc299
+  md5: 44c07eccf73f549b8ea5c9aacfe3ad0a
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - pyside6 >=6.7.2
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -12777,19 +12742,18 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 8742
-  timestamp: 1722732822766
+  size: 8747
+  timestamp: 1723759696471
 - kind: conda
   name: matplotlib
-  version: 3.9.1
-  build: py312hb401068_2
-  build_number: 2
+  version: 3.9.2
+  build: py312hb401068_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.1-py312hb401068_2.conda
-  sha256: e58bc7ca4d5840cdf2986d2ba49378d4ffcdc374635bd11587ac010103c22f13
-  md5: 1ead575881ba176014aad8dfac07d1b1
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.9.2-py312hb401068_0.conda
+  sha256: 1a3a285255fdb62dbd58df5426910071d47afdca8608a9f22c21dd74b8d1b308
+  md5: f468fd4f10632ff2500482118a3d4ace
   depends:
-  - matplotlib-base >=3.9.1,<3.9.2.0a0
+  - matplotlib-base >=3.9.2,<3.9.3.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tornado >=5
@@ -12797,17 +12761,16 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 8797
-  timestamp: 1722732924898
+  size: 8799
+  timestamp: 1723759810727
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py312h0d5aeb7_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h0d5aeb7_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.1-py312h0d5aeb7_2.conda
-  sha256: 1af41945c490c2fcad09855d9cfe8aa047bf205e95ca22de2df90028f5e3c47e
-  md5: 0aece95a1cd3b77990022d3e0f37c6aa
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.9.2-py312h0d5aeb7_0.conda
+  sha256: e84ce46cad067c84d737229f642613734c69d665dd7b6f3997aaa3586d2da41c
+  md5: 0c73a08429d20f15fa8b28083ec04cc9
   depends:
   - __osx >=10.13
   - certifi >=2020.06.20
@@ -12830,17 +12793,16 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 7652692
-  timestamp: 1722732881781
+  size: 7905104
+  timestamp: 1723759753087
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py312h854627b_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h854627b_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.1-py312h854627b_2.conda
-  sha256: f9fd13cd1aeafc8b26f4237494a86d3a3ef477a266a71ad4e5edae75f5883510
-  md5: 2a49f2a9c0447bc1bdaec98e3ee59117
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.2-py312h854627b_0.conda
+  sha256: ae075b97ce43439a7a914bf478564927a3dfe00724fb69555947cc3bae737a11
+  md5: a57b0ae7c0aac603839a4e83a3e997d6
   depends:
   - __glibc >=2.17,<3.0.a0
   - certifi >=2020.06.20
@@ -12865,17 +12827,16 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 8058949
-  timestamp: 1722732804101
+  size: 7904910
+  timestamp: 1723759675614
 - kind: conda
   name: matplotlib-base
-  version: 3.9.1
-  build: py312h90004f6_2
-  build_number: 2
+  version: 3.9.2
+  build: py312h90004f6_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.1-py312h90004f6_2.conda
-  sha256: e48a47f274ee3ce4b7922bb41ef5368cf78dedff44666bc44676faa8eb5f325f
-  md5: b887827aaf3c5019d6802eeab07b9697
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.9.2-py312h90004f6_0.conda
+  sha256: 50db6571737853422b164f2de6afb60d202043c078c8e52939396e5ea65a494f
+  md5: f1422f097083503f11d336f155748b73
   depends:
   - certifi >=2020.06.20
   - contourpy >=1.0.1
@@ -12899,8 +12860,8 @@ packages:
   license_family: PSF
   purls:
   - pkg:pypi/matplotlib?source=compressed-mapping
-  size: 7770509
-  timestamp: 1722733792441
+  size: 7747918
+  timestamp: 1723760858160
 - kind: conda
   name: matplotlib-inline
   version: 0.1.7
@@ -13917,41 +13878,62 @@ packages:
   timestamp: 1721194674491
 - kind: conda
   name: orc
-  version: 2.0.1
-  build: h17fec99_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.1-h17fec99_1.conda
-  sha256: d340c67b23fb0e1ef7e13574dd4a428f360bfce93b2a588b3b63625926b038d6
-  md5: 3bf65f0d8e7322a1cfe8b670fa35ec81
+  version: 2.0.2
+  build: h22b2039_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.2-h22b2039_0.conda
+  sha256: b5a0667937d9d2d8d50e624e67fdc54c898a33013cd3a6fada343f3c4e69ae6e
+  md5: f7c6463d97edb79a39df8e5e90c53b1b
   depends:
-  - libgcc-ng >=12
+  - __osx >=10.13
+  - libcxx >=16
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
+  - snappy >=1.2.1,<1.3.0a0
   - tzdata
   - zstd >=1.5.6,<1.6.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 1029691
-  timestamp: 1716789702707
+  size: 466353
+  timestamp: 1723760915178
 - kind: conda
   name: orc
-  version: 2.0.1
-  build: h7e885a9_1
-  build_number: 1
+  version: 2.0.2
+  build: h669347b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.2-h669347b_0.conda
+  sha256: 8a126e0be7f87c499f0a9b5229efa4321e60fc4ae46abdec9b13240631cb1746
+  md5: 1e6c10f7d749a490612404efeb179eb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libprotobuf >=4.25.3,<4.25.4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.2.1,<1.3.0a0
+  - tzdata
+  - zstd >=1.5.6,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1066349
+  timestamp: 1723760593232
+- kind: conda
+  name: orc
+  version: 2.0.2
+  build: h784c2ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.1-h7e885a9_1.conda
-  sha256: 8aca1dcb6e9b3e71ffbec26c2b84f45fa682d9075b78cd30acc48044b64149ec
-  md5: 97012c0aeee0bf55c05b5ec42cac0864
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.2-h784c2ca_0.conda
+  sha256: f083c8f49430ca80b6d8a776c37bc1021075dc5f826527c44a85f90607a5c652
+  md5: dbb01d6e4f992ea4f0dcb049ab926cc7
   depends:
   - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
+  - snappy >=1.2.1,<1.3.0a0
   - tzdata
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -13960,31 +13942,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 925642
-  timestamp: 1716789911582
-- kind: conda
-  name: orc
-  version: 2.0.1
-  build: hf43e91b_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.1-hf43e91b_1.conda
-  sha256: 718010a056ef084a12bfd6b4d7908c8817a0093ecc395c270857134e002d5857
-  md5: 15d11d156ad646e69176df6af6ef0826
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - libprotobuf >=4.25.3,<4.25.4.0a0
-  - libzlib >=1.2.13,<2.0.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
-  - tzdata
-  - zstd >=1.5.6,<1.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  purls: []
-  size: 438785
-  timestamp: 1716789731333
+  size: 999325
+  timestamp: 1723761049521
 - kind: conda
   name: overrides
   version: 7.7.0
@@ -14591,17 +14550,17 @@ packages:
   timestamp: 1717777969967
 - kind: conda
   name: poppler
-  version: 24.07.0
+  version: 24.08.0
   build: h686f694_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/poppler-24.07.0-h686f694_0.conda
-  sha256: c22de4784acad150c56c0064ba383abd80b097eeb0c192461efec8e572599a2c
-  md5: 4e21d8257375ae401877013416ebc12b
+  url: https://conda.anaconda.org/conda-forge/win-64/poppler-24.08.0-h686f694_0.conda
+  sha256: a18060dc625c081307f800b3e89b487e375dc9a9fb7b9f0fa093d6e41927614e
+  md5: 927a6b4a37decb917ce5b52eed2f3333
   depends:
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
-  - libcurl >=8.8.0,<9.0a0
+  - libcurl >=8.9.1,<9.0a0
   - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libintl >=0.22.5,<1.0a0
@@ -14617,16 +14576,16 @@ packages:
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 2374174
-  timestamp: 1720374177748
+  size: 2379143
+  timestamp: 1723083494559
 - kind: conda
   name: poppler
-  version: 24.07.0
+  version: 24.08.0
   build: h744cbf2_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.07.0-h744cbf2_0.conda
-  sha256: 012c492087fdcc10a97fab28f3e105ca995bc796f72f0744b1cd050ca35828e5
-  md5: 1603ef5fcf8bffffc3451ca182b6df0a
+  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.08.0-h744cbf2_0.conda
+  sha256: 5be39a4f1569045a15e46928b67e5459493ae921519888d3a82c1c64dbdc842a
+  md5: ed41cbc38d3955f7aa121196461dc5d1
   depends:
   - __osx >=10.13
   - cairo >=1.18.0,<2.0a0
@@ -14634,7 +14593,7 @@ packages:
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
-  - libcurl >=8.8.0,<9.0a0
+  - libcurl >=8.9.1,<9.0a0
   - libcxx >=16
   - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
@@ -14644,22 +14603,22 @@ packages:
   - libtiff >=4.6.0,<4.7.0a0
   - libzlib >=1.3.1,<2.0a0
   - nspr >=4.35,<5.0a0
-  - nss >=3.102,<4.0a0
+  - nss >=3.103,<4.0a0
   - openjpeg >=2.5.2,<3.0a0
   - poppler-data
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 1586876
-  timestamp: 1720373241748
+  size: 1591847
+  timestamp: 1723083003580
 - kind: conda
   name: poppler
-  version: 24.07.0
+  version: 24.08.0
   build: hb0d391f_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.07.0-hb0d391f_0.conda
-  sha256: 20ddd62419f3ddf779dfaae7d12001b0e63e365f781b1137f6db0b428193a3cb
-  md5: 561842bc59112340fa1f5f1ed06ae4a2
+  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.08.0-hb0d391f_0.conda
+  sha256: 78f1163ad49f6745d8086922054c837e2ecce69877dd0efa2a82f3f2b4fc1bdd
+  md5: cbe41fbbe05b1f78182ced1f0defdf81
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.0,<2.0a0
@@ -14667,7 +14626,7 @@ packages:
   - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.16,<3.0a0
-  - libcurl >=8.8.0,<9.0a0
+  - libcurl >=8.9.1,<9.0a0
   - libgcc-ng >=12
   - libglib >=2.80.3,<3.0a0
   - libiconv >=1.17,<2.0a0
@@ -14677,14 +14636,14 @@ packages:
   - libtiff >=4.6.0,<4.7.0a0
   - libzlib >=1.3.1,<2.0a0
   - nspr >=4.35,<5.0a0
-  - nss >=3.102,<4.0a0
+  - nss >=3.103,<4.0a0
   - openjpeg >=2.5.2,<3.0a0
   - poppler-data
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 1906317
-  timestamp: 1720373278987
+  size: 1911070
+  timestamp: 1723082747225
 - kind: conda
   name: poppler-data
   version: 0.4.12
@@ -15838,51 +15797,51 @@ packages:
 - kind: conda
   name: python_abi
   version: '3.12'
-  build: 4_cp312
-  build_number: 4
+  build: 5_cp312
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
-  sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
-  md5: dccc2d142812964fcc6abdc97b672dff
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
+  sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
+  md5: 0424ae29b104430108f5218a66db7260
   constrains:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 6385
-  timestamp: 1695147396604
+  size: 6238
+  timestamp: 1723823388266
 - kind: conda
   name: python_abi
   version: '3.12'
-  build: 4_cp312
-  build_number: 4
+  build: 5_cp312
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
-  sha256: 82c154d95c1637604671a02a89e72f1382e89a4269265a03506496bd928f6f14
-  md5: 87201ac4314b911b74197e588cca3639
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
+  sha256: 4da26c7508d5bc5d8621e84dc510284402239df56aab3587a7d217de9d3c806d
+  md5: c34dd4920e0addf7cfcc725809f25d8e
   constrains:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 6496
-  timestamp: 1695147498447
+  size: 6312
+  timestamp: 1723823137004
 - kind: conda
   name: python_abi
   version: '3.12'
-  build: 4_cp312
-  build_number: 4
+  build: 5_cp312
+  build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-  sha256: 488f8519d04b48f59bd6fde21ebe2d7a527718ff28aac86a8b53aa63658bdef6
-  md5: 17f4ccf6be9ded08bd0a376f489ac1a6
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-5_cp312.conda
+  sha256: 9486662af81a219e96d343449eff242f38d7c5128ced5ce5acf85857265058d6
+  md5: e8681f534453af7afab4cd2bc1423eec
   constrains:
   - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 6785
-  timestamp: 1695147430513
+  size: 6730
+  timestamp: 1723823139725
 - kind: conda
   name: pytz
   version: '2024.1'
@@ -16645,25 +16604,6 @@ packages:
   size: 38500
   timestamp: 1721804986901
 - kind: pypi
-  name: ribasim-lumping
-  version: 0.1.0
-  path: src/ribasim_lumping
-  sha256: 25f734682e8e1d8bbcea37b6147101f264a13471b82341daf989834955d1a942
-  requires_dist:
-  - contextily
-  - geopandas
-  - matplotlib
-  - networkx
-  - numpy
-  - pandas
-  - pydantic
-  - ribasim
-  - shapely
-  - xarray
-  - xugrid
-  requires_python: '>=3.10'
-  editable: true
-- kind: pypi
   name: ribasim-nl
   version: 0.1.0
   path: src/ribasim_nl
@@ -16779,12 +16719,12 @@ packages:
   timestamp: 1723039277393
 - kind: conda
   name: ruff
-  version: 0.5.7
+  version: 0.6.1
   build: py312h7a6832a_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.5.7-py312h7a6832a_0.conda
-  sha256: 8ef95b535c160a81dad2c56f3755187e4fb7b01a444b9183ec11a1bbd46910e3
-  md5: 113ba113d1f49decf8d2fcd10f72090e
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.1-py312h7a6832a_0.conda
+  sha256: e5c954b67cf00b89d1b64da652d2dae774f849ae7961a52d8c226fe9f39336fd
+  md5: 692adc6fcbcf83e0a23dfc5783d141cc
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -16795,16 +16735,16 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
-  size: 6314546
-  timestamp: 1723151403766
+  size: 6338756
+  timestamp: 1723845582188
 - kind: conda
   name: ruff
-  version: 0.5.7
+  version: 0.6.1
   build: py312h8b25c6c_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.5.7-py312h8b25c6c_0.conda
-  sha256: f64bb57fb68a1574aa5027cde2769ba020c0b4c7ade2b83591ed04b523e59171
-  md5: 7f01e511cf73bceae4d4da96951b693d
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.1-py312h8b25c6c_0.conda
+  sha256: 4150163a68d709bb43b825661a0351ee6ef434c95ca4e50c6d722e96187fa434
+  md5: cb868f88436af1db6df8b5de992360df
   depends:
   - __osx >=10.13
   - libcxx >=16
@@ -16816,16 +16756,16 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
-  size: 6169333
-  timestamp: 1723151007579
+  size: 6192936
+  timestamp: 1723844613061
 - kind: conda
   name: ruff
-  version: 0.5.7
+  version: 0.6.1
   build: py312hbe4c86d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.5.7-py312hbe4c86d_0.conda
-  sha256: b8cc83042471c5740f29a5f3ce1ef7116b892095591907929671fe4e33345026
-  md5: 8871e1b8e5ec1c57d3769adc0b9e5d68
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.1-py312hbe4c86d_0.conda
+  sha256: 56681b77861dfb08f656248c5707c23ed9c3fb7758531cabb563f008a7c4f4a6
+  md5: 15153af670ac4d72f188aecdb4bc6119
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
@@ -16838,8 +16778,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
-  size: 7184746
-  timestamp: 1723150552013
+  size: 7216969
+  timestamp: 1723844217866
 - kind: conda
   name: s2n
   version: 1.5.0
@@ -16933,18 +16873,19 @@ packages:
 - kind: conda
   name: scipy
   version: 1.14.0
-  build: py312h1f4e10d_1
-  build_number: 1
+  build: py312h1f4e10d_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_1.conda
-  sha256: e2c55a57bdac972d5f0ecae09a8a8041ee6519627231851e8edb27fd8e1a5e11
-  md5: 4667a8b9e594a70eb0ef680615a4b411
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.0-py312h1f4e10d_2.conda
+  sha256: beb4737c20a8d6bf864d937761f323569402baa133b121bd35d7f81c27ca4dc6
+  md5: bcdfde2d67d09e76e27ae1f634772c6c
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
+  - numpy >=1.23.5,<2.3
   - numpy >=1.19,<3
+  - numpy >=1.23.5
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
@@ -16953,18 +16894,47 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=hash-mapping
-  size: 15758479
-  timestamp: 1720325181489
+  - pkg:pypi/scipy?source=compressed-mapping
+  size: 15915111
+  timestamp: 1723857062798
 - kind: conda
   name: scipy
   version: 1.14.0
-  build: py312hb9702fa_1
-  build_number: 1
+  build: py312h499d17b_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312h499d17b_2.conda
+  sha256: a84bd33593abc9b6acadcd31410f9a028031f00c2a8db33255f2358570673346
+  md5: fbb459d6590fad7bd00aeb1665bb67d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.4.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - numpy >=1.23.5,<2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=compressed-mapping
+  size: 17610049
+  timestamp: 1723856153431
+- kind: conda
+  name: scipy
+  version: 1.14.0
+  build: py312hb9702fa_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_1.conda
-  sha256: 259651aa3966f9735aab2b3ee9c25d4fa93914484e9b757c0b6fda87bac78a0f
-  md5: 9899db3cf8965c3aecab3daf5227d3eb
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.0-py312hb9702fa_2.conda
+  sha256: 5b7c993667836317f39d55046abff58eee468939675bda3f59872e2e64e2d819
+  md5: 610311c8f21dbbf294157f03922e9ca8
   depends:
   - __osx >=10.13
   - libblas >=3.9.0,<4.0a0
@@ -16974,43 +16944,17 @@ packages:
   - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.3
+  - numpy >=1.23.5,<2.3
   - numpy >=1.19,<3
+  - numpy >=1.23.5
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=hash-mapping
-  size: 16203819
-  timestamp: 1720323983766
-- kind: conda
-  name: scipy
-  version: 1.14.0
-  build: py312hc2bc53b_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.0-py312hc2bc53b_1.conda
-  sha256: 6bd24bc823863bb568ffe0ebdfb506d4413d94d15b478b12a0b223d9373f531e
-  md5: eae80145f63aa04a02dda456d4883b46
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng
-  - libgfortran5 >=12.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - numpy <2.3
-  - numpy >=1.19,<3
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/scipy?source=hash-mapping
-  size: 17653680
-  timestamp: 1720324049729
+  - pkg:pypi/scipy?source=compressed-mapping
+  size: 16131947
+  timestamp: 1723855841034
 - kind: conda
   name: send2trash
   version: 1.8.3
@@ -17149,47 +17093,31 @@ packages:
   timestamp: 1720886333536
 - kind: conda
   name: simplejson
-  version: 3.19.2
-  build: py312h41838bb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.2-py312h41838bb_0.conda
-  sha256: 5bb9c286fa0f3b56eaa260c68fb45e897bacb9c063baf76a88ecd3e001871f9e
-  md5: 4d3e79397df9b944a6297e583d3b76e9
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/simplejson?source=hash-mapping
-  size: 128950
-  timestamp: 1696596106966
-- kind: conda
-  name: simplejson
-  version: 3.19.2
-  build: py312h98912ed_0
+  version: 3.19.3
+  build: py312h41a817b_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.2-py312h98912ed_0.conda
-  sha256: 3d8fee62aa0fd5aaf737ad200b7f8785c076d66f4226014a8d04b5c215010a95
-  md5: 7eb0e4dbb44dd065300144525326ab8d
+  url: https://conda.anaconda.org/conda-forge/linux-64/simplejson-3.19.3-py312h41a817b_0.conda
+  sha256: 0d0de00e5570c37818836d1eb15b44cca47dffbad34c4100add83d796443b276
+  md5: 5ee99b39f0c3b74a2c6da28752a9b761
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/simplejson?source=hash-mapping
-  size: 130931
-  timestamp: 1696596072174
+  - pkg:pypi/simplejson?source=compressed-mapping
+  size: 130202
+  timestamp: 1723702839180
 - kind: conda
   name: simplejson
-  version: 3.19.2
-  build: py312he70551f_0
+  version: 3.19.3
+  build: py312h4389bb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.2-py312he70551f_0.conda
-  sha256: 5e47ae1a0ad0d2d92c9a4a7362a9813db1bdf8883311214acfdc9361c9484fb3
-  md5: 410f7b348e7c154cbcf90be692992e2d
+  url: https://conda.anaconda.org/conda-forge/win-64/simplejson-3.19.3-py312h4389bb4_0.conda
+  sha256: 97a519abcb3976b1ecdd135c785b9012bc1e432e098ae5a781293c6a93a4ca06
+  md5: a2da9923ed7f140bdc687a59b6d410ad
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -17199,9 +17127,27 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/simplejson?source=hash-mapping
-  size: 129515
-  timestamp: 1696596080274
+  - pkg:pypi/simplejson?source=compressed-mapping
+  size: 129197
+  timestamp: 1723703355462
+- kind: conda
+  name: simplejson
+  version: 3.19.3
+  build: py312hbd25219_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/simplejson-3.19.3-py312hbd25219_0.conda
+  sha256: b6b12ee88ed395f268efb7671028ab27851bd5684810c77d40e91ae996430ca7
+  md5: d6843b9f409068e72ec00131f6262692
+  depends:
+  - __osx >=10.13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/simplejson?source=compressed-mapping
+  size: 128705
+  timestamp: 1723702909479
 - kind: conda
   name: six
   version: 1.16.0
@@ -19337,21 +19283,21 @@ packages:
   timestamp: 1681770298596
 - kind: conda
   name: zipp
-  version: 3.19.2
+  version: 3.20.0
   build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.19.2-pyhd8ed1ab_0.conda
-  sha256: e3e9c8501f581bfdc4700b83ea283395e237ec6b9b5cbfbedb556e1da6f4fdc9
-  md5: 49808e59df5535116f6878b2a820d6f4
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.0-pyhd8ed1ab_0.conda
+  sha256: 72fa72af24006e37a9f027d6d9f407369edcbd9bbb93db299820eb63ea07e404
+  md5: 05b6bcb391b5be17374f7ad0aeedc479
   depends:
   - python >=3.8
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp?source=hash-mapping
-  size: 20917
-  timestamp: 1718013395428
+  - pkg:pypi/zipp?source=compressed-mapping
+  size: 20857
+  timestamp: 1723591347715
 - kind: conda
   name: zlib
   version: 1.3.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -74,7 +74,6 @@ xugrid = "*"
 bokeh_helpers = { path = "src/bokeh_helpers", editable = true }
 hydamo = { path = "src/hydamo", editable = true }
 peilbeheerst_model = { path = "src/peilbeheerst_model", editable = true }
-ribasim_lumping = { path = "src/ribasim_lumping", editable = true }
 ribasim_nl = { path = "src/ribasim_nl", editable = true }
 
 [feature.dev.pypi-dependencies]


### PR DESCRIPTION
Fixes #122.

At this point we'll work with the already uploaded results of ribasim_lumping and patch those up for use with the current Ribasim version, like for instance done in #129.

That means for now we don't need to update this code to run. I don't delete the code because we probably want to use it later on and may need to look at the implementation. This does mean we cannot `import ribasim_lumping` within the pixi environment.

Also updates dependencies with `pixi update`.