### PR TITLE
Delfland couple-ready: Changing Brielse Meer from `Basin` to `LevelBoundary`

### DIFF
--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -164,6 +164,12 @@ ribasim_model.merge_basins(node_id=88, to_node_id=2)
 ribasim_model.merge_basins(node_id=32, to_node_id=50)
 ribasim_model.merge_basins(node_id=54, to_node_id=1)
 
+# remove Brielse Meer as `Basin` and add as `LevelBoundary`-`Pump`-combination
+ribasim_model.remove_node(98, True)
+ribasim_model.remove_node(565, True)
+ribasim_model.pump.static.df.loc[ribasim_model.pump.static.df["node_id"] == 460, "meta_func_aanvoer"] = 1
+ribasim_model.link.add(ribasim_model.pump[460], ribasim_model.basin[10])
+
 # (re)set 'meta_node_id'-values
 ribasim_model.level_boundary.node.df.meta_node_id = ribasim_model.level_boundary.node.df.index
 ribasim_model.tabulated_rating_curve.node.df.meta_node_id = ribasim_model.tabulated_rating_curve.node.df.index

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -168,6 +168,7 @@ ribasim_model.merge_basins(node_id=54, to_node_id=1)
 ribasim_model.remove_node(98, True)
 ribasim_model.remove_node(565, True)
 ribasim_model.pump.static.df.loc[ribasim_model.pump.static.df["node_id"] == 460, "meta_func_aanvoer"] = 1
+ribasim_model.pump.static.df.loc[ribasim_model.pump.static.df["node_id"] == 460, "meta_func_afvoer"] = 0
 ribasim_model.link.add(ribasim_model.pump[460], ribasim_model.basin[10])
 
 # (re)set 'meta_node_id'-values


### PR DESCRIPTION
Brielse Meer was modelled as `Basin` for Delfland, which caused coupling issues with Hollandse Delta. Therefore, the `Basin` Brielse Meer has been removed and substituted by a `LevelBoundary`. The connected `Pump` is set to _aanvoer_-only.