### PR TITLE
Fix issues in transboundary_inflow

### DIFF
--- a/src/ribasim_nl/ribasim_nl/model.py
+++ b/src/ribasim_nl/ribasim_nl/model.py
@@ -1140,7 +1140,8 @@ class Model(Model):
     def _set_arrow_input(self):
         """Use "input" dir and avoid large databases by writing some tables to Arrow"""
         self.input_dir = Path("input")
-        self.basin.time.set_filepath(Path("basin_time.arrow"))
-        # Need to set parent fields to get it in the TOML: https://github.com/Deltares/Ribasim/issues/2039
-        self.basin.model_fields_set.add("time")
-        self.model_fields_set.add("basin")
+        if self.basin.time.df is not None:
+            self.basin.time.set_filepath(Path("basin_time.arrow"))
+            # Need to set parent fields to get it in the TOML: https://github.com/Deltares/Ribasim/issues/2039
+            self.basin.model_fields_set.add("time")
+            self.model_fields_set.add("basin")


### PR DESCRIPTION
One change in `ribasim_nl.Model`: don't set `basin_time.arrow` if the table doesn't exist, because this will be written to TOML and then the core will complain the file doesn't exist. (made a note at the end of https://github.com/Deltares/Ribasim/issues/2039#issuecomment-3204851989)

- Address a TODO on removing static flow_rates when we have dynamic ones
- Stop removing existing dynamic flow rates (Monsin and Lobith were removed before)
- Make the script robust to missing static or time tables

I also moved some code around to make it clear what the input paths are.