### PR TITLE
Update DVC files to reflect ignoring results directory

### DIFF
--- a/data/AaenMaas/modellen/AaenMaas_2025_9_0.dvc
+++ b/data/AaenMaas/modellen/AaenMaas_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 24938dd51dc4e950fb08b8d1ec69de2a
+md5: e6f412454ec3092f3494b3781cff9a19
 frozen: true
 deps:
 - md5: a4f0769ae54d57e510ce098fa1c45444.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/AaenMaas/modellen/AaenMaas_2025_9_0
 outs:
-- md5: f95762ba1c46bca62755daa02f44d94b.dir
-  size: 93678776
-  nfiles: 8
+- md5: 9f4a13cbc90b8c64d66212a183aedee7.dir
+  size: 55648170
+  nfiles: 3
   hash: md5
   path: AaenMaas_2025_9_0

--- a/data/AmstelGooienVecht/modellen/AmstelGooienVecht_parameterized_2025_9_0.dvc
+++ b/data/AmstelGooienVecht/modellen/AmstelGooienVecht_parameterized_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: e995cbe029d59c8f0b12ac59d1e93512
+md5: 470013fd27a9c01c5579103e28fb3d75
 frozen: true
 deps:
 - md5: 997fe8f0f439ae08d06b545e6970656e.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/AmstelGooienVecht/modellen/AmstelGooienVecht_parameterized_2025_9_0
 outs:
-- md5: bd24473f58cfdc69d568f324b918e56c.dir
-  size: 49798056
-  nfiles: 15
+- md5: 99d614dbc936010e2b53d72927ceac7b.dir
+  size: 23998323
+  nfiles: 3
   hash: md5
   path: AmstelGooienVecht_parameterized_2025_9_0

--- a/data/BrabantseDelta/modellen/BrabantseDelta_2025_9_0.dvc
+++ b/data/BrabantseDelta/modellen/BrabantseDelta_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 153735fd3026f231e84066bf71a2f3c6
+md5: 59d958e2ee18994819341ad7b639f8ae
 frozen: true
 deps:
 - md5: 8b78bde6f5e0d02cc4555341f98c9e84.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/BrabantseDelta/modellen/BrabantseDelta_2025_9_0
 outs:
-- md5: 51f7f48612ebb8d42eb70d1419187a11.dir
-  size: 115607977
-  nfiles: 8
+- md5: e5517187ba82f07084bfdc9a28052979.dir
+  size: 74410370
+  nfiles: 3
   hash: md5
   path: BrabantseDelta_2025_9_0

--- a/data/DeDommel/modellen/DeDommel_2025_9_0.dvc
+++ b/data/DeDommel/modellen/DeDommel_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 3d0c7e37041e2015df9418bbe378c8ca
+md5: 180d78bfc11db0a179298dfe651dc888
 frozen: true
 deps:
 - md5: 9794e6e45c763025ad01399689fa5d45.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/DeDommel/modellen/DeDommel_2025_9_0
 outs:
-- md5: 96bfe073b75b985d42aa8d01a8c46404.dir
-  size: 123304292
-  nfiles: 8
+- md5: 7a954dd29d7b9c8710a698811339232f.dir
+  size: 80384450
+  nfiles: 3
   hash: md5
   path: DeDommel_2025_9_0

--- a/data/Delfland/modellen/Delfland_parameterized_2025_9_1.dvc
+++ b/data/Delfland/modellen/Delfland_parameterized_2025_9_1.dvc
@@ -1,4 +1,4 @@
-md5: d15166d1e32d363c5ff58a4f2765867a
+md5: 5580f44a53ff61d13e9ad558c6297d39
 frozen: true
 deps:
 - md5: e0448160a534ec6f5e26c88a005a00ae.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/Delfland/modellen/Delfland_parameterized_2025_9_1
 outs:
-- md5: 62687d86223334eed590f9f7e8a693b0.dir
-  size: 26010388
-  nfiles: 16
+- md5: ed393eda7ddf0b0785bc3bd3936904dc.dir
+  size: 14147811
+  nfiles: 4
   hash: md5
   path: Delfland_parameterized_2025_9_1

--- a/data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_2025_9_0.dvc
+++ b/data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 8d98e237d2324fb53220959c2c0d4e4b
+md5: 12cb18ca8022d9c98b1bd24cf1562efd
 frozen: true
 deps:
 - md5: 7af98da8b3c1892766d302bfe62842c0.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_2025_9_0
 outs:
-- md5: e3bf4485365de487476c45c1acc212ff.dir
-  size: 89711489
-  nfiles: 11
+- md5: cdceb31a29edea006fb7369d7e5cb41a.dir
+  size: 49107122
+  nfiles: 4
   hash: md5
   path: DrentsOverijsselseDelta_2025_9_0

--- a/data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_parameterized_2025_9_11.dvc
+++ b/data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_parameterized_2025_9_11.dvc
@@ -1,4 +1,4 @@
-md5: 9ac3ad2c8dd81498d095396bb3be5404
+md5: ef6a92c254ec0de105a3496920c13cbc
 frozen: true
 deps:
 - md5: c8e2dddc319daf4e6db45d9b172e6710.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_parameterized_2025_9_11
 outs:
-- md5: 91527d0144a3c5abc85323be4d57e3ab.dir
-  size: 47988006
-  nfiles: 15
+- md5: f2152ae3a799955dd02d5819cb21ae78.dir
+  size: 22903099
+  nfiles: 3
   hash: md5
   path: HollandsNoorderkwartier_parameterized_2025_9_11

--- a/data/HollandseDelta/modellen/HollandseDelta_parameterized_2025_9_0.dvc
+++ b/data/HollandseDelta/modellen/HollandseDelta_parameterized_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: e52973f29b0423b2da2b5c1d24137716
+md5: cbc99cf68c6b2a39d747d1c7755950d5
 frozen: true
 deps:
 - md5: 17fe329d33daacf0bb14a90ce008b29a.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/HollandseDelta/modellen/HollandseDelta_parameterized_2025_9_0
 outs:
-- md5: c56a9269ee4eec763887a8614190bfa3.dir
-  size: 77766084
-  nfiles: 15
+- md5: cb1c75474f12a7f19c2d98ef5c65d07f.dir
+  size: 36260779
+  nfiles: 3
   hash: md5
   path: HollandseDelta_parameterized_2025_9_0

--- a/data/HunzeenAas/modellen/HunzeenAas_2025_10_1.dvc
+++ b/data/HunzeenAas/modellen/HunzeenAas_2025_10_1.dvc
@@ -1,4 +1,4 @@
-md5: 214944a61c4931d5948a6954aa9456d7
+md5: e6a80bee848aa578e9d5531c473bb46a
 frozen: true
 deps:
 - md5: c2ace4e741ac05592b7fdf6fe7ee0500.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/HunzeenAas/modellen/HunzeenAas_2025_10_1
 outs:
-- md5: 46d0b0ed010775587c0fa8ad8f911304.dir
-  size: 379389205
-  nfiles: 14
+- md5: c792a0bdb1770ab77b101386a13b03bb.dir
+  size: 345066482
+  nfiles: 4
   hash: md5
   path: HunzeenAas_2025_10_1

--- a/data/Limburg/modellen/Limburg_2025_9_0.dvc
+++ b/data/Limburg/modellen/Limburg_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 8e605264c8576cbd6e4a3c3b5fc37cdf
+md5: 8c2183d221fbf5d0ee824a50683c62e8
 frozen: true
 deps:
 - md5: c46a3ec5f1dddfd26af5576edb198c3b.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/Limburg/modellen/Limburg_2025_9_0
 outs:
-- md5: 0a810b75c357ff1c794d8b39bdf38687.dir
-  size: 128561953
-  nfiles: 8
+- md5: ca20b0f28d97cf3eed1481f539c77071.dir
+  size: 83284450
+  nfiles: 3
   hash: md5
   path: Limburg_2025_9_0

--- a/data/Noorderzijlvest/modellen/Noorderzijlvest_2025_10_3.dvc
+++ b/data/Noorderzijlvest/modellen/Noorderzijlvest_2025_10_3.dvc
@@ -1,4 +1,4 @@
-md5: 35dc52f1f86167a4f9b3c83e304131c1
+md5: 05be54e007c6719fc12c1b872ce80120
 frozen: true
 deps:
 - md5: a12e224ddb9fc5cb2de6ad1eca80975e.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/Noorderzijlvest/modellen/Noorderzijlvest_2025_10_3
 outs:
-- md5: ddf4dc0155be37bfeabf420b6da19a07.dir
-  size: 92226807
-  nfiles: 13
+- md5: aa6933fc18068251f7bac6c9784a9c32.dir
+  size: 52448554
+  nfiles: 3
   hash: md5
   path: Noorderzijlvest_2025_10_3

--- a/data/Rijkswaterstaat/modellen/hws_2025_10_0.dvc
+++ b/data/Rijkswaterstaat/modellen/hws_2025_10_0.dvc
@@ -1,4 +1,4 @@
-md5: a168422f4f600462dd5db6462adef89a
+md5: f4c7a78259f986fe5ffb03daaa15a621
 frozen: true
 deps:
 - md5: 76165c5bff0cf20fa468e8766ba163ff.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/Rijkswaterstaat/modellen/hws_2025_10_0
 outs:
-- md5: 700914d929b4633fbf6c1bba4a8c8f55.dir
-  size: 47001133
-  nfiles: 12
+- md5: d3429cc229353a009a2feb17f27576c7.dir
+  size: 42700954
+  nfiles: 2
   hash: md5
   path: hws_2025_10_0

--- a/data/RijnenIJssel/modellen/RijnenIJssel_2025_9_0.dvc
+++ b/data/RijnenIJssel/modellen/RijnenIJssel_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: f88f40a57f82580f71ada67ecfd1c550
+md5: e82bf5670a8ca3d925ccdd490a7515dc
 frozen: true
 deps:
 - md5: d96d7032e4145a9ad40075bda06997ba.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/RijnenIJssel/modellen/RijnenIJssel_2025_9_0
 outs:
-- md5: 2c6fca3f653b4a2b5fc84bd3eeb4510a.dir
-  size: 50865576
-  nfiles: 8
+- md5: 86a1b8442f54b646e87bc348efcc88b4.dir
+  size: 31222146
+  nfiles: 3
   hash: md5
   path: RijnenIJssel_2025_9_0

--- a/data/Rijnland/modellen/Rijnland_parameterized_2025_9_0.dvc
+++ b/data/Rijnland/modellen/Rijnland_parameterized_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 0e64d2161388f5a7222277f179a33bae
+md5: fa2d4c813a4f64ed9eb5afd85f20ff55
 frozen: true
 deps:
 - md5: 6cb4f8c99340d5b0b1f4e34ba1fafc8a.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/Rijnland/modellen/Rijnland_parameterized_2025_9_0
 outs:
-- md5: 929d5547a8a8c5156a0c2ec8bf13d49a.dir
-  size: 64097032
-  nfiles: 15
+- md5: bdabcfff48e54ea73e2bc7776edab98b.dir
+  size: 30769611
+  nfiles: 3
   hash: md5
   path: Rijnland_parameterized_2025_9_0

--- a/data/Rivierenland/modellen/Rivierenland_parameterized_2025_9_1.dvc
+++ b/data/Rivierenland/modellen/Rivierenland_parameterized_2025_9_1.dvc
@@ -1,4 +1,4 @@
-md5: fc5fc4ca841d1fcd9b2c0ad2264d35fe
+md5: 2c1c228dd349ca2a8dc096fbefa6dad8
 frozen: true
 deps:
 - md5: f49381e7bac8175735b660ad12d20be5.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/Rivierenland/modellen/Rivierenland_parameterized_2025_9_1
 outs:
-- md5: 4dcf1b59d5cfa80028be99fc7d4ca15a.dir
-  size: 51551022
-  nfiles: 16
+- md5: d5493fb785672ff0734b7d821aa13939.dir
+  size: 28609443
+  nfiles: 4
   hash: md5
   path: Rivierenland_parameterized_2025_9_1

--- a/data/Scheldestromen/modellen/Scheldestromen_parameterized_2025_9_0.dvc
+++ b/data/Scheldestromen/modellen/Scheldestromen_parameterized_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: cc8421a7a4581cfc032f3066cf51a375
+md5: 7a4c1fd0f8e61792ce5e049b1520f9c7
 frozen: true
 deps:
 - md5: 815a0fa32d583496ac2470426dced0d0.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/Scheldestromen/modellen/Scheldestromen_parameterized_2025_9_0
 outs:
-- md5: 008df9f7c617cab700d631df1fa98978.dir
-  size: 27087594
-  nfiles: 15
+- md5: 95d6967b95bedd7c958c141e5b1800c8.dir
+  size: 15192275
+  nfiles: 3
   hash: md5
   path: Scheldestromen_parameterized_2025_9_0

--- a/data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_parameterized_2025_9_0.dvc
+++ b/data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_parameterized_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: e18822c6c8a05fb76fe33e29d6e04ff8
+md5: 1c2d23aea4b6302c59a73e19fc154854
 frozen: true
 deps:
 - md5: 9c9b654122fa878bf14e2db3c668e03c.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_parameterized_2025_9_0
 outs:
-- md5: 700a12cac7bcb5f1cb6b68c8f646d879.dir
-  size: 24385557
-  nfiles: 15
+- md5: 3d59e8121decde30c171b9a92f633969.dir
+  size: 11452403
+  nfiles: 3
   hash: md5
   path: SchielandendeKrimpenerwaard_parameterized_2025_9_0

--- a/data/StichtseRijnlanden/modellen/StichtseRijnlanden_2025_9_0.dvc
+++ b/data/StichtseRijnlanden/modellen/StichtseRijnlanden_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: a39fb80fad70893724e4c1e67c3ba696
+md5: 7c0f2b7b0895d1df1f2928dc1b1a5bf0
 frozen: true
 deps:
 - md5: 7a7cbb702b33f3c17b723cf7437d1ce6.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/StichtseRijnlanden/modellen/StichtseRijnlanden_2025_9_0
 outs:
-- md5: 76c363afc3eba1ace093dcce982f3c1c.dir
-  size: 78677543
-  nfiles: 9
+- md5: ab8d9a35d8a6597d791a8c6d9e00cd33.dir
+  size: 52399866
+  nfiles: 3
   hash: md5
   path: StichtseRijnlanden_2025_9_0

--- a/data/ValleienVeluwe/modellen/ValleienVeluwe_2025_9_0.dvc
+++ b/data/ValleienVeluwe/modellen/ValleienVeluwe_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: a2a7589074aa9a11e5d8588338f8556a
+md5: d448601aa1ac3fbf2b325310dbc63c08
 frozen: true
 deps:
 - md5: 8af8b899010b0ca3f39caa338d88d39b.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/ValleienVeluwe/modellen/ValleienVeluwe_2025_9_0
 outs:
-- md5: e719c2b1e64acfefe00492ea4e7304aa.dir
-  size: 90497072
-  nfiles: 17
+- md5: 33e98b314470ad447e631c2ea7722be2.dir
+  size: 59207042
+  nfiles: 4
   hash: md5
   path: ValleienVeluwe_2025_9_0

--- a/data/Vechtstromen/modellen/Vechtstromen_2025_9_0.dvc
+++ b/data/Vechtstromen/modellen/Vechtstromen_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: 8bc09b5ddd5df9676e88dffa6ff713b6
+md5: 3910fc01544f02c453fc3cd23d8a9fa3
 frozen: true
 deps:
 - md5: 88316b14d10b623dbbc3bd4a5f3f32d7.dir
@@ -7,8 +7,8 @@ deps:
   hash: md5
   path: remote://modeldata/Vechtstromen/modellen/Vechtstromen_2025_9_0
 outs:
-- md5: da33f0417baa9ed37580e1273ed2940f.dir
-  size: 114249516
-  nfiles: 8
+- md5: cd9f96ea6857f669725edd17a0368fb1.dir
+  size: 77612002
+  nfiles: 3
   hash: md5
   path: Vechtstromen_2025_9_0

--- a/data/WetterskipFryslan/modellen/WetterskipFryslan_parameterized_2025_9_1.dvc
+++ b/data/WetterskipFryslan/modellen/WetterskipFryslan_parameterized_2025_9_1.dvc
@@ -1,4 +1,4 @@
-md5: 2d39c612c0fd9d48ba9fc406e6e5dd8c
+md5: 027ff7d7113ed1b98c51c0bead83c783
 frozen: true
 deps:
 - md5: 0ed311a4f3e639c3c7f5e1903488d0b3.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/WetterskipFryslan/modellen/WetterskipFryslan_parameterized_2025_9_1
 outs:
-- md5: b378c2db29dcbc784ebe4417aeb614a4.dir
-  size: 170981727
-  nfiles: 16
+- md5: bf47c88015d10cf9f0c4fc55ace6903f.dir
+  size: 93337538
+  nfiles: 4
   hash: md5
   path: WetterskipFryslan_parameterized_2025_9_1

--- a/data/Zuiderzeeland/modellen/Zuiderzeeland_parameterized_2025_9_0.dvc
+++ b/data/Zuiderzeeland/modellen/Zuiderzeeland_parameterized_2025_9_0.dvc
@@ -1,4 +1,4 @@
-md5: e17642c769da866ce52152f55740ccc7
+md5: 2cced8980d1a68e4f9637ef919c4f674
 frozen: true
 deps:
 - md5: e9d395e75b01d8df6fa53704eeef5372.dir
@@ -8,8 +8,8 @@ deps:
   path:
     remote://modeldata/Zuiderzeeland/modellen/Zuiderzeeland_parameterized_2025_9_0
 outs:
-- md5: 11117af02574228c502e06c4711f52db.dir
-  size: 33614025
-  nfiles: 15
+- md5: c6944916dee6388016fd8eb7b265168f.dir
+  size: 16092995
+  nfiles: 3
   hash: md5
   path: Zuiderzeeland_parameterized_2025_9_0

--- a/dvc.lock
+++ b/dvc.lock
@@ -5,121 +5,124 @@ stages:
     deps:
     - path: data/AaenMaas/modellen/AaenMaas_2025_9_0
       hash: md5
-      md5: f95762ba1c46bca62755daa02f44d94b.dir
-      size: 93678776
-      nfiles: 8
-    - path: data/AmstelGooienVecht/modellen/AmstelGooienVecht_parameterized_2025_9_0
+      md5: 9f4a13cbc90b8c64d66212a183aedee7.dir
+      size: 55648170
+      nfiles: 3
+    - path:
+        data/AmstelGooienVecht/modellen/AmstelGooienVecht_parameterized_2025_9_0
       hash: md5
-      md5: bd24473f58cfdc69d568f324b918e56c.dir
-      size: 49798056
-      nfiles: 15
+      md5: 99d614dbc936010e2b53d72927ceac7b.dir
+      size: 23998323
+      nfiles: 3
     - path: data/BrabantseDelta/modellen/BrabantseDelta_2025_9_0
       hash: md5
-      md5: 51f7f48612ebb8d42eb70d1419187a11.dir
-      size: 115607977
-      nfiles: 8
+      md5: e5517187ba82f07084bfdc9a28052979.dir
+      size: 74410370
+      nfiles: 3
     - path: data/DeDommel/modellen/DeDommel_2025_9_0
       hash: md5
-      md5: 96bfe073b75b985d42aa8d01a8c46404.dir
-      size: 123304292
-      nfiles: 8
+      md5: 7a954dd29d7b9c8710a698811339232f.dir
+      size: 80384450
+      nfiles: 3
     - path: data/Delfland/modellen/Delfland_parameterized_2025_9_1
       hash: md5
-      md5: 62687d86223334eed590f9f7e8a693b0.dir
-      size: 26010388
-      nfiles: 16
-    - path: data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_2025_9_0
+      md5: ed393eda7ddf0b0785bc3bd3936904dc.dir
+      size: 14147811
+      nfiles: 4
+    - path:
+        data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_2025_9_0
       hash: md5
-      md5: e3bf4485365de487476c45c1acc212ff.dir
-      size: 89711489
-      nfiles: 11
+      md5: cdceb31a29edea006fb7369d7e5cb41a.dir
+      size: 49107122
+      nfiles: 4
     - path:
         data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_parameterized_2025_9_11
       hash: md5
-      md5: 91527d0144a3c5abc85323be4d57e3ab.dir
-      size: 47988006
-      nfiles: 15
+      md5: f2152ae3a799955dd02d5819cb21ae78.dir
+      size: 22903099
+      nfiles: 3
     - path: data/HollandseDelta/modellen/HollandseDelta_parameterized_2025_9_0
       hash: md5
-      md5: c56a9269ee4eec763887a8614190bfa3.dir
-      size: 77766084
-      nfiles: 15
+      md5: cb1c75474f12a7f19c2d98ef5c65d07f.dir
+      size: 36260779
+      nfiles: 3
     - path: data/HunzeenAas/modellen/HunzeenAas_2025_10_1
       hash: md5
-      md5: 46d0b0ed010775587c0fa8ad8f911304.dir
-      size: 379389205
-      nfiles: 14
+      md5: c792a0bdb1770ab77b101386a13b03bb.dir
+      size: 345066482
+      nfiles: 4
     - path: data/Limburg/modellen/Limburg_2025_9_0
       hash: md5
-      md5: 0a810b75c357ff1c794d8b39bdf38687.dir
-      size: 128561953
-      nfiles: 8
+      md5: ca20b0f28d97cf3eed1481f539c77071.dir
+      size: 83284450
+      nfiles: 3
     - path: data/Noorderzijlvest/modellen/Noorderzijlvest_2025_10_3
       hash: md5
-      md5: ddf4dc0155be37bfeabf420b6da19a07.dir
-      size: 92226807
-      nfiles: 13
+      md5: aa6933fc18068251f7bac6c9784a9c32.dir
+      size: 52448554
+      nfiles: 3
     - path: data/Rijkswaterstaat/modellen/hws_2025_10_0
       hash: md5
-      md5: 700914d929b4633fbf6c1bba4a8c8f55.dir
-      size: 47001133
-      nfiles: 12
+      md5: d3429cc229353a009a2feb17f27576c7.dir
+      size: 42700954
+      nfiles: 2
     - path: data/RijnenIJssel/modellen/RijnenIJssel_2025_9_0
       hash: md5
-      md5: 2c6fca3f653b4a2b5fc84bd3eeb4510a.dir
-      size: 50865576
-      nfiles: 8
+      md5: 86a1b8442f54b646e87bc348efcc88b4.dir
+      size: 31222146
+      nfiles: 3
     - path: data/Rijnland/modellen/Rijnland_parameterized_2025_9_0
       hash: md5
-      md5: 929d5547a8a8c5156a0c2ec8bf13d49a.dir
-      size: 64097032
-      nfiles: 15
+      md5: bdabcfff48e54ea73e2bc7776edab98b.dir
+      size: 30769611
+      nfiles: 3
     - path: data/Rivierenland/modellen/Rivierenland_parameterized_2025_9_1
       hash: md5
-      md5: 4dcf1b59d5cfa80028be99fc7d4ca15a.dir
-      size: 51551022
-      nfiles: 16
+      md5: d5493fb785672ff0734b7d821aa13939.dir
+      size: 28609443
+      nfiles: 4
     - path: data/Scheldestromen/modellen/Scheldestromen_parameterized_2025_9_0
       hash: md5
-      md5: 008df9f7c617cab700d631df1fa98978.dir
-      size: 27087594
-      nfiles: 15
+      md5: 95d6967b95bedd7c958c141e5b1800c8.dir
+      size: 15192275
+      nfiles: 3
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_parameterized_2025_9_0
       hash: md5
-      md5: 700a12cac7bcb5f1cb6b68c8f646d879.dir
-      size: 24385557
-      nfiles: 15
+      md5: 3d59e8121decde30c171b9a92f633969.dir
+      size: 11452403
+      nfiles: 3
     - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_2025_9_0
       hash: md5
-      md5: 76c363afc3eba1ace093dcce982f3c1c.dir
-      size: 78677543
-      nfiles: 9
+      md5: ab8d9a35d8a6597d791a8c6d9e00cd33.dir
+      size: 52399866
+      nfiles: 3
     - path: data/ValleienVeluwe/modellen/ValleienVeluwe_2025_9_0
       hash: md5
-      md5: e719c2b1e64acfefe00492ea4e7304aa.dir
-      size: 90497072
-      nfiles: 17
+      md5: 33e98b314470ad447e631c2ea7722be2.dir
+      size: 59207042
+      nfiles: 4
     - path: data/Vechtstromen/modellen/Vechtstromen_2025_9_0
       hash: md5
-      md5: da33f0417baa9ed37580e1273ed2940f.dir
-      size: 114249516
-      nfiles: 8
-    - path: data/WetterskipFryslan/modellen/WetterskipFryslan_parameterized_2025_9_1
+      md5: cd9f96ea6857f669725edd17a0368fb1.dir
+      size: 77612002
+      nfiles: 3
+    - path:
+        data/WetterskipFryslan/modellen/WetterskipFryslan_parameterized_2025_9_1
       hash: md5
-      md5: b378c2db29dcbc784ebe4417aeb614a4.dir
-      size: 170981727
-      nfiles: 16
+      md5: bf47c88015d10cf9f0c4fc55ace6903f.dir
+      size: 93337538
+      nfiles: 4
     - path: data/Zuiderzeeland/modellen/Zuiderzeeland_parameterized_2025_9_0
       hash: md5
-      md5: 11117af02574228c502e06c4711f52db.dir
-      size: 33614025
-      nfiles: 15
+      md5: c6944916dee6388016fd8eb7b265168f.dir
+      size: 16092995
+      nfiles: 3
     outs:
     - path: data/Rijkswaterstaat/modellen/lhm_parts
       hash: md5
       md5: 91ec20507efe16085dd4073d6e42da51.dir
-      size: 6173631922
+      size: 1783285170
       nfiles: 3
   aa_en_maas:
     cmd: uv run python notebooks/aa_en_maas/main.py


### PR DESCRIPTION
We now ignore the results folder with DVC. However some of the files we were tracking still included results. This updates the DVC files such that they are not counted. I also pushed the data.