### PR TITLE
Run AGV shortest_path and crossings_to_ribasim

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -14706,10 +14706,12 @@ packages:
   name: peilbeheerst-model
   version: 0.1.0
   path: src/peilbeheerst_model
-  sha256: e8c270f68d683c802990a8bb905cd665fd327b33e1d17bf3e01dfe9c49ec335e
+  sha256: 9ec22544800123361c4449542c548c1e3739a3f8d9d5bbe2f91a8d50d304fac5
   requires_dist:
+  - fiona
   - geopandas
   - matplotlib
+  - networkx
   - numpy
   - pandas
   - pydantic

--- a/src/peilbeheerst_model/01_parse_crossings.py
+++ b/src/peilbeheerst_model/01_parse_crossings.py
@@ -29,7 +29,7 @@ for waterschap, waterschap_struct in waterschap_data.items():
     init_settings = waterschap_struct["init"]
     init_settings["logfile"] = pathlib.Path(init_settings["output_path"]).with_suffix(".log")
 
-    if waterschap not in ["HHNK"]:
+    if waterschap not in ["AmstelGooienVecht"]:
         continue
 
     # if pathlib.Path(init_settings["output_path"]).exists() and "crossings_hydroobject" in fiona.listlayers(init_settings["output_path"]):
@@ -127,3 +127,5 @@ fig2.savefig("reduction_results.jpeg", bbox_inches="tight")
 
 print(pd.DataFrame(reduction_results, index=waterschappen))
 print(pd.DataFrame(network_results, index=waterschappen))
+
+# %%

--- a/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.py
+++ b/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.py
@@ -1,7 +1,47 @@
-from peilbeheerst_model import shortest_path_waterschap
+# The AGV shortest path code is identical to the other water boards.
+# Below the content of shortest_path_waterschappen is spelled out to be able to
+# point to the right data from the cloud storage.
+
+import fiona
+import geopandas as gpd
+import pandas as pd
+from shapely.wkt import dumps
+
+from peilbeheerst_model.shortest_path import shortest_path
+from ribasim_nl import CloudStorage
 
 waterschap = "AmstelGooienVecht"
-gdf_out = shortest_path_waterschap(waterschap)
-gdf_out.to_file(
-    f"/DATAFOLDER/projects/4750_30/Data_shortest_path/{waterschap}/{waterschap}_shortest_path.gpkg", driver="GPKG"
-)
+
+cloud = CloudStorage()
+# cloud.download_verwerkt(waterschap)
+# cloud.download_verwerkt("Rijkswaterstaat")
+# cloud.download_basisgegevens()
+
+# %%
+verwerkt_dir = cloud.joinpath(waterschap, "verwerkt")
+
+# Load Data
+# Define crossings file path
+data_path = verwerkt_dir / "crossings.gpkg"
+
+# Load crossings file
+DATA = {L: gpd.read_file(data_path, layer=L) for L in fiona.listlayers(data_path)}
+
+# Select rhws
+
+# Select RHWS peilgebeied & calculate representative point
+gdf_rhws = DATA["peilgebied"].loc[DATA["peilgebied"]["peilgebied_cat"] == 1].copy()
+gdf_rhws["representative_point"] = gdf_rhws.representative_point()
+
+# Apply aggregation level based filter
+gdf_cross = (
+    DATA["crossings_hydroobject_filtered"].loc[DATA["crossings_hydroobject_filtered"]["agg_links_in_use"]].copy()
+)  # filter aggregation level
+
+gdf_crossings_out = shortest_path(waterschap, DATA, gdf_cross, gdf_rhws)
+# Write final output
+gdf_out = gpd.GeoDataFrame(pd.concat(gdf_crossings_out))
+gdf_out["shortest_path"] = gdf_out["shortest_path"].apply(lambda geom: dumps(geom) if geom is not None else None)
+gdf_out.to_file(verwerkt_dir / "shortest_path.gpkg", driver="GPKG")
+
+# cloud.upload_verwerkt(waterschap)

--- a/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.py
+++ b/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.py
@@ -45,3 +45,5 @@ gdf_out["shortest_path"] = gdf_out["shortest_path"].apply(lambda geom: dumps(geo
 gdf_out.to_file(verwerkt_dir / "shortest_path.gpkg", driver="GPKG")
 
 # cloud.upload_verwerkt(waterschap)
+
+# %%

--- a/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.py
+++ b/src/peilbeheerst_model/Shortest_path/10_shortest_path_AGV.py
@@ -44,6 +44,6 @@ gdf_out = gpd.GeoDataFrame(pd.concat(gdf_crossings_out))
 gdf_out["shortest_path"] = gdf_out["shortest_path"].apply(lambda geom: dumps(geom) if geom is not None else None)
 gdf_out.to_file(verwerkt_dir / "shortest_path.gpkg", driver="GPKG")
 
-# cloud.upload_verwerkt(waterschap)
+cloud.upload_verwerkt(waterschap)
 
 # %%

--- a/src/peilbeheerst_model/crossings_to_ribasim/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/crossings_to_ribasim/AmstelGooienVecht.py
@@ -1,0 +1,116 @@
+# Modified version of the AGV part of 02_crossings_to_ribasim.py.
+
+# %%
+
+import pandas as pd
+from ribasim import Model
+
+from peilbeheerst_model import CrossingsToRibasim, RibasimNetwork, waterschap_data
+from ribasim_nl import CloudStorage
+
+# %%
+waterschap = "AmstelGooienVecht"
+waterschap_struct = waterschap_data[waterschap]
+
+cloud = CloudStorage()
+verwerkt_dir = cloud.joinpath(waterschap, "verwerkt")
+# cloud.download_verwerkt(waterschap)
+# cloud.download_basisgegevens()
+
+# %%
+
+pd.set_option("display.max_columns", None)
+# warnings.filterwarnings("ignore")
+
+
+model_characteristics = {
+    # model description
+    "waterschap": "AmstelGooienVecht",
+    "modelname": "repro",
+    "modeltype": "boezemmodel",
+    # define paths
+    "path_postprocessed_data": verwerkt_dir / "postprocessed.gpkg",
+    "path_crossings": verwerkt_dir / "crossings.gpkg",
+    "path_boezem": verwerkt_dir / "shortest_path.gpkg",
+    "path_Pdrive": None,
+    # apply filters
+    "crossings_layer": "crossings_hydroobject_filtered",
+    "in_use": True,
+    "agg_links_in_use": True,
+    "agg_areas_in_use": True,
+    "aggregation": True,
+    # data storage settings
+    "write_goodcloud": False,  # TODO
+    "write_checks": True,
+    # numerical settings
+    "solver": None,
+    "logging": None,
+    "starttime": "2024-01-01 00:00:00",
+    "endtime": "2024-01-02 00:00:00",
+}
+
+waterboard = CrossingsToRibasim(model_characteristics=model_characteristics)
+
+post_processed_data, crossings = waterboard.read_files()
+post_processed_data, crossings = waterboard.routing_processor(post_processed_data, crossings)
+crossings = waterboard.assign_node_ids(crossings)
+edges = waterboard.create_edges(crossings)
+nodes, edges = waterboard.create_nodes(crossings, edges)
+edges = waterboard.embed_boezems(edges, post_processed_data, crossings)
+
+# create individual model parts of the network
+network = RibasimNetwork(nodes=nodes, edges=edges, model_characteristics=model_characteristics)
+
+edge = network.edge()
+basin_node, basin_profile, basin_static, basin_state, basin_area = network.basin()
+pump_node, pump_static = network.pump()
+tabulated_rating_curve_node, tabulated_rating_curve_static = network.tabulated_rating_curve()
+level_boundary_node, level_boundary_static = network.level_boundary()
+flow_boundary_node, flow_boundary_static = network.flow_boundary()
+manning_resistance_node, manning_resistance_static = network.manning_resistance()
+terminal_node = network.terminal()
+
+# linear_resistance = network.linear_resistance()
+# fractional_flow = network.fractional_flow()
+# outlet = network.outlet()
+# discrete_control = network.discrete_control()
+# pid_control = network.pid_control()
+
+# insert the individual model modules in an actual model
+model = Model(starttime=model_characteristics["starttime"], endtime=model_characteristics["endtime"], crs="EPSG:28992")
+
+model.edge.df = edge
+
+model.basin.node.df = basin_node
+model.basin.profile = basin_profile
+model.basin.static = basin_static
+model.basin.state = basin_state
+model.basin.area = basin_area
+
+model.pump.node.df = pump_node
+model.pump.static = pump_static
+
+model.tabulated_rating_curve.node.df = tabulated_rating_curve_node
+model.tabulated_rating_curve.static = tabulated_rating_curve_static
+
+model.manning_resistance.node.df = manning_resistance_node
+model.manning_resistance.static = manning_resistance_static
+
+model.level_boundary.node.df = level_boundary_node
+model.level_boundary.static = level_boundary_static
+
+model.flow_boundary.node.df = flow_boundary_node
+model.flow_boundary.static = flow_boundary_static
+
+model.terminal.node.df = terminal_node
+
+# add checks and metadata
+checks = network.check(model, post_processed_data=post_processed_data, crossings=crossings)
+model = network.add_meta_data(model, checks, post_processed_data, crossings)
+
+# write the result
+network.WriteResults(model=model, checks=checks)
+
+# %%
+
+# cloud.upload_verwerkt(waterschap)

--- a/src/peilbeheerst_model/crossings_to_ribasim/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/crossings_to_ribasim/AmstelGooienVecht.py
@@ -113,4 +113,6 @@ network.WriteResults(model=model, checks=checks)
 
 # %%
 
-# cloud.upload_verwerkt(waterschap)
+cloud.upload_verwerkt(waterschap)
+
+# %%

--- a/src/peilbeheerst_model/parse_crossings/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/parse_crossings/AmstelGooienVecht.py
@@ -10,7 +10,7 @@ waterschap_struct = waterschap_data[waterschap]
 cloud = CloudStorage()
 verwerkt_dir = cloud.joinpath(waterschap, "verwerkt")
 cloud.download_verwerkt(waterschap)
-cloud.download_basisgegevens()
+cloud.download_basisgegevens(bronnen=["KRW"])
 
 # %%
 
@@ -36,3 +36,5 @@ else:
 # %%
 
 cloud.upload_verwerkt(waterschap)
+
+# %%

--- a/src/peilbeheerst_model/peilbeheerst_model/__init__.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/__init__.py
@@ -1,7 +1,14 @@
 __version__ = "0.1.0"
 
-from peilbeheerst_model.parse_crossings import ParseCrossings
-from peilbeheerst_model.shortest_path import shortest_path_waterschap
-from peilbeheerst_model.waterschappen import waterschap_data
+from .crossings_to_ribasim import CrossingsToRibasim, RibasimNetwork
+from .parse_crossings import ParseCrossings
+from .shortest_path import shortest_path_waterschap
+from .waterschappen import waterschap_data
 
-__all__ = ["ParseCrossings", "shortest_path_waterschap", "waterschap_data"]
+__all__ = [
+    "CrossingsToRibasim",
+    "ParseCrossings",
+    "RibasimNetwork",
+    "shortest_path_waterschap",
+    "waterschap_data",
+]

--- a/src/peilbeheerst_model/peilbeheerst_model/general_functions.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/general_functions.py
@@ -2,6 +2,7 @@
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import pandas as pd
+import pyogrio
 
 
 def read_gpkg_layers(gpkg_path, engine="fiona", print_var=False):
@@ -55,28 +56,39 @@ def show_layers_and_columns(waterschap):
         print()
 
 
+# def store_data(waterschap, output_gpkg_path):
+#     """
+#     Store Geospatial Data to a GeoPackage (GPKG) File.
+
+#     Parameters
+#     ----------
+#         waterschap (dict): A dictionary containing GeoDataFrames to be stored in the GPKG file.
+#         output_gpkg_path (str): The file path (including the file name without extension) to save the GPKG file.
+
+#     Returns
+#     -------
+#         None
+
+#     This function stores geospatial data from a dictionary of GeoDataFrames into a GeoPackage (GPKG) file.
+
+#     Parameters
+#     ----------
+#     - waterschap: A dictionary where the keys represent layer names, and the values are GeoDataFrames.
+#     - output_gpkg_path: The file path for the output GPKG file. The '.gpkg' extension is added automatically.
+#     """
+#     for key in waterschap.keys():
+#         waterschap[str(key)].to_file(output_gpkg_path + ".gpkg", layer=str(key), driver="GPKG")
+
+
 def store_data(waterschap, output_gpkg_path):
-    """
-    Store Geospatial Data to a GeoPackage (GPKG) File.
-
-    Parameters
-    ----------
-        waterschap (dict): A dictionary containing GeoDataFrames to be stored in the GPKG file.
-        output_gpkg_path (str): The file path (including the file name without extension) to save the GPKG file.
-
-    Returns
-    -------
-        None
-
-    This function stores geospatial data from a dictionary of GeoDataFrames into a GeoPackage (GPKG) file.
-
-    Parameters
-    ----------
-    - waterschap: A dictionary where the keys represent layer names, and the values are GeoDataFrames.
-    - output_gpkg_path: The file path for the output GPKG file. The '.gpkg' extension is added automatically.
-    """
     for key in waterschap.keys():
-        waterschap[str(key)].to_file(output_gpkg_path + ".gpkg", layer=str(key), driver="GPKG")
+        pyogrio.write_dataframe(
+            waterschap[key],
+            output_gpkg_path + ".gpkg",
+            layer=str(key),
+            driver="GPKG",
+            promote_to_multi=False,
+        )
 
 
 def overlapping_peilgebieden(waterschap_peilgebieden):

--- a/src/peilbeheerst_model/peilbeheerst_model/parse_crossings.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/parse_crossings.py
@@ -9,6 +9,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import pydantic
+import pyogrio
 import shapely.ops
 import tqdm.auto as tqdm
 from shapely.geometry import LineString, MultiLineString, MultiPoint, Point, Polygon
@@ -600,14 +601,33 @@ class ParseCrossings:
 
         # Write the input files (some with minor modifications)
         for layer, df in self.df_gpkg.items():
-            df.to_file(output_path, layer=layer)
+            # df.to_file(output_path, layer=layer)
+
+            pyogrio.write_dataframe(
+                df,
+                output_path,
+                layer=str(layer),
+                driver="GPKG",
+                promote_to_multi=False,
+            )
 
         # Write supplied output files
         df_hydro.to_file(output_path, layer="crossings_hydroobject")
         if df_filter is not None:
-            df_filter.to_file(output_path, layer=f"crossings_{filterlayer}")
+            # df_filter.to_file(output_path, layer=f"crossings_{filterlayer}")
+            pyogrio.write_dataframe(
+                df_filter, output_path, layer=f"crossings_{filterlayer}", driver="GPKG", promote_to_multi=False
+            )
+
         if df_hydro_filter is not None:
-            df_hydro_filter.to_file(output_path, layer="crossings_hydroobject_filtered")
+            # df_hydro_filter.to_file(output_path, layer="crossings_hydroobject_filtered")
+            pyogrio.write_dataframe(
+                df_hydro_filter,
+                output_path,
+                layer="crossings_hydroobject_filtered",
+                driver="GPKG",
+                promote_to_multi=False,
+            )
 
     @pydantic.validate_call(config={"strict": True})
     def _classify_from_to_peilgebieden(self, pfrom: str | None, pto: str | None) -> tuple[str, str]:

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_agv.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_agv.py
@@ -24,7 +24,7 @@ waterschap2 = "AGV"
 cloud = CloudStorage()
 cloud.download_verwerkt(waterschap)
 cloud.download_verwerkt("Rijkswaterstaat")
-cloud.download_basisgegevens()
+cloud.download_basisgegevens(bronnen=["RWS_waterschaps_grenzen"])  # only download subdirectory of the basisgegevens
 
 # %%
 verwerkt_dir = cloud.joinpath(waterschap, "verwerkt")

--- a/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_agv.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/postprocess_data/post-process_agv.py
@@ -9,6 +9,7 @@
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pyogrio
 
 from peilbeheerst_model.general_functions import read_gpkg_layers
 from ribasim_nl import CloudStorage
@@ -126,9 +127,19 @@ if remove_cat_2:
 
 output_gpkg_path = verwerkt_dir / "postprocessed.gpkg"
 
+# for key in AVG.keys():
+#     print(key)
+#     AVG[str(key)].to_file(output_gpkg_path, layer=str(key), driver="GPKG")
+
 for key in AVG.keys():
-    print(key)
-    AVG[str(key)].to_file(output_gpkg_path, layer=str(key), driver="GPKG")
+    pyogrio.write_dataframe(
+        AVG[key],
+        output_gpkg_path,
+        layer=str(key),
+        driver="GPKG",
+        promote_to_multi=False,
+    )
+
 
 cloud.upload_verwerkt(waterschap)
 # %%

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/AmstelGooienVecht.py
@@ -57,18 +57,18 @@ for variable in variables:
     AVG[variable] = df_var
 
 # there is one last gpkg which contains the streefpeilen (and peilgebieden)
-AVG["peilgebied"] = gpd.read_file(aangeleverd_dir / "Na_levering" / "vigerende_peilgebieden.gpkg")
+# AVG["peilgebied"] = gpd.read_file(aangeleverd_dir / "Na_levering" / "vigerende_peilgebieden.gpkg")
 
 
-AVG["peilgebied"]["streefpeil"] = np.nan
-AVG["peilgebied"]["streefpeil"] = AVG["peilgebied"]["streefpeil"].fillna(value=AVG["peilgebied"]["GPGZMRPL"])
-AVG["peilgebied"]["streefpeil"] = AVG["peilgebied"]["streefpeil"].fillna(value=AVG["peilgebied"]["IWS_GPGVASTP"])
-AVG["peilgebied"]["streefpeil"] = AVG["peilgebied"]["streefpeil"].fillna(value=AVG["peilgebied"]["IWS_GPGONDP"])
+# AVG["peilgebied"]["streefpeil"] = np.nan
+# AVG["peilgebied"]["streefpeil"] = AVG["peilgebied"]["streefpeil"].fillna(value=AVG["peilgebied"]["GPGZMRPL"])
+# AVG["peilgebied"]["streefpeil"] = AVG["peilgebied"]["streefpeil"].fillna(value=AVG["peilgebied"]["IWS_GPGVASTP"])
+# AVG["peilgebied"]["streefpeil"] = AVG["peilgebied"]["streefpeil"].fillna(value=AVG["peilgebied"]["IWS_GPGONDP"])
 
-print(
-    "Number of missing streefpeilen = ",
-    len(AVG["peilgebied"]["streefpeil"].loc[AVG["peilgebied"]["streefpeil"].isna()]),
-)
+# print(
+#     "Number of missing streefpeilen = ",
+#     len(AVG["peilgebied"]["streefpeil"].loc[AVG["peilgebied"]["streefpeil"].isna()]),
+# )
 
 # fig, ax = plt.subplots()
 # AVG['peilgebied'].geometry.plot(ax=ax, color='cornflowerblue')
@@ -81,10 +81,10 @@ print(
 
 # overwrite previous data
 AVG["stuw"] = gpd.read_file(dump_path + "/Stuw.shp")
-AVG["stuw"] = AVG["stuw"].loc[AVG["stuw"].LHM == "LHM"]
+# AVG["stuw"] = AVG["stuw"].loc[AVG["stuw"].LHM == "LHM"]
 
 AVG["gemaal"] = gpd.read_file(dump_path + "/Gemaal.shp")
-AVG["gemaal"] = AVG["gemaal"].loc[AVG["gemaal"].LHM == "LHM"]
+# AVG["gemaal"] = AVG["gemaal"].loc[AVG["gemaal"].LHM == "LHM"]
 
 AVG["duikersifonhevel"] = gpd.read_file(dump_path + "/DuikerSifonHevel.shp")
 AVG["hydroobject"] = gpd.read_file(dump_path + "/LHM_hydrovakken.shp")
@@ -145,8 +145,8 @@ AVG["duikersifonhevel"] = AVG["duikersifonhevel"][["code", "geometry"]]
 AVG["duikersifonhevel"].loc[:, "nen3610id"] = "dummy_nen3610id_duikersifonhevel_" + AVG[
     "duikersifonhevel"
 ].index.astype(str)
-AVG["duikersifonhevel"]["globalid"] = "dummy_globalid_duikersifonhevel_" + AVG["duikersifonhevel"].index.astype(str)
-AVG["duikersifonhevel"] = gpd.GeoDataFrame(AVG["duikersifonhevel"]).to_crs("epsg:28992")
+AVG['duikersifonhevel']['globalid'] = 'dummy_globalid_duikersifonhevel_' + AVG['duikersifonhevel'].index.astype(str)
+AVG['duikersifonhevel'] = gpd.GeoDataFrame(AVG['duikersifonhevel']).to_crs('epsg:28992')
 
 # hydroobject
 AVG["hydroobject"] = AVG["hydroobject"][["geometry"]]
@@ -156,17 +156,22 @@ AVG["hydroobject"]["globalid"] = "dummy_globalid_hydroobject_" + AVG["hydroobjec
 AVG["hydroobject"] = gpd.GeoDataFrame(AVG["hydroobject"]).set_crs("epsg:28992")
 
 # streefpeil
-AVG["streefpeil"] = pd.DataFrame()
-AVG["streefpeil"]["waterhoogte"] = AVG["peilgebied"]["streefpeil"]
-AVG["streefpeil"]["globalid"] = "dummy_globalid_streefpeil_" + AVG["streefpeil"].index.astype(str)
-AVG["streefpeil"]["geometry"] = np.nan
-AVG["streefpeil"] = gpd.GeoDataFrame(AVG["streefpeil"]).set_crs("epsg:28992")
+# AVG["streefpeil"] = pd.DataFrame()
+# AVG["streefpeil"]["waterhoogte"] = AVG["peilgebied"]["streefpeil"]
+# AVG["streefpeil"]["globalid"] = "dummy_globalid_streefpeil_" + AVG["streefpeil"].index.astype(str)
+# AVG["streefpeil"]["geometry"] = np.nan
+# AVG["streefpeil"] = gpd.GeoDataFrame(AVG["streefpeil"]).set_crs("epsg:28992")
 
 # peilgebied
 AVG["peilgebied"]["code"] = AVG["peilgebied"]["GAFNAAM"]
 AVG["peilgebied"]["geometry"] = AVG["peilgebied"]["geometry"]
 AVG["peilgebied"]["nen3610id"] = "dummy_nen3610id_peilgebied_" + AVG["peilgebied"].index.astype(str)
 AVG["peilgebied"]["globalid"] = "dummy_globalid_peilgebied_" + AVG["peilgebied"].index.astype(str)
+
+AVG['streefpeil'] = AVG['peilgebied'][['waterhoogte', 'globalid']]
+AVG['streefpeil']['code'] = 'dummy_code_streefpeil_' + AVG['streefpeil'].index.astype(str)
+AVG['streefpeil']['geometry'] = None
+AVG['streefpeil'] = gpd.GeoDataFrame(AVG['streefpeil'], geometry = 'geometry')
 
 AVG["peilgebied"] = AVG["peilgebied"][["code", "nen3610id", "globalid", "geometry"]]
 AVG["peilgebied"] = gpd.GeoDataFrame(AVG["peilgebied"]).to_crs("epsg:28992")

--- a/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/preprocess_data/AmstelGooienVecht.py
@@ -33,6 +33,8 @@ dump_path = (
     aangeleverd_dir / "aanlevering_6maart24/data dump 6 maart LHM AGV.zip!/data dump 6 maart LHM AGV/"
 ).as_posix()
 
+dump_path_peilgebied = (aangeleverd_dir / "verbeterde_LHM_gebieden_geactualiseerd/").as_posix()
+
 verwerkt_dir.mkdir(parents=True, exist_ok=True)
 
 
@@ -88,7 +90,7 @@ AVG["gemaal"] = gpd.read_file(dump_path + "/Gemaal.shp")
 
 AVG["duikersifonhevel"] = gpd.read_file(dump_path + "/DuikerSifonHevel.shp")
 AVG["hydroobject"] = gpd.read_file(dump_path + "/LHM_hydrovakken.shp")
-AVG["peilgebied"] = gpd.read_file(dump_path + "/LHM_gebieden.shp")
+AVG["peilgebied"] = gpd.read_file(dump_path_peilgebied + "/LHM_gebieden.shp").to_crs(crs="EPSG:28992")
 
 
 AVG["peilgebied"].loc[AVG["peilgebied"].zomer == 0, "zomer"] = np.nan
@@ -145,8 +147,8 @@ AVG["duikersifonhevel"] = AVG["duikersifonhevel"][["code", "geometry"]]
 AVG["duikersifonhevel"].loc[:, "nen3610id"] = "dummy_nen3610id_duikersifonhevel_" + AVG[
     "duikersifonhevel"
 ].index.astype(str)
-AVG['duikersifonhevel']['globalid'] = 'dummy_globalid_duikersifonhevel_' + AVG['duikersifonhevel'].index.astype(str)
-AVG['duikersifonhevel'] = gpd.GeoDataFrame(AVG['duikersifonhevel']).to_crs('epsg:28992')
+AVG["duikersifonhevel"]["globalid"] = "dummy_globalid_duikersifonhevel_" + AVG["duikersifonhevel"].index.astype(str)
+AVG["duikersifonhevel"] = gpd.GeoDataFrame(AVG["duikersifonhevel"]).to_crs("epsg:28992")
 
 # hydroobject
 AVG["hydroobject"] = AVG["hydroobject"][["geometry"]]
@@ -167,11 +169,12 @@ AVG["peilgebied"]["code"] = AVG["peilgebied"]["GAFNAAM"]
 AVG["peilgebied"]["geometry"] = AVG["peilgebied"]["geometry"]
 AVG["peilgebied"]["nen3610id"] = "dummy_nen3610id_peilgebied_" + AVG["peilgebied"].index.astype(str)
 AVG["peilgebied"]["globalid"] = "dummy_globalid_peilgebied_" + AVG["peilgebied"].index.astype(str)
+AVG["peilgebied"]["waterhoogte"] = AVG["peilgebied"].streefpeil
 
-AVG['streefpeil'] = AVG['peilgebied'][['waterhoogte', 'globalid']]
-AVG['streefpeil']['code'] = 'dummy_code_streefpeil_' + AVG['streefpeil'].index.astype(str)
-AVG['streefpeil']['geometry'] = None
-AVG['streefpeil'] = gpd.GeoDataFrame(AVG['streefpeil'], geometry = 'geometry')
+AVG["streefpeil"] = AVG["peilgebied"][["waterhoogte", "globalid"]]
+AVG["streefpeil"]["code"] = "dummy_code_streefpeil_" + AVG["streefpeil"].index.astype(str)
+AVG["streefpeil"]["geometry"] = None
+AVG["streefpeil"] = gpd.GeoDataFrame(AVG["streefpeil"], geometry="geometry")
 
 AVG["peilgebied"] = AVG["peilgebied"][["code", "nen3610id", "globalid", "geometry"]]
 AVG["peilgebied"] = gpd.GeoDataFrame(AVG["peilgebied"]).to_crs("epsg:28992")

--- a/src/peilbeheerst_model/peilbeheerst_model/shortest_path.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/shortest_path.py
@@ -14,7 +14,7 @@ from shapely.geometry import LineString, MultiLineString, Point
 from shapely.ops import split
 from shapely.wkt import dumps
 
-from peilbeheerst_model import waterschap_data
+from .waterschappen import waterschap_data
 
 # ### Define functions
 # 1. splitting functions

--- a/src/ribasim_nl/ribasim_nl/__init__.py
+++ b/src/ribasim_nl/ribasim_nl/__init__.py
@@ -1,9 +1,15 @@
 __version__ = "0.1.0"
 
-from ribasim_nl.cloud import CloudStorage
-from ribasim_nl.model import Model
-from ribasim_nl.network import Network
-from ribasim_nl.network_validator import NetworkValidator
-from ribasim_nl.reset_index import reset_index
+from .cloud import CloudStorage
+from .model import Model
+from .network import Network
+from .network_validator import NetworkValidator
+from .reset_index import reset_index
 
-__all__ = ["CloudStorage", "Network", "reset_index", "Model", "NetworkValidator"]
+__all__ = [
+    "CloudStorage",
+    "Model",
+    "Network",
+    "NetworkValidator",
+    "reset_index",
+]


### PR DESCRIPTION
The shortest path script is modified for AGV to be able to run from the cloud.
I modified `crossings_to_ribasim.py` a bit so I could run it outside the HKV network. I removed HKV-specific code regarding the P and Z drives for writing results, and only retained the cloud saving. I also removed the symbology writing, I'm not sure what it was like, but if that is really needed it could be brought back if that data is shared. Ribasim Python now writes the default symbology in the GeoPackage. These changes will probably affect @rbruijnshkv though, so good to have a look at that.

I also addressed some warnings and fixed the fact that the Node table was written without a CRS. There are more warnings though. It's best to not filter them out, because mistakes are easily made if they are not addressed.

This does generate a valid AGV model / network (not yet parametrized, only with default values), that does run. I didn't yet compare the outcome to the uploaded models. It is here if you want to look: [_repro.zip](https://github.com/user-attachments/files/17478837/_repro.zip).