### PR TITLE
profiles to DVC with prep_cross_section as separate stage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     "python.analysis.typeCheckingMode": "off",
     "autoDocstring.docstringFormat": "numpy",
     "python-envs.defaultEnvManager": "renan-r-santos.pixi-code:pixi",
-    "python-envs.defaultPackageManager": "renan-r-santos.pixi-code:pixi"
+    "python-envs.defaultPackageManager": "renan-r-santos.pixi-code:pixi",
+    "chat.tools.terminal.autoApprove": {
+        "pixi": true
+    }
 }

--- a/data/Delfland/modellen/.gitignore
+++ b/data/Delfland/modellen/.gitignore
@@ -1,1 +1,2 @@
+/Delfland_pre_parameterized
 /Delfland_parameterized

--- a/data/Delfland/verwerkt/.gitignore
+++ b/data/Delfland/verwerkt/.gitignore
@@ -1,0 +1,2 @@
+/cross_sections
+/profielen

--- a/data/Rijnland/verwerkt/.gitignore
+++ b/data/Rijnland/verwerkt/.gitignore
@@ -1,0 +1,2 @@
+/cross_sections
+/profielen

--- a/data/Zuiderzeeland/modellen/.gitignore
+++ b/data/Zuiderzeeland/modellen/.gitignore
@@ -1,1 +1,2 @@
 /Zuiderzeeland_parameterized
+/Zuiderzeeland_pre_parameterized

--- a/data/Zuiderzeeland/verwerkt/.gitignore
+++ b/data/Zuiderzeeland/verwerkt/.gitignore
@@ -1,0 +1,2 @@
+/cross_sections
+/profielen

--- a/dvc.lock
+++ b/dvc.lock
@@ -1288,15 +1288,20 @@ stages:
     cmd:
     - pixi run python src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
     deps:
+    - path: data/Delfland/verwerkt/profielen
+      hash: md5
+      md5: 50df904939bd503ed64ed8002d12eb21.dir
+      size: 239884379
+      nfiles: 6
     - path: src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
       hash: md5
-      md5: f4a4086de19ced4bed5d65b97b7a3f9a
-      size: 18742
+      md5: 725a0ec171dee01442fa6b2e1f7d646b
+      size: 19065
     outs:
     - path: data/Delfland/modellen/Delfland_parameterized
       hash: md5
-      md5: fa2f8fea0ac69e02cf7c619dbd88f6bb.dir
-      size: 10879157
+      md5: a04e899a6b64e8c002a9a58b28fc8907.dir
+      size: 11014325
       nfiles: 2
   peilbeheerst@amstel_gooi_en_vecht:
     cmd:
@@ -1426,15 +1431,20 @@ stages:
     - pixi run python
       src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
     deps:
+    - path: data/Zuiderzeeland/verwerkt/profielen
+      hash: md5
+      md5: 06f482ecb8798bfa7c9e4c559191f1f5.dir
+      size: 207861396
+      nfiles: 6
     - path: src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
       hash: md5
-      md5: 05d57b545bdc91cc79de2ec8151b9bc6
-      size: 37641
+      md5: cc4c8e7ab8df643cf28d40d840d3931d
+      size: 37964
     outs:
     - path: data/Zuiderzeeland/modellen/Zuiderzeeland_parameterized
       hash: md5
-      md5: 4f9f665141228372376447ea96454269.dir
-      size: 13439157
+      md5: 0de5fe0b5291e553f59f823388b2805f.dir
+      size: 14999733
       nfiles: 2
   cross_sections@Rijnland:
     cmd: pixi run python src/peilbeheerst_model/profiles/prep_cross_sections.py
@@ -1482,4 +1492,128 @@ stages:
       hash: md5
       md5: 7048894524d5646bdf006d25753ee1e2.dir
       size: 969941042
+      nfiles: 6
+  peilbeheerst_pre@delfland:
+    cmd:
+    - pixi run python src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+      --pre
+    deps:
+    - path: src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+      hash: md5
+      md5: 725a0ec171dee01442fa6b2e1f7d646b
+      size: 19065
+    outs:
+    - path: data/Delfland/modellen/Delfland_pre_parameterized
+      hash: md5
+      md5: b72945afb528a9ddf4aaba1207fcc2f6.dir
+      size: 3711130
+      nfiles: 2
+  cross_sections@Delfland:
+    cmd: pixi run python src/peilbeheerst_model/profiles/prep_cross_sections.py
+      Delfland --no-sync
+    deps:
+    - path: data/Delfland/modellen/Delfland_pre_parameterized
+      hash: md5
+      md5: b72945afb528a9ddf4aaba1207fcc2f6.dir
+      size: 3711130
+      nfiles: 2
+    - path: src/peilbeheerst_model/profiles/prep_cross_sections.py
+      hash: md5
+      md5: 2040576530b172824691cefa46a1aea1
+      size: 10665
+    outs:
+    - path: data/Delfland/verwerkt/cross_sections
+      hash: md5
+      md5: 48535b4e473183d88e7afcd26e2eaed5.dir
+      size: 12435456
+      nfiles: 1
+  profile@Delfland:
+    cmd: pixi run python src/peilbeheerst_model/profiles/Delfland.py
+    deps:
+    - path: data/Delfland/modellen/Delfland_pre_parameterized
+      hash: md5
+      md5: b72945afb528a9ddf4aaba1207fcc2f6.dir
+      size: 3711130
+      nfiles: 2
+    - path: data/Delfland/verwerkt/cross_sections
+      hash: md5
+      md5: 48535b4e473183d88e7afcd26e2eaed5.dir
+      size: 12435456
+      nfiles: 1
+    - path: src/peilbeheerst_model/profiles/Delfland.py
+      hash: md5
+      md5: 7b9381f1a75595494e7d1f65a6ba145e
+      size: 320
+    - path: src/ribasim_nl/ribasim_nl/profiles
+      hash: md5
+      md5: f01cb4884f38550aa83fd828e9b1eaba.dir
+      size: 97589
+      nfiles: 9
+    outs:
+    - path: data/Delfland/verwerkt/profielen
+      hash: md5
+      md5: 3211ead6f3fd0cc96dec9a7816e21516.dir
+      size: 239883207
+      nfiles: 6
+  peilbeheerst_pre@zuiderzeeland:
+    cmd:
+    - pixi run python
+      src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py --pre
+    deps:
+    - path: src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+      hash: md5
+      md5: c3fa4c1e7518ad9709aa41f845dd6024
+      size: 38396
+    outs:
+    - path: data/Zuiderzeeland/modellen/Zuiderzeeland_pre_parameterized
+      hash: md5
+      md5: 8563c8b2e5ef75bb91096570621b345e.dir
+      size: 3948698
+      nfiles: 2
+  cross_sections@Zuiderzeeland:
+    cmd: pixi run python src/peilbeheerst_model/profiles/prep_cross_sections.py
+      Zuiderzeeland --no-sync
+    deps:
+    - path: data/Zuiderzeeland/modellen/Zuiderzeeland_pre_parameterized
+      hash: md5
+      md5: 8563c8b2e5ef75bb91096570621b345e.dir
+      size: 3948698
+      nfiles: 2
+    - path: src/peilbeheerst_model/profiles/prep_cross_sections.py
+      hash: md5
+      md5: 2040576530b172824691cefa46a1aea1
+      size: 10665
+    outs:
+    - path: data/Zuiderzeeland/verwerkt/cross_sections
+      hash: md5
+      md5: ce048bd3a92e99cd07ac853f34e26875.dir
+      size: 1445888
+      nfiles: 1
+  profile@Zuiderzeeland:
+    cmd: pixi run python src/peilbeheerst_model/profiles/Zuiderzeeland.py
+    deps:
+    - path: data/Zuiderzeeland/modellen/Zuiderzeeland_pre_parameterized
+      hash: md5
+      md5: 8563c8b2e5ef75bb91096570621b345e.dir
+      size: 3948698
+      nfiles: 2
+    - path: data/Zuiderzeeland/verwerkt/cross_sections
+      hash: md5
+      md5: ce048bd3a92e99cd07ac853f34e26875.dir
+      size: 1445888
+      nfiles: 1
+    - path: src/peilbeheerst_model/profiles/Zuiderzeeland.py
+      hash: md5
+      md5: 06212d6a9c5501d5a97869585285ecff
+      size: 604
+    - path: src/ribasim_nl/ribasim_nl/profiles
+      hash: md5
+      md5: f01cb4884f38550aa83fd828e9b1eaba.dir
+      size: 97589
+      nfiles: 9
+    outs:
+    - path: data/Zuiderzeeland/verwerkt/profielen
+      hash: md5
+      md5: ff6391d260d77bf77de498714e2883a0.dir
+      size: 207861685
       nfiles: 6

--- a/dvc.lock
+++ b/dvc.lock
@@ -1436,3 +1436,50 @@ stages:
       md5: 4f9f665141228372376447ea96454269.dir
       size: 13439157
       nfiles: 2
+  cross_sections@Rijnland:
+    cmd: pixi run python src/peilbeheerst_model/profiles/prep_cross_sections.py
+      Rijnland --no-sync
+    deps:
+    - path: data/Rijnland/modellen/Rijnland_parameterized
+      hash: md5
+      md5: 1e0d68ed2ede66994c7503f6ac244053.dir
+      size: 31609013
+      nfiles: 2
+    - path: src/peilbeheerst_model/profiles/prep_cross_sections.py
+      hash: md5
+      md5: 09abc4463ea12d2c401058c2daff1f02
+      size: 10689
+    outs:
+    - path: data/Rijnland/verwerkt/cross_sections
+      hash: md5
+      md5: 9c966d9d07ab7643681262b53e1b5b7e.dir
+      size: 23691264
+      nfiles: 1
+  profile@Rijnland:
+    cmd: pixi run python src/peilbeheerst_model/profiles/Rijnland.py
+    deps:
+    - path: data/Rijnland/modellen/Rijnland_parameterized
+      hash: md5
+      md5: 1e0d68ed2ede66994c7503f6ac244053.dir
+      size: 31609013
+      nfiles: 2
+    - path: data/Rijnland/verwerkt/cross_sections
+      hash: md5
+      md5: 9c966d9d07ab7643681262b53e1b5b7e.dir
+      size: 23691264
+      nfiles: 1
+    - path: src/peilbeheerst_model/profiles/Rijnland.py
+      hash: md5
+      md5: e359d88730eef662567b91f3f3b32ee0
+      size: 296
+    - path: src/ribasim_nl/ribasim_nl/profiles
+      hash: md5
+      md5: f01cb4884f38550aa83fd828e9b1eaba.dir
+      size: 97589
+      nfiles: 9
+    outs:
+    - path: data/Rijnland/verwerkt/profielen
+      hash: md5
+      md5: 7048894524d5646bdf006d25753ee1e2.dir
+      size: 969941042
+      nfiles: 6

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -6,7 +6,7 @@ stages:
     outs:
       - data/Rijkswaterstaat/verwerkt/bathymetrie
     frozen: true
-  peilbeheerst:
+  peilbeheerst_pre:
     foreach:
       delfland: Delfland
       amstel_gooi_en_vecht: AmstelGooienVecht
@@ -20,11 +20,11 @@ stages:
       zuiderzeeland: Zuiderzeeland
     do:
       cmd:
-        - pixi run python src/peilbeheerst_model/Parametrize/${item}_parametrize.py
+        - pixi run python src/peilbeheerst_model/Parametrize/${item}_parametrize.py --pre
       deps:
         - src/peilbeheerst_model/Parametrize/${item}_parametrize.py
       outs:
-        - data/${item}/modellen/${item}_parameterized
+        - data/${item}/modellen/${item}_pre_parameterized
   cross_sections:
     foreach:
       - AmstelGooienVecht
@@ -41,7 +41,7 @@ stages:
       cmd: pixi run python src/peilbeheerst_model/profiles/prep_cross_sections.py ${item} --no-sync
       deps:
         - src/peilbeheerst_model/profiles/prep_cross_sections.py
-        - data/${item}/modellen/${item}_parameterized
+        - data/${item}/modellen/${item}_pre_parameterized
       outs:
         - data/${item}/verwerkt/cross_sections
   profile:
@@ -61,10 +61,30 @@ stages:
       deps:
         - src/peilbeheerst_model/profiles/${item}.py
         - src/ribasim_nl/ribasim_nl/profiles
-        - data/${item}/modellen/${item}_parameterized
+        - data/${item}/modellen/${item}_pre_parameterized
         - data/${item}/verwerkt/cross_sections
       outs:
         - data/${item}/verwerkt/profielen
+  peilbeheerst:
+    foreach:
+      delfland: Delfland
+      amstel_gooi_en_vecht: AmstelGooienVecht
+      hollands_noorderkwartier: HollandsNoorderkwartier
+      hollandse_delta: HollandseDelta
+      rijnland: Rijnland
+      rivierenland: Rivierenland
+      scheldestromen: Scheldestromen
+      schieland_en_de_krimpenerwaard: SchielandendeKrimpenerwaard
+      wetterskip_fryslan: WetterskipFryslan
+      zuiderzeeland: Zuiderzeeland
+    do:
+      cmd:
+        - pixi run python src/peilbeheerst_model/Parametrize/${item}_parametrize.py
+      deps:
+        - src/peilbeheerst_model/Parametrize/${item}_parametrize.py
+        - data/${item}/verwerkt/profielen
+      outs:
+        - data/${item}/modellen/${item}_parameterized
   rijkswaterstaat:
     cmd:
       - pixi run python notebooks/rijkswaterstaat/2_basins.py

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -25,6 +25,46 @@ stages:
         - src/peilbeheerst_model/Parametrize/${item}_parametrize.py
       outs:
         - data/${item}/modellen/${item}_parameterized
+  cross_sections:
+    foreach:
+      - AmstelGooienVecht
+      - Delfland
+      - HollandseDelta
+      - HollandsNoorderkwartier
+      - Rijnland
+      - Rivierenland
+      - Scheldestromen
+      - SchielandendeKrimpenerwaard
+      - WetterskipFryslan
+      - Zuiderzeeland
+    do:
+      cmd: pixi run python src/peilbeheerst_model/profiles/prep_cross_sections.py ${item} --no-sync
+      deps:
+        - src/peilbeheerst_model/profiles/prep_cross_sections.py
+        - data/${item}/modellen/${item}_parameterized
+      outs:
+        - data/${item}/verwerkt/cross_sections
+  profile:
+    foreach:
+      - AmstelGooienVecht
+      - Delfland
+      - HollandseDelta
+      - HollandsNoorderkwartier
+      - Rijnland
+      - Rivierenland
+      - Scheldestromen
+      - SchielandendeKrimpenerwaard
+      - WetterskipFryslan
+      - Zuiderzeeland
+    do:
+      cmd: pixi run python src/peilbeheerst_model/profiles/${item}.py
+      deps:
+        - src/peilbeheerst_model/profiles/${item}.py
+        - src/ribasim_nl/ribasim_nl/profiles
+        - data/${item}/modellen/${item}_parameterized
+        - data/${item}/verwerkt/cross_sections
+      outs:
+        - data/${item}/verwerkt/profielen
   rijkswaterstaat:
     cmd:
       - pixi run python notebooks/rijkswaterstaat/2_basins.py

--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Amstel, Gooi en Vecht."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -279,6 +280,13 @@ ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] =
 )
 
 ribasim_model.basin.area.df["meta_streefpeil"] = ribasim_model.basin.area.df["meta_streefpeil"].astype(float)
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 # set basin profiles and add storing basins where applicable
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=100)

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -1,6 +1,7 @@
 """Parametrisation of water board: Delfland."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -221,6 +222,13 @@ ribasim_param.validate_basin_area(ribasim_model)
 
 # check streefpeilen at manning nodes
 ribasim_param.validate_manning_basins(ribasim_model)
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud)  # , min_area=100
 

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Hollands Noorderkwartier."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -232,6 +233,13 @@ ribasim_model.merge_basins(node_id=203, to_node_id=21)  # klein gebiedje in duin
 for node_type in ["LevelBoundary", "TabulatedRatingCurve", "Pump"]:
     mask = ribasim_model.node.df["node_type"] == node_type
     ribasim_model.node.df.loc[mask, "meta_node_id"] = ribasim_model.node.df.loc[mask].index
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10)
 

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Hollandse Delta."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -670,6 +671,13 @@ ribasim_model.basin.area.df.loc[
 ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] == -9.999, "meta_streefpeil"] = str(
     unknown_streefpeil
 )
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10)
 

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Rijnland."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -166,6 +167,13 @@ ribasim_param.validate_basin_area(ribasim_model)
 
 # check streefpeilen at manning nodes
 ribasim_param.validate_manning_basins(ribasim_model)
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Rivierenland."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -349,6 +350,13 @@ ribasim_model.node.df.loc[ribasim_model.tabulated_rating_curve.node.df.index, "m
     ribasim_model.tabulated_rating_curve.node.df.index
 )
 ribasim_model.node.df.loc[ribasim_model.pump.node.df.index, "meta_node_id"] = ribasim_model.pump.node.df.index
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Scheldestromen."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -195,6 +196,13 @@ inlaat_structures.append(309)
 for node_type in ["LevelBoundary", "TabulatedRatingCurve", "Pump"]:
     mask = ribasim_model.node.df["node_type"] == node_type
     ribasim_model.node.df.loc[mask, "meta_node_id"] = ribasim_model.node.df.loc[mask].index
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Schieland en de Krimpenerwaard."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -342,6 +343,13 @@ ribasim_param.validate_basin_area(ribasim_model)
 
 # check target levels at manning nodes
 ribasim_param.validate_manning_basins(ribasim_model)
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 # TODO: Replace standard profile by determined profiles (and add storing basins where applicable)
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)

--- a/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Fryslan."""
 
 import datetime
+import sys
 import warnings
 
 import geopandas as gpd
@@ -484,6 +485,13 @@ ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] =
 for node_type in ["LevelBoundary", "TabulatedRatingCurve", "Pump"]:
     mask = ribasim_model.node.df["node_type"] == node_type
     ribasim_model.node.df.loc[mask, "meta_node_id"] = ribasim_model.node.df.loc[mask].index
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud)
 

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -1,6 +1,7 @@
 """Parameterisation of water board: Zuiderzeeland."""
 
 import datetime
+import sys
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
@@ -539,6 +540,13 @@ ribasim_model.basin.area.df.loc[
 ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] == -9.999, "meta_streefpeil"] = str(
     unknown_streefpeil
 )
+
+# Save pre-profile model for DVC profile pipeline
+if "--pre" in sys.argv:
+    pre_param_toml = cloud.joinpath(waterschap, "modellen", f"{waterschap}_pre_parameterized", "ribasim.toml")
+    pre_param_toml.parent.mkdir(parents=True, exist_ok=True)
+    ribasim_model.write(pre_param_toml)
+    raise SystemExit(0)
 
 # set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)

--- a/src/peilbeheerst_model/profiles/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/profiles/AmstelGooienVecht.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "AmstelGooienVecht",
         "agv_crossings_v05.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/profiles/AmstelGooienVecht.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "AmstelGooienVecht",
         "agv_crossings_v05.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Delfland.py
+++ b/src/peilbeheerst_model/profiles/Delfland.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "Delfland",
         "delfland_crossings_v08.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Delfland.py
+++ b/src/peilbeheerst_model/profiles/Delfland.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "Delfland",
         "delfland_crossings_v08.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/HollandsNoorderkwartier.py
+++ b/src/peilbeheerst_model/profiles/HollandsNoorderkwartier.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "HollandsNoorderkwartier",
         "hhnk_crossings_v26.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/HollandsNoorderkwartier.py
+++ b/src/peilbeheerst_model/profiles/HollandsNoorderkwartier.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "HollandsNoorderkwartier",
         "hhnk_crossings_v26.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/HollandseDelta.py
+++ b/src/peilbeheerst_model/profiles/HollandseDelta.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
         val_flag="hoofdwaterloop",
         layer_hydro_objects=None,
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/HollandseDelta.py
+++ b/src/peilbeheerst_model/profiles/HollandseDelta.py
@@ -10,7 +10,7 @@ if __name__ == "__main__":
         "SOORT_OPPE",
         val_flag="hoofdwaterloop",
         layer_hydro_objects=None,
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Rijnland.py
+++ b/src/peilbeheerst_model/profiles/Rijnland.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "Rijnland",
         "rijnland_crossings_v04.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Rijnland.py
+++ b/src/peilbeheerst_model/profiles/Rijnland.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "Rijnland",
         "rijnland_crossings_v04.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Rivierenland.py
+++ b/src/peilbeheerst_model/profiles/Rivierenland.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "Rivierenland",
         "wsrl_crossings_v06.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Rivierenland.py
+++ b/src/peilbeheerst_model/profiles/Rivierenland.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "Rivierenland",
         "wsrl_crossings_v06.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Scheldestromen.py
+++ b/src/peilbeheerst_model/profiles/Scheldestromen.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         "aangeleverd/Na_levering/Oplevering_Scheldestromen_20240328/Oplevering_20240328.gpkg",
         "categorieoppwaterlichaam",
         val_flag="primair",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Scheldestromen.py
+++ b/src/peilbeheerst_model/profiles/Scheldestromen.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
         "categorieoppwaterlichaam",
         val_flag="primair",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/SchielandendeKrimpenerwaard.py
+++ b/src/peilbeheerst_model/profiles/SchielandendeKrimpenerwaard.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "SchielandendeKrimpenerwaard",
         "hhsk_crossings_voor_profielen_met_OG_hydroobjecten.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/SchielandendeKrimpenerwaard.py
+++ b/src/peilbeheerst_model/profiles/SchielandendeKrimpenerwaard.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "SchielandendeKrimpenerwaard",
         "hhsk_crossings_voor_profielen_met_OG_hydroobjecten.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/WetterskipFryslan.py
+++ b/src/peilbeheerst_model/profiles/WetterskipFryslan.py
@@ -7,6 +7,7 @@ if __name__ == "__main__":
         "WetterskipFryslan",
         "wetterskip_crossings_v06.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/WetterskipFryslan.py
+++ b/src/peilbeheerst_model/profiles/WetterskipFryslan.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "WetterskipFryslan",
         "wetterskip_crossings_v06.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Zuiderzeeland.py
+++ b/src/peilbeheerst_model/profiles/Zuiderzeeland.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     gen_profiles.main(
         "Zuiderzeeland",
         "zzl_crossings_v05.gpkg",
-        sync=False,
+        sync=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/Zuiderzeeland.py
+++ b/src/peilbeheerst_model/profiles/Zuiderzeeland.py
@@ -13,6 +13,7 @@ if __name__ == "__main__":
         "Zuiderzeeland",
         "zzl_crossings_v05.gpkg",
         sync=True,
+        overwrite=True,
         export_profile_tables=True,
         export_intermediate_output=True,
     )

--- a/src/peilbeheerst_model/profiles/gen_profiles.py
+++ b/src/peilbeheerst_model/profiles/gen_profiles.py
@@ -173,10 +173,9 @@ def _read_basins(cloud: CloudStorage, water_authority: str) -> gpd.GeoDataFrame:
     :return: basin dataset (polygons)
     """
     fn = cloud.joinpath(
-        # water_authority, "verwerkt", "Work_dir", f"{water_authority}_parameterized", "input", "database.gpkg"
         water_authority,
         "modellen",
-        f"{water_authority}_parameterized",
+        f"{water_authority}_pre_parameterized",
         "input",
         "database.gpkg",
     )
@@ -292,11 +291,3 @@ def _export_profiles(
         table = pd.DataFrame(table[[c for c in table.columns if c != "geometry"]])
         table.to_csv(fn, index=False)
         print(f"File saved: {fn}")
-
-    # upload files to the GoodCloud
-    print("Uploading to the GoodCloud...", end="", flush=True)
-    cloud.upload_content(wd, overwrite=True)
-    if export_intermediate_output:
-        (wd / "intermediate").mkdir(exist_ok=True)
-        cloud.upload_content(wd / "intermediate", overwrite=True)
-    print("\rFiles uploaded to the GoodCloud")

--- a/src/peilbeheerst_model/profiles/gen_profiles.py
+++ b/src/peilbeheerst_model/profiles/gen_profiles.py
@@ -173,7 +173,12 @@ def _read_basins(cloud: CloudStorage, water_authority: str) -> gpd.GeoDataFrame:
     :return: basin dataset (polygons)
     """
     fn = cloud.joinpath(
-        water_authority, "verwerkt", "Work_dir", f"{water_authority}_parameterized", "input", "database.gpkg"
+        # water_authority, "verwerkt", "Work_dir", f"{water_authority}_parameterized", "input", "database.gpkg"
+        water_authority,
+        "modellen",
+        f"{water_authority}_parameterized",
+        "input",
+        "database.gpkg",
     )
     gdf = gpd.read_file(fn, layer="Basin / area")
     return gdf[gdf["node_id"] == gdf["meta_node_id"]]
@@ -187,7 +192,7 @@ def _read_cross_sections(cloud: CloudStorage, water_authority: str) -> gpd.GeoDa
 
     :return: cross-section dataset (lines)
     """
-    fn = cloud.joinpath(water_authority, "verwerkt", "profielen", "intermediate", "lines_z.gpkg")
+    fn = cloud.joinpath(water_authority, "verwerkt", "cross_sections", "lines_z.gpkg")
     return gpd.read_file(fn)
 
 

--- a/src/peilbeheerst_model/profiles/prep_cross_sections.py
+++ b/src/peilbeheerst_model/profiles/prep_cross_sections.py
@@ -24,7 +24,9 @@ def get_basins(water_authority: str, cloud: CloudStorage = CloudStorage()) -> gp
     :return: basin data
     :rtype: geopandas.GeoDataFrame
     """
-    fn_basins = cloud.joinpath(water_authority, "modellen", f"{water_authority}_parameterized", "database.gpkg")
+    fn_basins = cloud.joinpath(
+        water_authority, "modellen", f"{water_authority}_parameterized", "input", "database.gpkg"
+    )
     return gpd.read_file(fn_basins, layer="Basin / area")
 
 
@@ -215,7 +217,7 @@ def export_to_cloud(
         cloud.download_basisgegevens(["profielen"], overwrite=overwrite)
 
     # working directories
-    folders = water_authority, "verwerkt", "profielen", "intermediate"
+    folders = water_authority, "verwerkt", "cross_sections"
     src = cloud.joinpath(*folders)
 
     # re-preprocess cross-sections
@@ -225,7 +227,6 @@ def export_to_cloud(
 
     # ensure existence of working directories
     src.mkdir(parents=True, exist_ok=True)
-    cloud.create_dir(*folders[:-1])
     cloud.create_dir(*folders)
 
     # get data

--- a/src/peilbeheerst_model/profiles/prep_cross_sections.py
+++ b/src/peilbeheerst_model/profiles/prep_cross_sections.py
@@ -25,7 +25,7 @@ def get_basins(water_authority: str, cloud: CloudStorage = CloudStorage()) -> gp
     :rtype: geopandas.GeoDataFrame
     """
     fn_basins = cloud.joinpath(
-        water_authority, "modellen", f"{water_authority}_parameterized", "input", "database.gpkg"
+        water_authority, "modellen", f"{water_authority}_pre_parameterized", "input", "database.gpkg"
     )
     return gpd.read_file(fn_basins, layer="Basin / area")
 
@@ -227,14 +227,12 @@ def export_to_cloud(
 
     # ensure existence of working directories
     src.mkdir(parents=True, exist_ok=True)
-    cloud.create_dir(*folders)
 
     # get data
     lines = get_profiles(water_authority, cloud, buffer=buffer)
 
-    # upload data
+    # save data locally (DVC handles remote storage)
     lines.to_file(src / fn)
-    cloud.upload_file(src / fn)
     print(f"File saved: {src / fn}")
 
 


### PR DESCRIPTION
I picked up https://github.com/Deltares/Ribasim-NL/issues/496 and have added the profiles to DVC.

- It would require "sync=True" within peilbeheerst_mode/profiles/WATER_AUTHORITY.py in order to download profiles data (gpkg) and some other folders/files.
- Also small change on gen_profiles to read folder "modellen" instead of "verwerkt/Work_dir" where model results are located.
- The prep_cross_section becomes a stage to prepare cross_section for waterboards needed. Once this is run, does not have to be repeated since DVC will take care of that.

However, it takes a bit long for each waterboard, and it does upload generated profile_tables back to the cloud (the option is set to True in all waterboards for now).
All changes in branch "profile_dvc". - not sure if we want to merge that indeed.... From what I read it would be useful mainly for water quality simulations