### PR TITLE
adjust setup_logging(), issue on some peelbeheerst models

### DIFF
--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_feedback_processor.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_feedback_processor.py
@@ -65,6 +65,8 @@ class RibasimFeedbackProcessor:
         for handler in logging.root.handlers[:]:
             logging.root.removeHandler(handler)
 
+        self.log_filename.parent.mkdir(parents=True, exist_ok=True)
+
         logging.basicConfig(
             filename=self.log_filename,
             level=logging.DEBUG,


### PR DESCRIPTION
Models from **_Rijnland_** and **_Schieland_en_de_krimpenerwaard_** failed mid run due to "FileNotFoundError".
Fixed with the addition of mkdir line on _def setup_logging(self)_   in "ribasim_feedback_processor.py" to ensure model folder exists before logging is carried out.