### PR TITLE
Fix koppelen_modellen

### DIFF
--- a/notebooks/koppelen_modellen.py
+++ b/notebooks/koppelen_modellen.py
@@ -50,6 +50,32 @@ forced_coupling = {
 
 
 # %% Functions
+def replace_listen_node_id(model: Model, old_node_id: int, new_node_id: int | None) -> bool:
+    """Replace listen_node_id references in all control tables.
+
+    If new_node_id is None, removes the entries instead of replacing.
+    Returns True if any references were found.
+    """
+    has_control = False
+    tables = [
+        model.discrete_control.variable.df,
+        model.continuous_control.variable.df,
+        model.pid_control.static.df,
+        model.pid_control.time.df,
+    ]
+    for df in tables:
+        if df is None:
+            continue
+        mask = df.listen_node_id == old_node_id
+        if mask.any():
+            has_control = True
+            if new_node_id is not None:
+                df.loc[mask, "listen_node_id"] = new_node_id
+            else:
+                df.drop(df.index[mask], inplace=True)
+    return has_control
+
+
 def get_basin_link(
     model: Model,
     basin_id: int,
@@ -84,6 +110,7 @@ def initialize_models(toml_file: Path) -> tuple[Model, Network, pd.DataFrame]:
     node_ids = model.node.df.index.to_numpy()
     for i in remove_nodes:
         if i in node_ids:
+            replace_listen_node_id(model, i, None)
             model.remove_node(node_id=i, remove_links=True)
 
     # Load the network
@@ -301,12 +328,8 @@ def process_boundary_nodes(model: Model, network: Network, basin_areas_df: pd.Da
                 for i in to_node_ids
             ]
 
-        # Replace boundary id in discrete and continuous control with basin id
-        has_control = False
-        for df in [model.discrete_control.variable.df, model.continuous_control.variable.df]:
-            if df is not None:
-                has_control = any(df.listen_node_id == boundary_node_id)
-                df.loc[df.listen_node_id == boundary_node_id, "listen_node_id"] = couple_with_basin_id
+        # Replace boundary id in all control tables with basin id
+        has_control = replace_listen_node_id(model, boundary_node_id, couple_with_basin_id)
 
         # Add control node for non RWS boundaries when no control node is yet present
         # Disabled since no data is supplied yet to the control node
@@ -491,6 +514,17 @@ def merge_lb(model: Model, lb_neighbors: pd.DataFrame, boundary_node_id: int):
             f"Cannot merge {boundary_node} => {neighbor_node}: Expected Outlet, got {model.get_node_type(from_node_ids)} and {model.get_node_type(to_node_ids)}"
         )
         return
+
+    # Update listen references for removed boundary nodes
+    upstream_basin_id = model.upstream_node_id(from_node_ids)
+    if isinstance(upstream_basin_id, pd.Series):
+        upstream_basin_id = upstream_basin_id.iloc[0]
+    downstream_basin_id = model.downstream_node_id(to_node_ids)
+    if isinstance(downstream_basin_id, pd.Series):
+        downstream_basin_id = downstream_basin_id.iloc[0]
+    replacement_basin = upstream_basin_id if upstream_basin_id is not None else downstream_basin_id
+    replace_listen_node_id(model, boundary_node_id, replacement_basin)
+    replace_listen_node_id(model, neighbor_id, replacement_basin)
 
     # Remove boundary node from model
     model.remove_node(boundary_node_id, remove_links=True)

--- a/src/ribasim_nl/ribasim_nl/model.py
+++ b/src/ribasim_nl/ribasim_nl/model.py
@@ -1132,9 +1132,19 @@ class Model(ribasim.Model):
         outlet_a = self.outlet.node.df.loc[outlet_a_id]
         outlet_b = self.outlet.node.df.loc[outlet_b_id]
 
-        # correct link from and to attributes
-        link_ids = self.link.df[self.link.df.to_node_id == outlet_a_id].index.to_list()
-        link_ids += self.link.df[self.link.df.from_node_id == outlet_b_id].index.to_list()
+        # Remove upstream (outlet_a) control node before link redirection, keeping the downstream one
+        upstream_ctrl_links = self.link.df[
+            (self.link.df.to_node_id == outlet_a_id) & (self.link.df.link_type == "control")
+        ]
+        for ctrl_link_id in upstream_ctrl_links.index:
+            ctrl_node_id: int = self.link.df.at[ctrl_link_id, "from_node_id"]  # pyrefly: ignore[bad-assignment]
+            self.remove_node(ctrl_node_id, remove_links=True)
+
+        # correct link from and to attributes (collect all links connected to either outlet for geometry reset)
+        link_ids = self.link.df[
+            (self.link.df.from_node_id.isin([outlet_a_id, outlet_b_id]))
+            | (self.link.df.to_node_id.isin([outlet_a_id, outlet_b_id]))
+        ].index.to_list()
 
         # Remove outlet_b from the links
         self.link.df.loc[self.link.df.from_node_id == outlet_b_id, "from_node_id"] = outlet_a_id


### PR DESCRIPTION
This fixes a few issues related to the new listen link types, and merging outlets that are both controlled (n=3), in which case we simply pick the downstream control.
