### PR TITLE
Add Junctions automatically on shared geometry

### DIFF
--- a/notebooks/generate_junctions.py
+++ b/notebooks/generate_junctions.py
@@ -198,5 +198,5 @@ if __name__ == "__main__":
     toml_path_output = cloud.joinpath("Rijkswaterstaat/modellen/lhm_coupled_junction/lhm.toml")
 
     model = Model.read(toml_path_input)
-    model = junctionfy(model)
+    model = junctionify(model)
     model.write(toml_path_output)


### PR DESCRIPTION
Fixes #399 

This finds overlapping line segments, starting from a to_node_id and merges them, introducing a Junction. It can add multiple Junctions in a row.

Still in draft because I see some errors on LHM, but it works on HWS:

from:
<img width="911" height="367" alt="Screenshot 2025-09-30 at 11 37 53" src="https://github.com/user-attachments/assets/327ab926-b6ab-4deb-b647-77810b59eb59" />

to:
<img width="944" height="422" alt="Screenshot 2025-09-30 at 11 38 11" src="https://github.com/user-attachments/assets/c11eda93-0a5a-4920-b847-1ca61efdfba3" />


