### PR TITLE
Update LHM budgets related scripts

### DIFF
--- a/scripts/add_lhm_budgets/get_data_LHM_run.py
+++ b/scripts/add_lhm_budgets/get_data_LHM_run.py
@@ -56,6 +56,6 @@ ds = ds.chunk(
     }
 )
 store = zarr.DirectoryStore("LHM_433_budgets.zip")
-print("writing to zar-file")
+print("writing to zarr-file")
 ds.to_zarr(store=store, mode="w")
 store.close()

--- a/scripts/add_lhm_budgets/get_data_LHM_run.py
+++ b/scripts/add_lhm_budgets/get_data_LHM_run.py
@@ -1,24 +1,61 @@
 from pathlib import Path
 
 import imod
+import pandas as pd
 import zarr
 
-path = Path(r"g:\LHM_modelruns\model_v3.5\35-jarige_run_3.5.1\NHI3.5.1_2004-2023\modflow\results")
+time_slice = slice(pd.Timestamp("2013-01-01"), pd.Timestamp("2022-12-31"))
 
-ar = imod.idf.open(path / "bdgriv/bdgriv_sys1_*_l*.IDF").sum(dim="layer").drop_vars(["dy", "dx"])
+path = Path(r"g:\projecten\2025\release_LHM433\modelruns\runs_LWKM\LWKM_run_resultaten_totaal")
+
+print("reading riv-budgets for sys 1")
+ar = (
+    imod.idf.open(path / "modflow" / "bdgriv/bdgriv_sys1_*_l*.IDF")
+    .sum(dim="layer")
+    .drop_vars(["dy", "dx"])
+    .sel(time=time_slice)
+)
 ar.name = "bdgriv_sys1"
 ds = ar.to_dataset()
 
 for isys in range(2, 7):
+    print(f"reading riv-budgets for sys{isys}")
     ds[f"bdgriv_sys{isys}"] = (
-        imod.idf.open(path / f"bdgriv/bdgriv_sys{isys}_*_l*.IDF").sum(dim="layer").drop_vars(["dy", "dx"])
+        imod.idf.open(path / "modflow" / f"bdgriv/bdgriv_sys{isys}_*_l*.IDF")
+        .sum(dim="layer")
+        .drop_vars(["dy", "dx"])
+        .sel(time=time_slice)
     )
 
 for isys in range(1, 4):
+    print(f"reading drn-budgets for sys {isys}")
     ds[f"bdgdrn_sys{isys}"] = (
-        imod.idf.open(path / f"bdgdrn/bdgdrn_sys{isys}_*_l*.IDF").sum(dim="layer").drop_vars(["dy", "dx"])
+        imod.idf.open(path / "modflow" / f"bdgdrn/bdgdrn_sys{isys}_*_l*.IDF")
+        .sum(dim="layer")
+        .drop_vars(["dy", "dx"])
+        .sel(time=time_slice)
     )
 
-store = zarr.DirectoryStore("LHM_budgets.zip")
-ds.to_zarr(store)
+print("reading MetaSWAP budgets")
+bdgsw = imod.idf.open(path / "metaswap" / "bdgPssw/bdgPssw_*_l*.IDF").sum(dim="layer").drop_vars(["dy", "dx"])
+bdgqr = imod.idf.open(path / "metaswap" / "bdgQrun/bdgQrun_*_l*.IDF").sum(dim="layer").drop_vars(["dy", "dx"])
+ds["bdgpssw"] = bdgsw.resample(time="1D").bfill().sel(time=time_slice)
+ds["bdgqrun"] = bdgqr.resample(time="1D").bfill().sel(time=time_slice)
+
+# rechunk for better cloud access
+# spatial: 50km x 50 km
+# temporal: one year
+distance = 50_000
+dxy = 250
+n = int(distance / dxy)
+ds = ds.chunk(
+    chunks={
+        "time": 365,
+        "y": n,
+        "x": n,
+    }
+)
+store = zarr.DirectoryStore("LHM_433_budgets.zip")
+print("writing to zar-file")
+ds.to_zarr(store=store, mode="w")
 store.close()

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -129,13 +129,18 @@ class AssignOfflineBudgets:
         # sys2: ditch dranage
         # sys3: OLF
 
+        # MetaSWAP budgets
+        # qrun: OLF via MetaSWAP
+        # pssw: irrigation from surface water
+        # TODO: evaluate if we need to add urban runoff
+
         # For the Ribasim schematization we distinguish:
         #   - Primary system for all basins
         #   - Secondary system in basins other than the main river system
 
         # For drainage an infiltration input based on LHM-output budgets, we distubute the LHM-systems in the following matter:
         #  - Primary system   -> RIV-sys 1 + 4 + 5
-        #  - Secondary system -> RIV-sys 2 + 3 + 6, DRN-sys 1 + 2 + 3
+        #  - Secondary system -> RIV-sys 2 + 3 + 6, DRN-sys 1 + 2 + 3, qrun + pssw
 
         # sum primairy systems
         primary_summed_budgets = budgets["bdgriv_sys1"]
@@ -148,6 +153,9 @@ class AssignOfflineBudgets:
         secondary_summed_budgets = secondary_summed_budgets.rename("secondair")
         for sys, package in zip([3, 6, 1, 2, 3], ["riv", "riv", "drn", "drn", "drn"]):
             secondary_summed_budgets += budgets[f"bdg{package}_sys{sys}"]
+        # add MetaSWAP budgets
+        for name in ["bdgqrun", "bdgpssw"]:
+            secondary_summed_budgets += budgets[name]
 
         # sum per system and node_id
         primary_budgets_per_node_id = (

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -1,4 +1,3 @@
-import zipfile
 from pathlib import Path
 
 import geopandas as gpd
@@ -16,12 +15,10 @@ from ribasim_nl import Model as ModelNL
 class AssignOfflineBudgets:
     def __init__(
         self,
-        lhm_budget_zip: Path | str = "Basisgegevens/LHM/4.3/results/LHM_budgets.zip.zip",
-        lhm_budget: Path | str = "Basisgegevens/LHM/4.3/results/LHM_budgets.zip",
+        lhm_budget_path: Path | str = "Basisgegevens/LHM/4.3/results/LHM_433_budgets.zip",
     ):
         self.cloud = CloudStorage()
-        self.lhm_budget_zip = self.cloud.joinpath(lhm_budget_zip)
-        self.lhm_budget = self.cloud.joinpath(lhm_budget)
+        self.lhm_budget_path = self.cloud.joinpath(lhm_budget_path)
 
     def compute_budgets(
         self,
@@ -101,9 +98,7 @@ class AssignOfflineBudgets:
             model = Model.read(model)
 
         # Open the LHM budget file
-        if zipfile.is_zipfile(self.lhm_budget):
-            raise TypeError(f"The .zarr file needs to be unzipped manually at '{self.lhm_budget.absolute()}'")
-        budgets = xr.open_zarr(str(self.lhm_budget))
+        budgets = xr.open_zarr(str(self.lhm_budget_path))
 
         return budgets, model
 


### PR DESCRIPTION
This PR updates:

The get_data_LHM_run.py script for:
1- Getting the latest LHM 4.3.3 release budgets from the LHM server. 
2- Adding the MetaSWAP budgets for runoff and surface water irrigation
3- Rechunking the data more spatially so lazy evaluation is more effective in case of water board scale models. 

The AssignOfflineBudgets-class for:
1- Dealing with the new zarr file
2- Dealing with the extra MetaSWAP budgets for secondary basins 
