### PR TITLE
Column meta_couple_authority

### DIFF
--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -255,29 +255,23 @@ assign = AssignAuthorities(
     waterschap=waterschap,
     ws_grenzen_path=ws_grenzen_path,
     RWS_grenzen_path=RWS_grenzen_path,
-    ws_buffer=1025,
-    RWS_buffer=1000,
+    RWS_buffer=1000,  # optional
 )
 ribasim_model = assign.assign_authorities()
 
-# 98% of the automatically assigned neighbouring water authorities are correct, fix the remaining 2%
-from_authority = {908: "HollandsNoorderkwartier", 2912: "Rijkswaterstaat"}
-for k, v in from_authority.items():
-    ribasim_model.level_boundary.static.df.loc[
-        ribasim_model.level_boundary.static.df["node_id"] == k, "meta_from_authority"
-    ] = v
-
-to_authority = {
+couple_authority = {
     907: "HollandsNoorderkwartier",
-    972: "HollandsNoorderkwartier",
-    996: "Rijnland",
     909: "Rijkswaterstaat",
     931: "Rijkswaterstaat",
+    994: "Rijnland",
+    2932: "Rijkswaterstaat",
 }
-for k, v in to_authority.items():
+
+# 98% of the automatically assigned neighbouring water authorities are correct, fix the remaining 2%
+for node_id, authority in couple_authority.items():
     ribasim_model.level_boundary.static.df.loc[
-        ribasim_model.level_boundary.static.df["node_id"] == k, "meta_to_authority"
-    ] = v
+        ribasim_model.level_boundary.static.df["node_id"] == node_id, "meta_couple_authority"
+    ] = authority
 
 # write model output
 ribasim_model.use_validation = True

--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -183,7 +183,7 @@ ribasim_model.link.add(level_boundary_node, tabulated_rating_curve_node)
 ribasim_model.link.add(tabulated_rating_curve_node, ribasim_model.basin[9])
 
 level_boundary_node = ribasim_model.level_boundary.add(
-    Node(geometry=Point(123113, 486351)), [level_boundary.Static(level=[default_level])]
+    Node(geometry=Point(123115, 489284)), [level_boundary.Static(level=[default_level])]
 )
 pump_node = ribasim_model.pump.add(Node(geometry=Point(123112, 489351)), [pump.Static(flow_rate=[20])])
 # TODO: Verify setting to 'aan- & afvoergemaal'
@@ -311,28 +311,27 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formating of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+
+# add the water authority column to couple the model with
 assign = AssignAuthorities(
     ribasim_model=ribasim_model,
     waterschap=waterschap,
     ws_grenzen_path=ws_grenzen_path,
     RWS_grenzen_path=RWS_grenzen_path,
-    RWS_buffer=1000,  # optional
+    custom_nodes={
+        907: "HollandsNoorderkwartier",
+        1050: "HollandsNoorderkwartier",
+        908: "HollandsNoorderkwartier",
+        905: "Rijkswaterstaat",
+        909: "Rijkswaterstaat",
+        931: "Rijkswaterstaat",
+        966: "Rijkswaterstaat",
+        2956: "Rijkswaterstaat",
+        994: "Rijnland",
+    },
 )
 ribasim_model = assign.assign_authorities()
-
-couple_authority = {
-    907: "HollandsNoorderkwartier",
-    909: "Rijkswaterstaat",
-    931: "Rijkswaterstaat",
-    994: "Rijnland",
-    2932: "Rijkswaterstaat",
-}
-
-# 98% of the automatically assigned neighbouring water authorities are correct, fix the remaining 2%
-for node_id, authority in couple_authority.items():
-    ribasim_model.level_boundary.static.df.loc[
-        ribasim_model.level_boundary.static.df["node_id"] == node_id, "meta_couple_authority"
-    ] = authority
 
 # write model output
 ribasim_model.use_validation = True

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -10,6 +10,7 @@ from shapely import Point
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model
@@ -231,6 +232,16 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formating of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    custom_nodes=None,
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 # write model output

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -10,6 +10,7 @@ from shapely import Point
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model
@@ -229,6 +230,21 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formatting of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    RWS_buffer=3000,  # due to harbour
+    custom_nodes={
+        4565: "AmstelGooienVecht",
+        1394: "AmstelGooienVecht",
+        3657: "AmstelGooienVecht",
+    },
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 # write model output

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -11,6 +11,7 @@ from shapely import Point
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model
@@ -388,6 +389,20 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formating of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    RWS_buffer=10000,  # is only neighbouring RWS, so increase buffer
+    custom_nodes={
+        9141: None,  # dunes
+        2687: None,  # dunes
+    },
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 ribasim_model.use_validation = True

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -11,6 +11,7 @@ from shapely import Point
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model import supply
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model
@@ -197,6 +198,18 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
 
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    custom_nodes={
+        1367: "Delfland",
+    },
+)
+
+ribasim_model = assign.assign_authorities()
 # set numerical settings
 # write model output
 ribasim_model.use_validation = True

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -11,6 +11,7 @@ from shapely import LineString, Point
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model, geometry
@@ -379,6 +380,21 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formatting of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    custom_nodes={
+        973: "Rijkswaterstaat",
+        940: "Rijkswaterstaat",
+        939: "Rijkswaterstaat",
+        1004: "Rijkswaterstaat",
+    },
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 # write model output

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -12,6 +12,7 @@ from shapely import Point
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage
@@ -112,6 +113,7 @@ ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] =
     unknown_streefpeil
 )
 
+inlaat_structures = []
 # add an TRC and links to the newly created level boundary
 level_boundary_node = ribasim_model.level_boundary.add(
     Node(geometry=Point(74861, 382484)), [level_boundary.Static(level=[default_level])]
@@ -126,6 +128,24 @@ ribasim_model.tabulated_rating_curve.node.df.loc[tabulated_rating_curve_node.nod
 )
 ribasim_model.link.add(level_boundary_node, tabulated_rating_curve_node)
 ribasim_model.link.add(tabulated_rating_curve_node, ribasim_model.basin[133])
+
+
+# add a TRC and LB from Belgium
+level_boundary_node = ribasim_model.level_boundary.add(
+    Node(geometry=Point(43290, 356428)), [level_boundary.Static(level=[default_level])]
+)
+tabulated_rating_curve_node = ribasim_model.tabulated_rating_curve.add(
+    Node(geometry=Point(43486, 357740)),
+    [tabulated_rating_curve.Static(level=[0.0, 0.1234], flow_rate=[0.0, 0.1234])],
+)
+ribasim_model.link.add(level_boundary_node, tabulated_rating_curve_node)
+ribasim_model.link.add(tabulated_rating_curve_node, ribasim_model.basin[1])
+inlaat_structures.append(tabulated_rating_curve_node.node_id)  # convert the node to aanvoer later on
+
+# (re) set 'meta_node_id'
+ribasim_model.level_boundary.node.df.meta_node_id = ribasim_model.level_boundary.node.df.index
+ribasim_model.tabulated_rating_curve.node.df.meta_node_id = ribasim_model.tabulated_rating_curve.node.df.index
+ribasim_model.pump.node.df.meta_node_id = ribasim_model.pump.node.df.index
 
 # insert standard profiles to each basin: these are [depth_profiles] meter deep, defined from the streefpeil
 ribasim_param.insert_standard_profile(
@@ -182,6 +202,11 @@ ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOE
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(ribasim_model, str(aanvoer_path), processor, aanvoer_enabled=AANVOER_CONDITIONS)
+
+for node in inlaat_structures:
+    ribasim_model.outlet.static.df.loc[ribasim_model.outlet.static.df["node_id"] == node, "meta_func_aanvoer"] = 1
+    ribasim_model.outlet.static.df.loc[ribasim_model.outlet.static.df["node_id"] == node, "meta_func_afvoer"] = 0
+
 # ribasim_param.add_discrete_control(ribasim_model, waterschap, default_level)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 
@@ -196,6 +221,17 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formatting of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    RWS_buffer=2000,  # mainly neighbouring RWS, so increase buffer. Not too much, due to nodes within Belgium.
+    custom_nodes=None,
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 # write model output

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard.py
@@ -11,6 +11,7 @@ from shapely import Point
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model import supply
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model
@@ -340,6 +341,17 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formatting of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    RWS_buffer=400,  # polygons match relatively good, lower buffer
+    custom_nodes=None,
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 # write model output

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -10,6 +10,7 @@ from shapely import Point
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 from peilbeheerst_model.add_storage_basins import AddStorageBasins
+from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.controle_output import Control
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
 from ribasim_nl import CloudStorage, Model
@@ -566,6 +567,26 @@ ribasim_model.manning_resistance.static.df.manning_n = 0.01
 # last formatting of the tables
 # only retain node_id's which are present in the .node table
 ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# add the water authority column to couple the model with
+assign = AssignAuthorities(
+    ribasim_model=ribasim_model,
+    waterschap=waterschap,
+    ws_grenzen_path=ws_grenzen_path,
+    RWS_grenzen_path=RWS_grenzen_path,
+    custom_nodes={
+        821: "WetterskipFryslan",
+        823: "WetterskipFryslan",
+        2889: "WetterskipFryslan",
+        820: "Rijkswaterstaat",
+        834: "Rijkswaterstaat",
+        857: "Rijkswaterstaat",
+        873: "Rijkswaterstaat",
+        875: "Rijkswaterstaat",
+        879: "Rijkswaterstaat",
+    },
+)
+ribasim_model = assign.assign_authorities()
 
 # set numerical settings
 # write model output

--- a/src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
@@ -1,40 +1,54 @@
 import geopandas as gpd
-import numpy as np
 import pandas as pd
+from shapely.ops import nearest_points
 
 
 class AssignAuthorities:
-    def __init__(self, ribasim_model, waterschap, ws_grenzen_path, RWS_grenzen_path, ws_buffer=1025, RWS_buffer=1000):
+    """
+    Assigns LevelBoundary nodes in a RIBASIM model to the most relevant neighboring authority polygon.
+
+    Each node is assigned to a polygon based on spatial containment or, if none contain it, the nearest polygon.
+    When multiple polygons contain a node, preference is given to the polygon named 'Rijkswaterstaat'.
+
+    The Rijkswaterstaat polygon may be buffered using the `RWS_buffer` parameter to increase the likelihood
+    that nearby LevelBoundary nodes are assigned to it.
+    """
+
+    def __init__(self, ribasim_model, waterschap, ws_grenzen_path, RWS_grenzen_path, RWS_buffer=0):
         self.ws_grenzen_path = ws_grenzen_path
         self.RWS_grenzen_path = RWS_grenzen_path
-
-        self.ws_buffer = ws_buffer
-        self.RWS_buffer = RWS_buffer
 
         self.ribasim_model = ribasim_model
         self.waterschap = waterschap
 
+        self.RWS_buffer = RWS_buffer
+
     def assign_authorities(self):
-        authority_borders = self.retrieve_geodataframe()
+        """
+        Main function that assigns external authorities to LevelBoundary nodes in the model.
+
+        Returns
+        -------
+            Updated RIBASIM model with `meta_couple_authority` added to level_boundary.static.df.
+        """
+        authority_polygons = self.load_data()
         ribasim_model = self.embed_authorities_in_model(
-            ribasim_model=self.ribasim_model, waterschap=self.waterschap, authority_borders=authority_borders
+            ribasim_model=self.ribasim_model, waterschap=self.waterschap, authority_polygons=authority_polygons
         )
         return ribasim_model
 
-    def retrieve_geodataframe(self):
-        """Main function which calls the other functions."""
-        ws_grenzen, RWS_grenzen = self.load_data()
-        authority_borders = self.clip_and_buffer(ws_grenzen, RWS_grenzen)
-        authority_borders = self.extent_authority_borders(authority_borders)
-
-        return authority_borders
-
     def load_data(self):
-        """Loads and processes the authority areas of the waterschappen and RWS."""
+        """
+        Loads and preprocesses waterschap and Rijkswaterstaat boundaries.
+
+        Returns
+        -------
+            GeoDataFrame containing cleaned and buffered authority polygons (EPSG:28992).
+        """
         ws_grenzen = gpd.read_file(self.ws_grenzen_path)
         RWS_grenzen = gpd.read_file(self.RWS_grenzen_path)
 
-        # Removing "\n", "waterschap", "Hoogheemraadschap", "van" and spaces and commas
+        # Removing "\n", "waterschap", "Hoogheemraadschap", "van" and spaces and commas to align names from file with GoodCloud names
         ws_grenzen["naam"] = ws_grenzen["naam"].str.replace(r"\n", "", regex=True)
         ws_grenzen["naam"] = ws_grenzen["naam"].str.replace("Waterschap", "", regex=False)
         ws_grenzen["naam"] = ws_grenzen["naam"].str.replace("Hoogheemraadschap", "", regex=False)
@@ -46,7 +60,6 @@ class AssignAuthorities:
         ws_grenzen["naam"] = ws_grenzen["naam"].str.replace(" ", "", regex=False)
 
         ws_grenzen = ws_grenzen.sort_values(by="naam").reset_index(drop=True)
-        self.ws_grenzen_OG = ws_grenzen.copy()
 
         # get rid of irrelvant polygons
         ws_grenzen = ws_grenzen.explode()
@@ -58,83 +71,85 @@ class AssignAuthorities:
         RWS_grenzen["geometry"] = RWS_grenzen.buffer(self.RWS_buffer)
         RWS_grenzen = RWS_grenzen.dissolve()[["geometry"]]
 
-        return ws_grenzen, RWS_grenzen
-
-    def clip_and_buffer(self, ws_grenzen, RWS_grenzen):
-        """Clips the waterboard boundaries by removing the RWS areas and applies a buffer to the remaining polygons."""
-        # Remove the RWS area in each WS
-        ws_grenzen_cut_out = gpd.overlay(ws_grenzen, RWS_grenzen, how="symmetric_difference", keep_geom_type=True)
-        ws_grenzen_cut_out.dropna(subset="area", inplace=True)
-
-        # add a name to the RWS area
-        RWS_grenzen["naam"] = "Rijkswaterstaat"
-
-        # add a buffer to each waterschap. Within this strip an authority will be found.
-        ws_grenzen_cut_out["geometry"] = ws_grenzen_cut_out.buffer(self.ws_buffer)
-
         # add the two layers together
-        authority_borders = pd.concat([ws_grenzen_cut_out, RWS_grenzen])
-        authority_borders = authority_borders.reset_index(drop=True)
-        authority_borders = gpd.GeoDataFrame(authority_borders, geometry="geometry").set_crs(crs="EPSG:28992")
+        authority_polygons = pd.concat([ws_grenzen, RWS_grenzen])
+        authority_polygons = authority_polygons.reset_index(drop=True)
+        authority_polygons = gpd.GeoDataFrame(authority_polygons, geometry="geometry").set_crs(crs="EPSG:28992")
 
-        return authority_borders
+        return authority_polygons
 
-    def extent_authority_borders(self, authority_borders):
-        """Extends the authority borders by combining them with the original waterboard boundaries and dissolving the geometries based on the name."""
-        # Add a bit more area by dissolving it with the original gdf
-        authority_borders = pd.concat([authority_borders, self.ws_grenzen_OG])
-        authority_borders = gpd.GeoDataFrame(authority_borders, geometry="geometry").set_crs(crs="EPSG:28992")
-        authority_borders = authority_borders.dissolve(by="naam", as_index=False)
-        authority_borders = authority_borders[["naam", "geometry"]]
+    def snap_points_to_nearest_polygon(self, LB_gdf, authority_polygons, waterschap):
+        """
+        Snaps each LevelBoundary point to the nearest relevant authority polygon.
 
-        return authority_borders
+        Preference is given to polygons that contain the point, and to 'Rijkswaterstaat'
+        in case of overlap. The current waterschap is excluded from snapping.
 
-    def embed_authorities_in_model(self, ribasim_model, waterschap, authority_borders):
+        Parameters
+        ----------
+            LB_gdf (GeoDataFrame): LevelBoundary node table with geometries.
+            authority_polygons (GeoDataFrame): All authority polygons.
+            waterschap (str): Name of the current water authority.
+
+        Returns
+        -------
+            GeoDataFrame with updated geometry and 'meta_couple_authority' column.
+        """
+        authority_polygons = authority_polygons.loc[
+            authority_polygons.naam != waterschap
+        ]  # do not snap the LevelBoundaries to its own waterschap; discard it from the polygons
+
+        def assign_polygon(row):
+            # Step 1: find all polygons that fall within the point
+            containing = authority_polygons[authority_polygons.contains(row.geometry)]
+
+            if not containing.empty:
+                if "Rijkswaterstaat" in containing["naam"].values:
+                    selected = containing[containing["naam"] == "Rijkswaterstaat"].iloc[
+                        0
+                    ]  # chose RWS if multiple polygons are there (assumption)
+                else:
+                    selected = containing.iloc[0]  # fallback to first if RWS not in list
+            else:
+                # Step 2: if point not in any polygon, fallback to nearest polygon
+                distances = authority_polygons.geometry.distance(row.geometry)
+                nearest_idx = distances.idxmin()
+                selected = authority_polygons.loc[nearest_idx]
+
+            snapped_point = nearest_points(row.geometry, selected.geometry)[1]
+            return snapped_point, selected["naam"]
+
+        snapped_results = LB_gdf.apply(assign_polygon, axis=1, result_type="expand")
+        LB_gdf["geometry"] = snapped_results[0]
+        LB_gdf["meta_couple_authority"] = snapped_results[1]
+
+        return LB_gdf
+
+    def embed_authorities_in_model(self, ribasim_model, waterschap, authority_polygons):
+        """
+        Embeds authority information into the RIBASIM model's level_boundary static table.
+
+        Parameters
+        ----------
+            ribasim_model: The RIBASIM model object.
+            waterschap (str): The current water authority to exclude from assignments.
+            authority_polygons (GeoDataFrame): The cleaned and combined authority polygons.
+
+        Returns
+        -------
+            Updated RIBASIM model with `meta_couple_authority` assigned.
+        """
         # create a temp copy of the level boundary df
         temp_LB_node = ribasim_model.level_boundary.node.df.copy().reset_index()
         temp_LB_node = temp_LB_node[["node_id", "node_type", "geometry"]]
         ribasim_model.level_boundary.static.df = ribasim_model.level_boundary.static.df[["node_id", "level"]]
 
-        # perform a spatial join
-        joined = gpd.sjoin(temp_LB_node, authority_borders, how="left", predicate="intersects")
-
-        # #find whether the LevelBoundary flows inward and outward the waterschap
-        FB_inward = ribasim_model.link.df.loc[ribasim_model.link.df.from_node_id.isin(joined.node_id.values)].copy()
-        FB_outward = ribasim_model.link.df.loc[ribasim_model.link.df.to_node_id.isin(joined.node_id.values)].copy()
-
-        # add the current waterschap name in the correct column
-        FB_inward["meta_to_authority"], FB_outward["meta_from_authority"] = waterschap, waterschap
-
-        temp_LB_node = temp_LB_node.merge(
-            right=FB_inward[["from_node_id", "meta_to_authority"]],
-            left_on="node_id",
-            right_on="from_node_id",
-            how="left",
-        )
-
-        temp_LB_node = temp_LB_node.merge(
-            right=FB_outward[["to_node_id", "meta_from_authority"]],
-            left_on="node_id",
-            right_on="to_node_id",
-            how="left",
-        )
-
-        # #replace the current waterschaps name in the joined layer to NaN, and drop those
-        joined["naam"] = joined["naam"].replace(to_replace=waterschap, value=np.nan)
-        joined = joined.dropna(subset="naam").reset_index(drop=True)
-
-        # now fill the meta_from_authority and meta_to_authority columns. As they already contain the correct position of the current waterschap, the remaining 'naam' will be placed correctly as well
-        temp_LB_node = temp_LB_node.merge(right=joined[["node_id", "naam"]], on="node_id", how="left")
-        temp_LB_node["meta_from_authority"] = temp_LB_node["meta_from_authority"].fillna(temp_LB_node["naam"])
-        temp_LB_node["meta_to_authority"] = temp_LB_node["meta_to_authority"].fillna(temp_LB_node["naam"])
-
-        # only select the relevant columns
-        temp_LB_node = temp_LB_node[["node_id", "node_type", "geometry", "meta_from_authority", "meta_to_authority"]]
-        temp_LB_node = temp_LB_node.drop_duplicates(subset="node_id").reset_index(drop=True)
+        # snap LevelBoundary points to nearest polygon
+        snapped_nodes = self.snap_points_to_nearest_polygon(temp_LB_node, authority_polygons, waterschap)
 
         # place the meta categories to the static table
         LB_static = ribasim_model.level_boundary.static.df.merge(
-            right=temp_LB_node[["node_id", "meta_from_authority", "meta_to_authority"]], on="node_id", how="left"
+            right=snapped_nodes[["node_id", "meta_couple_authority"]], on="node_id", how="left"
         ).reset_index(drop=True)
         LB_static.index.name = "fid"
         ribasim_model.level_boundary.static.df = LB_static


### PR DESCRIPTION
Added a column in the LevelBoundary.static named meta_couple_authority, which automatically searches for the correct water authority (waterschappen or Rijkswaterstaat) to be coupled with. Individual nodes can be overwritten by using the optional custom_nodes variable.