### PR TITLE
Run all peilbeheerst parametrize scripts

### DIFF
--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -327,7 +327,6 @@ else:
     aanvoergebieden = None
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(
@@ -340,6 +339,7 @@ ribasim_param.set_aanvoer_flags(
     aanvoer_enabled=AANVOER_CONDITIONS,
 )
 ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["node_id"] == 109, "meta_aanvoer"] = True
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 ribasim_param.add_continuous_control(ribasim_model, dy=-200)
 

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -294,12 +294,12 @@ basin_aanvoer_off = (
 # fmt: on
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(
     ribasim_model, str(aanvoer_path), processor, aanvoer_enabled=AANVOER_CONDITIONS, basin_aanvoer_off=basin_aanvoer_off
 )
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 ribasim_param.add_continuous_control(ribasim_model, dy=-50)
 

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -668,10 +668,10 @@ else:
 ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(ribasim_model, str(aanvoer_path), processor, aanvoer_enabled=AANVOER_CONDITIONS)
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 ribasim_param.add_continuous_control(ribasim_model, dy=-50, exclude_outlets=(1265, 1371))
 

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -235,10 +235,10 @@ else:
     aanvoergebieden = None
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(ribasim_model, aanvoergebieden, processor, aanvoer_enabled=AANVOER_CONDITIONS)
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 ribasim_param.add_continuous_control(ribasim_model, dy=-50)
 

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -408,12 +408,12 @@ else:
 ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(
     ribasim_model, str(aanvoer_path), processor, aanvoer_enabled=AANVOER_CONDITIONS, basin_aanvoer_off=(204)
 )
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 # change the control of the outlet at Kinderdijk
 ribasim_model.pump.static.df.loc[ribasim_model.pump.static.df.node_id == 280, "meta_categorie"] = (
     "Inlaat boezem, afvoer gemaal"

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -258,10 +258,10 @@ else:
 ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(ribasim_model, str(aanvoer_path), processor, aanvoer_enabled=AANVOER_CONDITIONS)
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 
 for node in inlaat_structures:
     ribasim_model.outlet.static.df.loc[ribasim_model.outlet.static.df["node_id"] == node, "meta_func_aanvoer"] = 1

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
@@ -382,7 +382,6 @@ else:
     aanvoergebieden = None
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(
@@ -392,6 +391,7 @@ ribasim_param.set_aanvoer_flags(
     basin_aanvoer_off=104,
     aanvoer_enabled=AANVOER_CONDITIONS,
 )
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 ribasim_param.add_continuous_control(ribasim_model, dy=-50)
 

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -588,10 +588,10 @@ for node in inlaat_structures:
     ribasim_model.outlet.static.df.loc[ribasim_model.outlet.static.df["node_id"] == node, "meta_func_aanvoer"] = 1
 
 # add control, based on the meta_categorie
-ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="outlet")
 ribasim_param.find_upstream_downstream_target_levels(ribasim_model, node="pump")
 ribasim_param.set_aanvoer_flags(ribasim_model, str(aanvoer_path), processor, aanvoer_enabled=AANVOER_CONDITIONS)
+ribasim_param.identify_node_meta_categorie(ribasim_model, aanvoer_enabled=AANVOER_CONDITIONS)
 ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
 ribasim_param.add_continuous_control(ribasim_model, dy=-50)
 


### PR DESCRIPTION
I want to be able to run all 10 `src\peilbeheerst_model\Parametrize\*_parametrize.py` locally. Currently only Delfland runs for me.

First I ran into this error in all but WetterskipFryslan and Delfland:
```
`AttributeError: 'DataFrame' object has no attribute 'meta_aanvoer'`
```

This seems to be related to the function call ordering, which is brought in line with those 2 in bda1cabdeaaf8d96029980c04ccf00cf982a963f.

The errors I get after that commit are pasted below for each water authority. Some are node ID validation issues that the recently added validation change brought to light. @rbruijnshkv could you push changes to this branch so we can get all 10 running?

# AmstelGooienVecht
```
uv run python src\peilbeheerst_model\Parametrize\AmstelGooienVecht_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\AmstelGooienVecht_parametrize.py", line 343, in <module>
    ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_parametrization.py", line 1518, in determine_min_upstream_max_downstream_levels
    ribasim_model.outlet.static.df = outlet
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\pydantic\main.py", line 995, in __setattr__
    setattr_handler(self, name, value)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\pydantic\main.py", line 114, in <lambda>
    'validate_assignment': lambda model, name, val: model.__pydantic_validator__.validate_assignment(model, name, val),  # pyright: ignore[reportAssignmentType]
                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for TableModel[OutletStaticSchema]
df
  Value error, non-nullable series 'flow_rate' contains null values:
fid
0     NaN
1     NaN
2     NaN
7     NaN
16    NaN
       ..
389   NaN
390   NaN
391   NaN
392   NaN
393   NaN
Name: flow_rate, Length: 148, dtype: float64 [type=value_error, input_value=     node_id  flow_rate  ...
[394 rows x 15 columns], input_type=DataFrame]
    For further information visit https://errors.pydantic.dev/2.11/v/value_error
```
# WetterskipFryslan
```
uv run python src\peilbeheerst_model\Parametrize\WetterskipFryslan_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\WetterskipFryslan_parametrize.py", line 608, in <module>
    add_controllers_to_connector_nodes(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        model=ribasim_model,
        ^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        drain_capacity=20,
        ^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\ribasim_nl\ribasim_nl\control.py", line 1206, in add_controllers_to_connector_nodes
    add_controllers_to_drain_nodes(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        model=model,
        ^^^^^^^^^^^^
        drain_nodes_df=drain_nodes_df,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        max_flow_capacity=drain_capacity,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\ribasim_nl\ribasim_nl\control.py", line 669, in add_controllers_to_drain_nodes
    validate_nodes_on_reversed_direction(drain_nodes_df, node_function="drain")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\ribasim_nl\ribasim_nl\control.py", line 193, in validate_nodes_on_reversed_direction
    raise ValueError(
        f"Found {len(result)} connector-node pairs with reversed flow-directions: {reversed_nodes} in set marked as category {node_function}"
    )
ValueError: Found 1 connector-node pairs with reversed flow-directions: [{2102: 2128}, {2128: 2102}] in set marked as category drain
```
# Scheldestromen
```
uv run python src\peilbeheerst_model\Parametrize\Scheldestromen_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\Scheldestromen_parametrize.py", line 271, in <module>
    ribasim_param.determine_min_upstream_max_downstream_levels(ribasim_model, waterschap)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_parametrization.py", line 1518, in determine_min_upstream_max_downstream_levels
    ribasim_model.outlet.static.df = outlet
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\pydantic\main.py", line 995, in __setattr__
    setattr_handler(self, name, value)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\pydantic\main.py", line 114, in <lambda>
    'validate_assignment': lambda model, name, val: model.__pydantic_validator__.validate_assignment(model, name, val),  # pyright: ignore[reportAssignmentType]
                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for TableModel[OutletStaticSchema]
df
  Value error, non-nullable series 'flow_rate' contains null values:
fid
0     NaN
2     NaN
3     NaN
4     NaN
5     NaN
       ..
172   NaN
173   NaN
174   NaN
175   NaN
176   NaN
Name: flow_rate, Length: 154, dtype: float64 [type=value_error, input_value=     node_id  flow_rate  ...
[177 rows x 17 columns], input_type=DataFrame]
    For further information visit https://errors.pydantic.dev/2.11/v/value_error
```

# Zuiderzeeland
```
uv run python src\peilbeheerst_model\Parametrize\Zuiderzeeland_parametrize.py
```

```
The target levels (streefpeilen) have been updated.
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\Zuiderzeeland_parametrize.py", line 107, in <module>
    processor.run()
    ~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 533, in run
    self.write_ribasim_model()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 107, in write_ribasim_model
    self.model.write(outputdir / "ribasim.toml")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 446, in write
    self._validate_model()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 606, in _validate_model
    node_model._validate_node_ids()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\geometry\node.py", line 377, in _validate_node_ids
    raise ValueError("Node ID validation failed:\n" + "\n".join(errors))
ValueError: Node ID validation failed:
LevelBoundary partition (static): unexpected node_ids {819}
```

# SchielandendeKrimpenerwaard
```
uv run python src\peilbeheerst_model\Parametrize\SchielandendeKrimpenerwaard_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\SchielandendeKrimpenerwaard_parametrize.py", line 108, in <module>
    processor.run()
    ~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 533, in run
    self.write_ribasim_model()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 107, in write_ribasim_model
    self.model.write(outputdir / "ribasim.toml")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 446, in write
    self._validate_model()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 606, in _validate_model
    node_model._validate_node_ids()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\geometry\node.py", line 377, in _validate_node_ids
    raise ValueError("Node ID validation failed:\n" + "\n".join(errors))
ValueError: Node ID validation failed:
TabulatedRatingCurve partition (static): unexpected node_ids {706}
```
# Rijnland
```
uv run python src\peilbeheerst_model\Parametrize\Rijnland_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\Rijnland_parametrize.py", line 107, in <module>
    processor.run()
    ~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 533, in run
    self.write_ribasim_model()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 107, in write_ribasim_model
    self.model.write(outputdir / "ribasim.toml")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 446, in write
    self._validate_model()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 606, in _validate_model
    node_model._validate_node_ids()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\geometry\node.py", line 377, in _validate_node_ids
    raise ValueError("Node ID validation failed:\n" + "\n".join(errors))
ValueError: Node ID validation failed:
TabulatedRatingCurve partition (static): unexpected node_ids {860}
```
# Rivierenland
```
uv run python src\peilbeheerst_model\Parametrize\Rivierenland_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\Rivierenland_parametrize.py", line 107, in <module>
    processor.run()
    ~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 533, in run
    self.write_ribasim_model()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 107, in write_ribasim_model
    self.model.write(outputdir / "ribasim.toml")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 446, in write
    self._validate_model()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 606, in _validate_model
    node_model._validate_node_ids()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\geometry\node.py", line 377, in _validate_node_ids
    raise ValueError("Node ID validation failed:\n" + "\n".join(errors))
ValueError: Node ID validation failed:
TabulatedRatingCurve partition (static): unexpected node_ids {649}
```
# Delfland
```
uv run python src\peilbeheerst_model\Parametrize\Delfland_parametrize.py
```
In progress:
> Running Ribasim simulation: 5/20 for situation: water_drainage
# HollandsNoorderkwartier
```
uv run python src\peilbeheerst_model\Parametrize\HollandsNoorderkwartier_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\HollandsNoorderkwartier_parametrize.py", line 108, in <module>
    processor.run()
    ~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 533, in run
    self.write_ribasim_model()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 107, in write_ribasim_model
    self.model.write(outputdir / "ribasim.toml")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 446, in write
    self._validate_model()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 601, in _validate_model
    raise ValueError(
        f"Minimum {link_type} inneighbor or outneighbor unsatisfied"
    )
ValueError: Minimum flow inneighbor or outneighbor unsatisfied
```
# HollandseDelta
```
uv run python src\peilbeheerst_model\Parametrize\HollandseDelta_parametrize.py
```

```
Traceback (most recent call last):
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\Parametrize\HollandseDelta_parametrize.py", line 109, in <module>
    processor.run()
    ~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 533, in run
    self.write_ribasim_model()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\src\peilbeheerst_model\peilbeheerst_model\ribasim_feedback_processor.py", line 107, in write_ribasim_model
    self.model.write(outputdir / "ribasim.toml")
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 446, in write
    self._validate_model()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\model.py", line 606, in _validate_model
    node_model._validate_node_ids()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\ProgramData\DevDrive\repo\ribasim\Ribasim-NL\.venv\Lib\site-packages\ribasim\geometry\node.py", line 377, in _validate_node_ids
    raise ValueError("Node ID validation failed:\n" + "\n".join(errors))
ValueError: Node ID validation failed:
LevelBoundary partition (static): unexpected node_ids {2756, 2701}
```
