### PR TITLE
Add pixi auto update action

### DIFF
--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -1,0 +1,35 @@
+name: Update Pixi lockfile
+permissions:
+  contents: write
+  pull-requests: write
+on:
+  schedule:
+    # At 03:00 on day 3 of the month
+    - cron: "0 3 3 * *"
+  # on demand
+  workflow_dispatch:
+jobs:
+  pixi-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.3
+        with:
+          pixi-version: "latest"
+          run-install: false
+      - name: Update lockfiles
+        run: |
+          set -o pipefail
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.CI_PR_PAT }}
+          commit-message: Update pixi lockfile
+          title: Update pixi lockfile
+          body-path: diff.md
+          branch: update/pixi-lock
+          base: main
+          delete-branch: true
+          add-paths: pixi.lock

--- a/.github/workflows/pre-commit_auto_update.yml
+++ b/.github/workflows/pre-commit_auto_update.yml
@@ -2,8 +2,8 @@ name: Pre-commit
 
 on:
   schedule:
-  # At 03:00 on day 1 of the month
-    - cron: "0 3 1 * *"
+  # At 03:00 on day 3 of the month
+    - cron: "0 3 3 * *"
   # on demand
   workflow_dispatch:
 


### PR DESCRIPTION
This is the same as what we use in the Ribasim repo. It updates the our pixi lock file once a month to make sure we are using recent packages.

I'm also changing the pre-commit update on the same time, such that there is less chance of a difference in pre-commit results on CI and locally.

@evetion can you make a CI_PR_PAT for this repo as well? Or would it make sense to have such a PAT org-wide?
