### PR TITLE
Remove `subnetwork_id` from the Edge table

### DIFF
--- a/src/peilbeheerst_model/peilbeheerst_model/crossings_to_ribasim.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/crossings_to_ribasim.py
@@ -891,7 +891,6 @@ class RibasimNetwork:
         # fill in the other columns
         edge["edge_type"] = "flow"
         edge["name"] = None
-        edge["subnetwork_id"] = None
         edge["geometry"] = self.edges["line_geom"]
 
         # comply to Ribasim 2024.11

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -370,7 +370,6 @@ def FlowBoundaries_to_LevelBoundaries(ribasim_model, default_level=0):
             "to_node_id",
             "edge_type",
             "name",
-            "subnetwork_id",
             "geometry",
             "meta_from_node_type",
             "meta_to_node_type",


### PR DESCRIPTION
As of https://github.com/Deltares/Ribasim/pull/1956 these are automatically inferred.