### PR TITLE
Take `Basin / time` out of the database

### DIFF
--- a/docs/dev/index.qmd
+++ b/docs/dev/index.qmd
@@ -88,7 +88,7 @@ pixi add --pypi 'ribasim @ file://absolute/path/to/Ribasim/python/ribasim' --edi
 
 The Pixi CLI only accepts absolute paths, but relative paths in `pixi.toml` will also work.
 
-For Ribasim developer documentation see https://ribasim.org/dev/.
+For Ribasim developer documentation see [ribasim.org/dev](https://ribasim.org/dev/).
 
 ## Environment variables {#sec-environment-variables}
 

--- a/notebooks/samenvoegen_modellen.py
+++ b/notebooks/samenvoegen_modellen.py
@@ -330,9 +330,9 @@ if write_lhm:
         lhm_model, readme = process_model_spec(idx + 2, model_spec, lhm_model, readme, write_toml=write_toml)
     # Write lhm model only if it exists
     print("write lhm model")
-    ribasim_toml = cloud.joinpath("Rijkswaterstaat", "modellen", "lhm", "lhm.toml")
+    ribasim_toml = cloud.joinpath("Rijkswaterstaat/modellen/lhm/lhm.toml")
     if lhm_model is not None:
         lhm_model.write(ribasim_toml)
-    cloud.joinpath("Rijkswaterstaat", "modellen", "lhm", "readme.md").write_text(readme)
+    cloud.joinpath("Rijkswaterstaat/modellen/lhm/readme.md").write_text(readme)
     if upload_model:
         cloud.upload_model("Rijkswaterstaat", model="lhm")

--- a/src/ribasim_nl/ribasim_nl/model.py
+++ b/src/ribasim_nl/ribasim_nl/model.py
@@ -90,6 +90,7 @@ class Model(Model):
     def __init__(self, **data):
         super().__init__(**data)
         self._parameterize = Parameterize(model=self)
+        self._set_arrow_input()
 
     def parameterize(self, **kwargs):
         self._parameterize.run(**kwargs)
@@ -1135,3 +1136,10 @@ class Model(Model):
             raise ValueError(
                 f"Links found with reversed source-destination: {list(df[duplicated_links].reset_index()[['link_id', 'from_node_id', 'to_node_id']].to_dict(orient='index').values())}"
             )
+
+    def _set_arrow_input(self):
+        """Avoid bloating the database by writing these to Arrow if they exist"""
+        self.input_dir = Path("input")
+        self.basin.time.set_filepath(Path("basin-time.arrow"))
+        self.flow_boundary.time.set_filepath(Path("flow-boundary-time.arrow"))
+        self.level_boundary.time.set_filepath(Path("level-boundary-time.arrow"))


### PR DESCRIPTION
Currently all models put all tables in the database. This results in databases of several hundred MB. For large tables it is much more efficient to store them in a separate Apache Arrow file.

I noticed it took 5 minutes to initialize a model due to it reading a large `Basin / time` table from the database. I could improve this in https://github.com/Deltares/Ribasim/pull/2533 but with this PR I propose to always force this table outside of the database, by hacking it into `ribasim_nl.Model.__init__`. To avoid cluttering the top level with too many files next to the TOML, I also set `input_dir = "input"` so the database and Arrow input files are stored there.

One downside of this is that because https://github.com/Deltares/Ribasim/issues/318 is still open, this means we cannot directly see `Basin / time` in QGIS, but we can drag and drop Arrow files into QGIS to inspect them, if they are not too large.
