### PR TITLE
fixed on AAM

### DIFF
--- a/notebooks/aa_en_maas/03_parameterize_model.py
+++ b/notebooks/aa_en_maas/03_parameterize_model.py
@@ -47,5 +47,5 @@ if run_model:
 
     # # %%
     controle_output = Control(ribasim_toml=ribasim_toml)
-    indicators = controle_output.run_all()
+    indicators = controle_output.run_aanvoer()
 # %%

--- a/src/peilbeheerst_model/peilbeheerst_model/controle_output.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/controle_output.py
@@ -323,3 +323,15 @@ class Control:
         self.store_data(data=control_dict, output_path=self.path_control_dict_path)
 
         return control_dict
+
+    def run_aanvoer(self):
+        control_dict = self.read_model_output()
+        control_dict = self.initial_final_level(control_dict)
+        control_dict = self.min_max_level(control_dict)
+        control_dict = self.error(control_dict)
+        control_dict = self.stationary(control_dict)
+        control_dict = self.find_stationary_flow(control_dict)
+
+        self.store_data(data=control_dict, output_path=self.path_control_dict_path)
+
+        return control_dict


### PR DESCRIPTION
Idealiter blijven dingen backward compatible. Wij kunnen nu `controle_output.run_all()` niet draaien omdat we wat nieuwe boolean kolommen missen in tabellen. Ik heb dat nu opgelost door `controle_output.run_aanvoer()` toe te voegen. Ik ga ervan uit dat er zo niets omvalt aan HKV-zijde