### PR TITLE
Simplify CI without dev environment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,29 +15,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout Ribasim-NL
-        uses: actions/checkout@v4
-        with:
-          path: Ribasim-NL
-
-      # Ribasim needs to be checked out next to this repo even for the prod environment
-      - name: Checkout Ribasim
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: Ribasim
-
+      - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          manifest-path: Ribasim-NL/pixi.toml
           pixi-version: "latest"
 
       - name: Check Quarto installation and all engines
-        working-directory: Ribasim-NL
         run: pixi run quarto-check
 
       - name: Render Quarto Project
-        working-directory: Ribasim-NL
         run: pixi run quarto-render
 
       - name: Publish Quarto Project
@@ -45,6 +31,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: Ribasim-NL/docs/_site
+          publish_dir: docs/_site
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -12,35 +12,23 @@ jobs:
   pixi-update:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Ribasim-NL
-        uses: actions/checkout@v4
-        with:
-          path: Ribasim-NL
-      # Ribasim needs to be checked out next to this repo even for the prod environment
-      - name: Checkout Ribasim
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: Ribasim
+      - uses: actions/checkout@v4
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          manifest-path: Ribasim-NL/pixi.toml
           pixi-version: "latest"
           run-install: false
       - name: Update lockfiles
         run: |
           set -o pipefail
           pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
-        working-directory: Ribasim-NL
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.CI_PR_PAT }}
           commit-message: Update pixi lockfile
           title: Update pixi lockfile
-          path: Ribasim-NL
-          body-path: Ribasim-NL/diff.md
+          body-path: diff.md
           branch: update/pixi-lock
           base: main
           delete-branch: true

--- a/.github/workflows/pre-commit_auto_update.yml
+++ b/.github/workflows/pre-commit_auto_update.yml
@@ -9,27 +9,15 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Ribasim-NL
-        uses: actions/checkout@v4
-        with:
-          path: Ribasim-NL
-      # Ribasim needs to be checked out next to this repo even for the prod environment
-      - name: Checkout Ribasim
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: Ribasim
+      - uses: actions/checkout@v4
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          manifest-path: Ribasim-NL/pixi.toml
           pixi-version: "latest"
       - name: Update pre-commit hooks
-        working-directory: Ribasim-NL
         run: |
           pixi run pre-commit-autoupdate
       - name: Run pre-commit on all files
-        working-directory: Ribasim-NL
         run: |
           pixi run pre-commit
         continue-on-error: true
@@ -40,5 +28,4 @@ jobs:
           title: Update pre-commit hooks
           commit-message: "Update pre-commit hooks"
           author: "GitHub <noreply@github.com>"
-          path: Ribasim-NL
           delete-branch: true

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -15,23 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - name: Checkout Ribasim-NL
-        uses: actions/checkout@v4
-        with:
-          path: Ribasim-NL
-
-      # Ribasim needs to be checked out next to this repo even for the prod environment
-      - name: Checkout Ribasim
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: Ribasim
-
+      - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          manifest-path: Ribasim-NL/pixi.toml
           pixi-version: "latest"
-
       - name: Run mypy on hydamo
-        working-directory: Ribasim-NL
         run: pixi run mypy-hydamo

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -21,25 +21,13 @@ jobs:
         arch:
           - x86
     steps:
-      - name: Checkout Ribasim-NL
-        uses: actions/checkout@v4
-        with:
-          path: Ribasim-NL
-
-      # Ribasim needs to be checked out next to this repo even for the prod environment
-      - name: Checkout Ribasim
-        uses: actions/checkout@v4
-        with:
-          repository: Deltares/Ribasim
-          path: Ribasim
+      - uses: actions/checkout@v4
 
       - uses: prefix-dev/setup-pixi@v0.8.8
         with:
-          manifest-path: Ribasim-NL/pixi.toml
           pixi-version: "latest"
 
       - name: Run tests
-        working-directory: Ribasim-NL
         run: pixi run test-hydamo
         env:
           RIBASIM_NL_CLOUD_PASS: ${{ secrets.RIBASIM_NL_CLOUD_PASS }}


### PR DESCRIPTION
Follow up to #304. We no longer need to checkout the Ribasim repository besides this on to be able to run CI.