### PR TITLE
Update assign_offline_budgets: bugfixes, refactor validation and plotting

### DIFF
--- a/notebooks/06_add_synthetic_forcing.py
+++ b/notebooks/06_add_synthetic_forcing.py
@@ -8,7 +8,7 @@ from ribasim_nl import CloudStorage, Model
 
 cloud = CloudStorage()
 starttime = datetime(2017, 1, 1)
-endtime = datetime(2018, 1, 1)
+endtime = datetime(2020, 1, 1)
 
 FIND_POST_FIXES = ["full_control_model"]
 # pass authorities as arguments, or edit list here

--- a/notebooks/07_add_dynamic_forcing.py
+++ b/notebooks/07_add_dynamic_forcing.py
@@ -20,7 +20,7 @@ from ribasim_nl import (
 
 cloud = CloudStorage()
 starttime = datetime(2017, 1, 1)
-endtime = datetime(2018, 1, 1)
+endtime = datetime(2020, 1, 1)
 write_budgets: bool = True  # write mfms_budgets.arrow for later verification
 assign_budget_fractions: bool = False  # compute (sub-) fractions from budgets-table
 add_lhm_fractions: bool = True

--- a/notebooks/07_add_dynamic_forcing.py
+++ b/notebooks/07_add_dynamic_forcing.py
@@ -7,11 +7,11 @@ from ribasim.delwaq import generate, parse, run_delwaq
 from ribasim_nl.aquo import waterbeheercode
 from ribasim_nl.assign_lhm_fractions import assign_lhm_fractions
 from ribasim_nl.assign_offline_budgets import AssignOfflineBudgets
+from ribasim_nl.set_forcing import SetDynamicForcing
 
 from ribasim_nl import (
     CloudStorage,
     Model,
-    SetDynamicForcing,
     add_transboundary_inflow,
     import_transboundary_inflow,
     merge_rwzi_model,
@@ -46,15 +46,16 @@ surface_runoff_budgets: set[str] = {"bdgqrun"}
 def add_forcing(model, cloud, starttime, endtime, assign_budget_fractions, fraction_prefix):
 
     # sync files so we're good to go!
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
 
-    # compute forcing
+    # Open zarr budgets (shared between forcing and offline budgets)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
+    # compute meteo forcing from zarr precipitation (and evaporation when available)
     forcing = SetDynamicForcing(
         model=model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
@@ -62,7 +63,6 @@ def add_forcing(model, cloud, starttime, endtime, assign_budget_fractions, fract
     model = forcing.add()
 
     # Add dynamic groundwater
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     _, budgets_df = offline_budgets.compute_budgets(
         model,
         primary_budgets=primary_budgets,

--- a/notebooks/07_add_dynamic_forcing.py
+++ b/notebooks/07_add_dynamic_forcing.py
@@ -3,6 +3,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+import xarray as xr
 from ribasim.delwaq import generate, parse, run_delwaq
 from ribasim_nl.aquo import waterbeheercode
 from ribasim_nl.assign_lhm_fractions import assign_lhm_fractions
@@ -49,13 +50,14 @@ def add_forcing(model, cloud, starttime, endtime, assign_budget_fractions, fract
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
 
-    # Open zarr budgets (shared between forcing and offline budgets)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    # Open zarr budgets, select time range early to reduce data volume
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     # compute meteo forcing from zarr precipitation (and evaporation when available)
     forcing = SetDynamicForcing(
         model=model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/notebooks/07_add_dynamic_forcing.py
+++ b/notebooks/07_add_dynamic_forcing.py
@@ -147,8 +147,6 @@ for authority in authorities:
 
         if check_build(dst_toml_file):
             model = Model.read(toml_file)
-            # update state so we start smooth/empty
-            model.update_state()
 
             # add categorie to basin / state
             series = model.basin.node.df["meta_categorie"]  # type: ignore

--- a/notebooks/rijkswaterstaat/5_model_netwerk.py
+++ b/notebooks/rijkswaterstaat/5_model_netwerk.py
@@ -226,7 +226,7 @@ basin_poly_gdf["outlet_data"] = None
 
 
 # %% init model
-model = Model(starttime="2020-01-01", endtime="2021-01-01", crs="EPSG:28992")
+model = Model(starttime="2017-01-01", endtime="2020-01-01", crs="EPSG:28992")
 
 
 # %% boundaries bouwen

--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -93,7 +93,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -282,22 +282,18 @@ implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -259,22 +259,18 @@ ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.s
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -99,7 +99,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -261,22 +261,18 @@ ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.s
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -98,7 +98,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -673,22 +673,18 @@ implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -92,7 +92,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -95,7 +95,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -212,22 +212,18 @@ ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.s
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -417,22 +417,18 @@ implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -96,7 +96,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -93,7 +93,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -197,22 +197,18 @@ implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
@@ -92,7 +92,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
@@ -349,22 +349,18 @@ implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
@@ -526,22 +526,18 @@ ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.s
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
@@ -104,7 +104,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -582,22 +582,18 @@ ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.s
 
 # set forcing
 if DYNAMIC_CONDITIONS:
-    # Add dynamic meteo
+    # Add dynamic meteo and groundwater from LHM zarr
+    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
+    cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
+    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        cloud=cloud,
+        budgets=offline_budgets.budgets,
         startdate=starttime,
         enddate=endtime,
     )
-
     ribasim_model = forcing.add()
-
-    # Add dynamic groundwater
-    lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budget.zip")
-    precipitation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc")
-    evaporation_path = cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc")
-    cloud.synchronize(filepaths=[lhm_budget_path, precipitation_path, evaporation_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
     offline_budgets.compute_budgets(ribasim_model)
 
 elif MIXED_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -99,7 +99,7 @@ unknown_streefpeil = (
 
 # forcing settings
 starttime = datetime.datetime(2017, 1, 1)
-endtime = datetime.datetime(2018, 1, 1)
+endtime = datetime.datetime(2020, 1, 1)
 saveat = 3600 * 24
 timestep_size = "d"
 timesteps = 2

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -358,42 +358,41 @@ class AssignOfflineBudgets:
             surface_runoff_budgets -= missing
 
     def _transpose_basin_definition_polygons(
-        self, basin_definition_primairy: gpd.GeoDataFrame, basin_definition_secundairy: gpd.GeoDataFrame
+        self, basin_definition_primary: gpd.GeoDataFrame, basin_definition_secundary: gpd.GeoDataFrame
     ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, gpd.GeoDataFrame]:
         """
-        Retruns basin_difinition_out with index of basin_definition_in that intersect the basin_definition_out polygons
+        Returns basin_difinition_out with index of basin_definition_in that intersect the basin_definition_out polygons
 
         Args:
-            basin_definition_primairy (gpd.GeoDataFrame): Basin definition with (multi) polygons
-            basin_definition_secundairy (gpd.GeoDataFrame): Basin definition with (multi) polygons
+            basin_definition_primary (gpd.GeoDataFrame): Basin definition with (multi) polygons
+            basin_definition_secundary (gpd.GeoDataFrame): Basin definition with (multi) polygons
 
         Returns
         -------
-            tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, gpd.GeoDataFrame]: basin_definition_secundairy geometry with primary based index, Basin definition with
-            polygons without any intersection for primairy and secundairy basins
+            tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, gpd.GeoDataFrame]: basin_definition_secundary geometry with primary based index, Basin definition with
+            polygons without any intersection for primary and secundary basins
         """
-        basin_definition_primairy_out = basin_definition_secundairy.copy()
-        tree = shapely.STRtree(basin_definition_secundairy["geometry"])
-        index_in, index_out = tree.query(basin_definition_primairy.representative_point(), predicate="intersects")
-        index_in = basin_definition_primairy.index[index_in]
-        index_out = basin_definition_secundairy.index[index_out]
+        tree = shapely.STRtree(basin_definition_secundary["geometry"])
+        index_in, index_out = tree.query(basin_definition_primary.representative_point(), predicate="intersects")
+        index_in = basin_definition_primary.index[index_in]
+        index_out = basin_definition_secundary.index[index_out]
         # evaluate non-matching items
-        # secondary basins with non matching primairy basins
-        index_undifined_secundary = basin_definition_secundairy.index[
-            ~np.isin(basin_definition_secundairy.index, index_out)
+        # secondary basins with non matching primary basins
+        index_undifined_secundary = basin_definition_secundary.index[
+            ~np.isin(basin_definition_secundary.index, index_out)
         ]
-        undifined_secondary_basins = basin_definition_primairy.loc[index_undifined_secundary]
-        # primary basins with non matching secundairy basins
+        undifined_secondary_basins = basin_definition_primary.loc[index_undifined_secundary]
+        # primary basins with non matching secundary basins
         # strategy: add to output df (fall true logic), and add to undifined output argument
-        index_undifined_primairy = basin_definition_primairy.index[~np.isin(basin_definition_primairy.index, index_in)]
-        undifined_primairy_basins = basin_definition_primairy.loc[index_undifined_primairy]
+        index_undifined_primary = basin_definition_primary.index[~np.isin(basin_definition_primary.index, index_in)]
+        undifined_primary_basins = basin_definition_primary.loc[index_undifined_primary]
         # prepare main output df
-        basin_definition_secundairy = basin_definition_secundairy.loc[index_out]
-        basin_definition_secundairy = basin_definition_secundairy.set_index([index_in])
-        basin_definition_primairy_out = pd.concat(
-            [basin_definition_secundairy, basin_definition_primairy.loc[index_undifined_primairy]]
+        basin_definition_secundary = basin_definition_secundary.loc[index_out]
+        basin_definition_secundary = basin_definition_secundary.set_index([index_in])
+        basin_definition_primary_out = pd.concat(
+            [basin_definition_secundary, basin_definition_primary.loc[index_undifined_primary]]
         )
-        return basin_definition_primairy_out, undifined_primairy_basins, undifined_secondary_basins
+        return basin_definition_primary_out, undifined_primary_basins, undifined_secondary_basins
 
     def _fill_basin_definition_from_points(
         self,
@@ -554,7 +553,7 @@ class AssignOfflineBudgets:
             secondary_values=secondary_values,
         )
 
-        # transpose primairy basins to secondary basin definition to get rid of the narrow polygons
+        # transpose primary basins to secondary basin definition to get rid of the narrow polygons
         basin_definition_primair_polygon, basin_definition_undifined_primair, basin_definition_undifined_secundair = (
             self._transpose_basin_definition_polygons(basin_definition_primair, basin_definition_secondair)
         )
@@ -660,7 +659,7 @@ class AssignOfflineBudgets:
 
         xmin, ymin, xmax, ymax = primary_basin_definition.total_bounds
         # sum over time to get all active nodes
-        primairy_sum = sum(
+        primary_sum = sum(
             budgets[v].sel(x=slice(xmin, xmax), y=slice(ymax, ymin)).sum("time").load()
             for v in self.primary_budget_keys
         )
@@ -679,13 +678,13 @@ class AssignOfflineBudgets:
         secondary_mask_cropped = secondary_basin_mask.where(secondary_basin_mask != -999).sel(
             x=slice(xmin, xmax), y=slice(ymax, ymin)
         )
-        primary_node_id = primary_mask_cropped * xr.where(primairy_sum != 0.0, 1, np.nan)
+        primary_node_id = primary_mask_cropped * xr.where(primary_sum != 0.0, 1, np.nan)
         secondary_node_id = secondary_mask_cropped * xr.where(secondary_sum != 0.0, 1, np.nan)
         runoff_node_id = secondary_mask_cropped * xr.where(runoff_sum != 0.0, 1, np.nan)
 
         # check for unassigned budget cells: cells where budget is active but mask is nodata (-999)
-        missed_primairy = xr.where(
-            (primary_basin_mask.sel(x=slice(xmin, xmax), y=slice(ymax, ymin)) == -999) & (primairy_sum != 0.0),
+        missed_primary = xr.where(
+            (primary_basin_mask.sel(x=slice(xmin, xmax), y=slice(ymax, ymin)) == -999) & (primary_sum != 0.0),
             1,
             np.nan,
         )
@@ -704,11 +703,11 @@ class AssignOfflineBudgets:
         # green (1) = budget active and assigned to a basin
         # red   (2) = budget active but outside any basin (missed)
         # NaN       = no budget activity
-        active_primary = xr.where(primairy_sum != 0.0, 1.0, np.nan)
+        active_primary = xr.where(primary_sum != 0.0, 1.0, np.nan)
         active_secondary = xr.where(secondary_sum != 0.0, 1.0, np.nan)
         active_runoff = xr.where(runoff_sum != 0.0, 1.0, np.nan)
 
-        combined_primary = xr.where(missed_primairy == 1, 2.0, xr.where(active_primary == 1, 1.0, np.nan))
+        combined_primary = xr.where(missed_primary == 1, 2.0, xr.where(active_primary == 1, 1.0, np.nan))
         combined_secondary = xr.where(missed_secondary == 1, 2.0, xr.where(active_secondary == 1, 1.0, np.nan))
         combined_runoff = xr.where(missed_runoff == 1, 2.0, xr.where(active_runoff == 1, 1.0, np.nan))
 
@@ -721,7 +720,7 @@ class AssignOfflineBudgets:
         base_colors = plt.colormaps["hsv"](np.linspace(0, 1, n, endpoint=False))
         node_cmap = ListedColormap(base_colors)
         node_norm = BoundaryNorm(np.append(all_node_ids - 0.5, all_node_ids[-1] + 0.5), node_cmap.N)
-        # plot the first four plots; from polygon definition to gridded primairy + secondary masks
+        # plot the first four plots; from polygon definition to gridded primary + secondary masks
         for gdf, ax, title in zip(
             [
                 basin_rest,
@@ -805,5 +804,6 @@ class AssignOfflineBudgets:
             fontweight="bold",
             bbox={"boxstyle": "round,pad=0.3", "facecolor": "lightblue", "edgecolor": "grey"},
         )
-        plt.savefig(path, bbox_inches="tight")
+        if path is not None:
+            plt.savefig(path, bbox_inches="tight")
         plt.close()

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -96,7 +96,7 @@ class AssignOfflineBudgets:
             budgets = Path(budgets)
             if not budgets.exists():
                 raise FileNotFoundError(
-                    f"You can't compute budgets if you don't have the zarr_budgets in a zip-file: {budgets}"
+                    f"You can't compute budgets if you don't have the budgets in a Zarr store: {budgets}"
                     "Download a copy"
                     "Alternatively go to: https://github.com/Deltares/Ribasim-NL/blob/main/scripts/add_lhm_budgets/get_data_LHM_run.py to see how you can create one."
                 )

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -101,6 +101,19 @@ class AssignOfflineBudgets:
                     "Alternatively go to: https://github.com/Deltares/Ribasim-NL/blob/main/scripts/add_lhm_budgets/get_data_LHM_run.py to see how you can create one."
                 )
         self.budgets = budgets
+        self.surface_runoff_budget_keys: set[str] = {"bdgqrun_m3d"}
+        self.secondary_budget_keys: set[str] = {
+            "bdgriv_sys2",
+            "bdgriv_sys3",
+            "bdgriv_sys6",
+            "bdgdrn_sys1",
+            "bdgdrn_sys2",
+            "bdgdrn_sys3",
+            "bdgpssw_m3d",
+        }
+        self.primary_budget_keys: set[str] = {"bdgriv_sys1", "bdgriv_sys4", "bdgriv_sys5"}
+        self.secondary_labels: set[str] = {"bergend"}
+        self.primary_labels: set[str] = {"hoofdwater", "doorgaand"}
 
     def compute_budgets(
         self,
@@ -180,24 +193,16 @@ class AssignOfflineBudgets:
             Model and with MODFLOW-MetaSWAP budgets per node_id and timestamp. These can be used for verification and/or to compute fraction tracer/concentrations
         """
         # Synchronize LHM budget and model files
-        if surface_runoff_budgets is None:
-            surface_runoff_budgets = {"bdgqrunm3"}
-        if secondary_budgets is None:
-            secondary_budgets = {
-                "bdgriv_sys2",
-                "bdgriv_sys3",
-                "bdgriv_sys6",
-                "bdgdrn_sys1",
-                "bdgdrn_sys2",
-                "bdgdrn_sys3",
-                "bdgpsswm3",
-            }
-        if primary_budgets is None:
-            primary_budgets = {"bdgriv_sys1", "bdgriv_sys4", "bdgriv_sys5"}
-        if secondary_values is None:
-            secondary_values = {"bergend"}
-        if primary_values is None:
-            primary_values = {"hoofdwater", "doorgaand"}
+        if surface_runoff_budgets is not None:
+            self.surface_runoff_budget_keys = surface_runoff_budgets
+        if secondary_budgets is not None:
+            self.secondary_budget_keys = secondary_budgets
+        if primary_budgets is not None:
+            self.primary_budget_keys = primary_budgets
+        if secondary_values is not None:
+            self.secondary_labels = secondary_values
+        if primary_values is not None:
+            self.primary_labels = primary_values
         print("read and validate budgets and model")
         budgets, model = self._sync_files(model)  # read model and budgets form zarr-store
         self._validate_budgets(
@@ -214,7 +219,6 @@ class AssignOfflineBudgets:
             primary_values=primary_values,
             secondary_values=secondary_values,
         )
-
         print("rasterize basins to masks")
         primary_basin_mask = imod.prepare.rasterize(
             primary_basin_definition,
@@ -230,11 +234,10 @@ class AssignOfflineBudgets:
             fill=-999,
             dtype=np.int32,
         )
-
         print("compute budgets per basin")
         primary_budgets_df = (
             _compute_budgets_per_basin(
-                _crop_to_gdf(budgets[list(primary_budgets)], primary_basin_definition),
+                _crop_to_gdf(budgets[list(self.primary_budget_keys)], primary_basin_definition),
                 primary_basin_mask,
             )
             / 86400
@@ -242,7 +245,10 @@ class AssignOfflineBudgets:
 
         secondary_budgets_df = (
             _compute_budgets_per_basin(
-                _crop_to_gdf(budgets[list(secondary_budgets | surface_runoff_budgets)], secondary_basin_definition),
+                _crop_to_gdf(
+                    budgets[list(self.secondary_budget_keys | self.surface_runoff_budget_keys)],
+                    secondary_basin_definition,
+                ),
                 secondary_basin_mask,
             )
             / 86400
@@ -253,7 +259,13 @@ class AssignOfflineBudgets:
         budgets_df = pd.concat([primary_budgets_df, secondary_budgets_df]).sort_index()
 
         # sum all budgets (columns) and create drainage and infiltration series
-        summed_budgets = pd.Series(budgets_df[list(primary_budgets | secondary_budgets)].sum(axis=1))
+        # Group-sum to ensure unique (node_id, time) index before mapping
+        summed_budgets = pd.Series(
+            budgets_df[list(self.primary_budget_keys | self.secondary_budget_keys)]
+            .groupby(level=["node_id", "time"])
+            .sum()
+            .sum(axis=1)
+        )
         drainage = summed_budgets.clip(
             upper=0
         ).abs()  # all <0 is drainage. Take absolute its a positive term in RIBASIM
@@ -261,7 +273,12 @@ class AssignOfflineBudgets:
             lower=0
         )  # alles > 0 (infiltratie is in modflow, ontrekking uit ribasim, maar in ribasim positief teken)
         surface_runoff = (
-            pd.Series(budgets_df[list(surface_runoff_budgets)].sum(axis=1)).clip(upper=0).abs()
+            budgets_df[list(self.surface_runoff_budget_keys)]
+            .groupby(level=["node_id", "time"])
+            .sum()
+            .sum(axis=1)
+            .clip(upper=0)
+            .abs()
         )  # assume surface_runoff can't be <0 in RIBASIM. And negative budgets in MODFLOW-MetaSWAP are positive terms in Ribasim
 
         # update basin drainage and infiltration
@@ -280,9 +297,9 @@ class AssignOfflineBudgets:
             assign_fractions_from_budgets(
                 model=model,
                 budgets_df=budgets_df,
-                primary_budgets=primary_budgets,
-                secondary_budgets=secondary_budgets,
-                surface_runoff_budgets=surface_runoff_budgets,
+                primary_budgets=self.primary_budget_keys,
+                secondary_budgets=self.secondary_budget_keys,
+                surface_runoff_budgets=self.surface_runoff_budget_keys,
                 primary_basin_ids=primary_basin_ids,
                 secondary_basin_ids=secondary_basin_ids,
                 prefix=fraction_prefix,
@@ -341,33 +358,42 @@ class AssignOfflineBudgets:
             surface_runoff_budgets -= missing
 
     def _transpose_basin_definition_polygons(
-        self,
-        basin_definition_in: gpd.GeoDataFrame,
-        basin_definition_out: gpd.GeoDataFrame,
-    ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
-        """Returns basin_definition_out with the index of basin_definition_in for polygons that intersect.
+        self, basin_definition_primairy: gpd.GeoDataFrame, basin_definition_secundairy: gpd.GeoDataFrame
+    ) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, gpd.GeoDataFrame]:
+        """
+        Retruns basin_difinition_out with index of basin_definition_in that intersect the basin_definition_out polygons
 
-        Parameters
-        ----------
-        basin_definition_in : gpd.GeoDataFrame
-            Basin definition with (multi)polygons.
-        basin_definition_out : gpd.GeoDataFrame
-            Basin definition with (multi)polygons.
+        Args:
+            basin_definition_primairy (gpd.GeoDataFrame): Basin definition with (multi) polygons
+            basin_definition_secundairy (gpd.GeoDataFrame): Basin definition with (multi) polygons
 
         Returns
         -------
-        tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]
-            - Basin definition with updated index based on intersections.
-            - Basin definition containing polygons without any intersection.
+            tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, gpd.GeoDataFrame]: basin_definition_secundairy geometry with primary based index, Basin definition with
+            polygons without any intersection for primairy and secundairy basins
         """
-        tree = shapely.STRtree(basin_definition_out["geometry"])
-        index_in, index_out = tree.query(basin_definition_in.representative_point(), predicate="intersects")
-        index_in = basin_definition_in.index[index_in]
-        index_out = basin_definition_out.index[index_out]
-        index_undifined = basin_definition_out.index[~np.isin(basin_definition_out.index, index_out)]
-        basin_definition_undifined = basin_definition_out.loc[index_undifined]
-        basin_definition_out = basin_definition_out.loc[index_out]
-        return basin_definition_out.set_index([index_in]), basin_definition_undifined
+        basin_definition_primairy_out = basin_definition_secundairy.copy()
+        tree = shapely.STRtree(basin_definition_secundairy["geometry"])
+        index_in, index_out = tree.query(basin_definition_primairy.representative_point(), predicate="intersects")
+        index_in = basin_definition_primairy.index[index_in]
+        index_out = basin_definition_secundairy.index[index_out]
+        # evaluate non-matching items
+        # secondary basins with non matching primairy basins
+        index_undifined_secundary = basin_definition_secundairy.index[
+            ~np.isin(basin_definition_secundairy.index, index_out)
+        ]
+        undifined_secondary_basins = basin_definition_primairy.loc[index_undifined_secundary]
+        # primary basins with non matching secundairy basins
+        # strategy: add to output df (fall true logic), and add to undifined output argument
+        index_undifined_primairy = basin_definition_primairy.index[~np.isin(basin_definition_primairy.index, index_in)]
+        undifined_primairy_basins = basin_definition_primairy.loc[index_undifined_primairy]
+        # prepare main output df
+        basin_definition_secundairy = basin_definition_secundairy.loc[index_out]
+        basin_definition_secundairy = basin_definition_secundairy.set_index([index_in])
+        basin_definition_primairy_out = pd.concat(
+            [basin_definition_secundairy, basin_definition_primairy.loc[index_undifined_primairy]]
+        )
+        return basin_definition_primairy_out, undifined_primairy_basins, undifined_secondary_basins
 
     def _fill_basin_definition_from_points(
         self,
@@ -529,13 +555,16 @@ class AssignOfflineBudgets:
         )
 
         # transpose primairy basins to secondary basin definition to get rid of the narrow polygons
-        basin_definition_primair_polygon, basin_definition_undifined = self._transpose_basin_definition_polygons(
-            basin_definition_primair, basin_definition_secondair
+        basin_definition_primair_polygon, basin_definition_undifined_primair, basin_definition_undifined_secundair = (
+            self._transpose_basin_definition_polygons(basin_definition_primair, basin_definition_secondair)
         )
+        if not basin_definition_undifined_primair.empty:
+            # Add undefined primary elements to secondary basins so secondary budgets will also be assigned
+            basin_definition_secondair = pd.concat([basin_definition_secondair, basin_definition_undifined_primair])
 
         # fill empty basins based on pip for secondary nodes
         basin_definition_primair_points = self._fill_basin_definition_from_points(
-            basin_definition_undifined, nodes[nodes[basin_metacol].isin(primary_values)]
+            basin_definition_undifined_secundair, nodes[nodes[basin_metacol].isin(primary_values)]
         )
         if not basin_definition_primair_points.empty:
             basin_definition_primair = pd.concat([basin_definition_primair_polygon, basin_definition_primair_points])
@@ -556,3 +585,225 @@ class AssignOfflineBudgets:
 
         if exception:
             raise ValueError(f"{basin_metacol}{exception}")
+
+    def plot_assign_validation(self, model: Model | Path | str, path: Path | str | None = None):
+        """Validate if all budget cells are assigned to a basin and plot the assignment
+
+        Parameters
+        ----------
+        model : Model | Path | str
+            Ribasim model or path to ribasim.toml
+        path : Path | str | None, optional
+            Directory path to save the control plot. If None, no plot is saved.
+        """
+        budgets, model = self._sync_files(model=model)  # read model and budgets from zarr-store
+        if path is not None:
+            path = Path(path)
+        primary_basin_definition, secondary_basin_definition = self._split_basin_definitions(ribasim_model=model)
+        primary_basin_mask = imod.prepare.rasterize(
+            primary_basin_definition,
+            column="node_id",
+            like=_crop_to_gdf(budgets["bdgriv_sys1"].isel(time=0, drop=True), primary_basin_definition),
+            fill=-999,
+            dtype=np.int32,
+        )
+        secondary_basin_mask = imod.prepare.rasterize(
+            secondary_basin_definition,
+            column="node_id",
+            like=_crop_to_gdf(budgets["bdgriv_sys1"].isel(time=0, drop=True), secondary_basin_definition),
+            fill=-999,
+            dtype=np.int32,
+        )
+        basin_definition = gpd.GeoDataFrame(pd.concat([primary_basin_definition, secondary_basin_definition]))
+        # split basin_definition by meta_categorie of Ribasim model itself, to keep original nod_id's
+        assert model.basin.node is not None
+        assert model.basin.node.df is not None
+        nodes = gpd.GeoDataFrame(
+            {
+                "node_id": model.basin.node.df.index,
+                "geometry": model.basin.node.df["geometry"],
+                "meta_categorie": model.basin.node.df["meta_categorie"],
+            }
+        ).set_index("node_id", drop=True)
+        basin_definition = basin_definition.set_index("node_id", drop=False)
+        basin_bergend = basin_definition.loc[nodes["meta_categorie"] == "bergend"]
+        basin_rest = basin_definition.loc[nodes["meta_categorie"] != "bergend"]
+
+        self._plot_assign_validation(
+            budgets=budgets,
+            basin_definition=basin_definition,
+            basin_rest=basin_rest,
+            basin_bergend=basin_bergend,
+            primary_basin_definition=primary_basin_definition,
+            secondary_basin_definition=secondary_basin_definition,
+            primary_basin_mask=primary_basin_mask,
+            secondary_basin_mask=secondary_basin_mask,
+            path=path,
+        )
+
+    def _plot_assign_validation(
+        self,
+        budgets,
+        basin_definition: gpd.GeoDataFrame,
+        basin_rest: gpd.GeoDataFrame,
+        basin_bergend: gpd.GeoDataFrame,
+        primary_basin_definition: gpd.GeoDataFrame,
+        secondary_basin_definition: gpd.GeoDataFrame,
+        primary_basin_mask,
+        secondary_basin_mask,
+        path: Path | None = None,
+    ):
+        # plot imports
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import BoundaryNorm, ListedColormap
+        from matplotlib.patches import Patch
+
+        xmin, ymin, xmax, ymax = primary_basin_definition.total_bounds
+        # sum over time to get all active nodes
+        primairy_sum = sum(
+            budgets[v].sel(x=slice(xmin, xmax), y=slice(ymax, ymin)).sum("time").load()
+            for v in self.primary_budget_keys
+        )
+        secondary_sum = sum(
+            budgets[v].sel(x=slice(xmin, xmax), y=slice(ymax, ymin)).sum("time").load()
+            for v in self.secondary_budget_keys
+        )
+        runoff_sum = sum(
+            budgets[v].sel(x=slice(xmin, xmax), y=slice(ymax, ymin)).sum("time").load()
+            for v in self.surface_runoff_budget_keys
+        )
+        # map to node_id of basins — crop masks to the same bbox first so all arrays share coordinates
+        primary_mask_cropped = primary_basin_mask.where(primary_basin_mask != -999).sel(
+            x=slice(xmin, xmax), y=slice(ymax, ymin)
+        )
+        secondary_mask_cropped = secondary_basin_mask.where(secondary_basin_mask != -999).sel(
+            x=slice(xmin, xmax), y=slice(ymax, ymin)
+        )
+        primary_node_id = primary_mask_cropped * xr.where(primairy_sum != 0.0, 1, np.nan)
+        secondary_node_id = secondary_mask_cropped * xr.where(secondary_sum != 0.0, 1, np.nan)
+        runoff_node_id = secondary_mask_cropped * xr.where(runoff_sum != 0.0, 1, np.nan)
+
+        # check for unassigned budget cells: cells where budget is active but mask is nodata (-999)
+        missed_primairy = xr.where(
+            (primary_basin_mask.sel(x=slice(xmin, xmax), y=slice(ymax, ymin)) == -999) & (primairy_sum != 0.0),
+            1,
+            np.nan,
+        )
+        missed_secondary = xr.where(
+            (secondary_basin_mask.sel(x=slice(xmin, xmax), y=slice(ymax, ymin)) == -999) & (secondary_sum != 0.0),
+            1,
+            np.nan,
+        )
+        missed_runoff = xr.where(
+            (secondary_basin_mask.sel(x=slice(xmin, xmax), y=slice(ymax, ymin)) == -999) & (runoff_sum != 0.0),
+            1,
+            np.nan,
+        )
+
+        # make red/green grids based solely on missed_* and active budget cells
+        # green (1) = budget active and assigned to a basin
+        # red   (2) = budget active but outside any basin (missed)
+        # NaN       = no budget activity
+        active_primary = xr.where(primairy_sum != 0.0, 1.0, np.nan)
+        active_secondary = xr.where(secondary_sum != 0.0, 1.0, np.nan)
+        active_runoff = xr.where(runoff_sum != 0.0, 1.0, np.nan)
+
+        combined_primary = xr.where(missed_primairy == 1, 2.0, xr.where(active_primary == 1, 1.0, np.nan))
+        combined_secondary = xr.where(missed_secondary == 1, 2.0, xr.where(active_secondary == 1, 1.0, np.nan))
+        combined_runoff = xr.where(missed_runoff == 1, 2.0, xr.where(active_runoff == 1, 1.0, np.nan))
+
+        # plot
+        _, axes = plt.subplots(2, 5, figsize=(30, 12))
+        # shared color mapping based on unique node_ids
+        all_node_ids = np.sort(basin_definition["node_id"].unique())
+        n = len(all_node_ids)
+        # Build a colormap with exactly one unique color per node_id
+        base_colors = plt.colormaps["hsv"](np.linspace(0, 1, n, endpoint=False))
+        node_cmap = ListedColormap(base_colors)
+        node_norm = BoundaryNorm(np.append(all_node_ids - 0.5, all_node_ids[-1] + 0.5), node_cmap.N)
+        # plot the first four plots; from polygon definition to gridded primairy + secondary masks
+        for gdf, ax, title in zip(
+            [
+                basin_rest,
+                basin_bergend,
+                primary_basin_definition,
+                secondary_basin_definition,
+            ],
+            [axes[0, 0], axes[0, 1], axes[1, 0], axes[1, 1]],
+            [
+                "Primair basin polygon",
+                "Secondary basin polygon",
+                "Gridded primary mask",
+                "Gridded secondary mask",
+            ],
+            strict=True,
+        ):
+            gdf.plot(
+                column="node_id",
+                ax=ax,
+                cmap=node_cmap,
+                norm=node_norm,
+                legend=False,
+            )
+            # Overlay basin boundaries
+            basin_definition.boundary.plot(ax=ax, color="grey", linewidth=0.7)
+            ax.set_title(f"{title} - node_id")
+        # Row 0 cols 2-4: budget grids mapped to node_id
+        for da, ax, title in zip(
+            [primary_node_id, secondary_node_id, runoff_node_id],
+            [axes[0, 2], axes[0, 3], axes[0, 4]],
+            ["Primary LHM budgets - node_id", "Secondary LHM budgets - node_id", "Runoff LHM budgets - node_id"],
+            strict=True,
+        ):
+            da.plot(ax=ax, cmap=node_cmap, norm=node_norm, add_colorbar=False)
+            basin_definition.boundary.plot(ax=ax, color="grey", linewidth=0.7)
+            ax.set_title(title)
+            ax.set_aspect("equal")
+        # red-green control grids
+        cmap_combined = ListedColormap(
+            [(0.0, 0.5, 0.0, 1.0), (1.0, 0.0, 0.0, 1.0), (0.0, 0.0, 0.0, 0.0)]
+        )  # green=OK, red=missed, transparent=inactive
+        cmap_combined.set_bad(color=(0, 0, 0, 0))  # NaN as transparent
+        norm_combined = BoundaryNorm([0.5, 1.5, 2.5, 3.5], cmap_combined.N)
+        legend_handles = [
+            Patch(facecolor="green", edgecolor="k", label="assigned (OK)"),
+            Patch(facecolor="red", edgecolor="k", label="missed (unassigned)"),
+        ]
+        # Row 1 cols 2-4: assignment check grids
+        for da, ax, title in zip(
+            [combined_primary, combined_secondary, combined_runoff],
+            [axes[1, 2], axes[1, 3], axes[1, 4]],
+            ["Primary: green=OK, red=missed", "Secondary: green=OK, red=missed", "Runoff: green=OK, red=missed"],
+            strict=True,
+        ):
+            da.plot(ax=ax, cmap=cmap_combined, norm=norm_combined, add_colorbar=False)
+            basin_definition.boundary.plot(ax=ax, color="grey", linewidth=0.7)
+            ax.set_title(title)
+            ax.set_aspect("equal")
+            ax.legend(handles=legend_handles, loc="upper right")
+        plt.tight_layout()
+        # Add group labels above the two sets of plots
+        # Left group: columns 0-1 (basin polygon definitions), right group: columns 2-4 (gridded budget checks)
+        fig = plt.gcf()
+        fig.text(
+            0.21,
+            1.01,
+            "Basin polygon definitions",
+            ha="center",
+            va="bottom",
+            fontsize=13,
+            fontweight="bold",
+            bbox={"boxstyle": "round,pad=0.3", "facecolor": "lightyellow", "edgecolor": "grey"},
+        )
+        fig.text(
+            0.68,
+            1.01,
+            "Gridded LHM budget assignment check",
+            ha="center",
+            va="bottom",
+            fontsize=13,
+            fontweight="bold",
+            bbox={"boxstyle": "round,pad=0.3", "facecolor": "lightblue", "edgecolor": "grey"},
+        )
+        plt.savefig(path, bbox_inches="tight")
+        plt.close()

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -206,7 +206,7 @@ class AssignOfflineBudgets:
         print("read and validate budgets and model")
         budgets, model = self._sync_files(model)  # read model and budgets form zarr-store
         self._validate_budgets(
-            budgets, primary_budgets, secondary_budgets, surface_runoff_budgets
+            budgets, self.primary_budget_keys, self.secondary_budget_keys, self.surface_runoff_budget_keys
         )  # check if all data-variables are present
 
         # Split into primary and secondary basin definition
@@ -381,7 +381,7 @@ class AssignOfflineBudgets:
         index_undifined_secundary = basin_definition_secundary.index[
             ~np.isin(basin_definition_secundary.index, index_out)
         ]
-        undifined_secondary_basins = basin_definition_primary.loc[index_undifined_secundary]
+        undifined_secondary_basins = basin_definition_secundary.loc[index_undifined_secundary]
         # primary basins with non matching secundary basins
         # strategy: add to output df (fall true logic), and add to undifined output argument
         index_undifined_primary = basin_definition_primary.index[~np.isin(basin_definition_primary.index, index_in)]
@@ -519,9 +519,9 @@ class AssignOfflineBudgets:
         """
         # optionally get basin_metacol from other basin_subtype
         if secondary_values is None:
-            secondary_values = {"bergend"}
+            secondary_values = self.secondary_labels
         if primary_values is None:
-            primary_values = {"hoofdwater", "doorgaand"}
+            primary_values = self.primary_labels
         assert ribasim_model.basin.node is not None
         assert ribasim_model.basin.node.df is not None
         if basin_metacol in ribasim_model.basin.node.df.columns:

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -378,21 +378,21 @@ class AssignOfflineBudgets:
         index_out = basin_definition_secundary.index[index_out]
         # evaluate non-matching items
         # secondary basins with non matching primary basins
-        index_undifined_secundary = basin_definition_secundary.index[
+        index_undefined_secundary = basin_definition_secundary.index[
             ~np.isin(basin_definition_secundary.index, index_out)
         ]
-        undifined_secondary_basins = basin_definition_secundary.loc[index_undifined_secundary]
+        undefined_secondary_basins = basin_definition_secundary.loc[index_undefined_secundary]
         # primary basins with non matching secundary basins
-        # strategy: add to output df (fall true logic), and add to undifined output argument
-        index_undifined_primary = basin_definition_primary.index[~np.isin(basin_definition_primary.index, index_in)]
-        undifined_primary_basins = basin_definition_primary.loc[index_undifined_primary]
+        # strategy: add to output df (fall true logic), and add to undefined output argument
+        index_undefined_primary = basin_definition_primary.index[~np.isin(basin_definition_primary.index, index_in)]
+        undefined_primary_basins = basin_definition_primary.loc[index_undefined_primary]
         # prepare main output df
         basin_definition_secundary = basin_definition_secundary.loc[index_out]
         basin_definition_secundary = basin_definition_secundary.set_index([index_in])
         basin_definition_primary_out = pd.concat(
-            [basin_definition_secundary, basin_definition_primary.loc[index_undifined_primary]]
+            [basin_definition_secundary, basin_definition_primary.loc[index_undefined_primary]]
         )
-        return basin_definition_primary_out, undifined_primary_basins, undifined_secondary_basins
+        return basin_definition_primary_out, undefined_primary_basins, undefined_secondary_basins
 
     def _fill_basin_definition_from_points(
         self,
@@ -554,16 +554,16 @@ class AssignOfflineBudgets:
         )
 
         # transpose primary basins to secondary basin definition to get rid of the narrow polygons
-        basin_definition_primair_polygon, basin_definition_undifined_primair, basin_definition_undifined_secundair = (
+        basin_definition_primair_polygon, basin_definition_undefined_primair, basin_definition_undefined_secundair = (
             self._transpose_basin_definition_polygons(basin_definition_primair, basin_definition_secondair)
         )
-        if not basin_definition_undifined_primair.empty:
+        if not basin_definition_undefined_primair.empty:
             # Add undefined primary elements to secondary basins so secondary budgets will also be assigned
-            basin_definition_secondair = pd.concat([basin_definition_secondair, basin_definition_undifined_primair])
+            basin_definition_secondair = pd.concat([basin_definition_secondair, basin_definition_undefined_primair])
 
         # fill empty basins based on pip for secondary nodes
         basin_definition_primair_points = self._fill_basin_definition_from_points(
-            basin_definition_undifined_secundair, nodes[nodes[basin_metacol].isin(primary_values)]
+            basin_definition_undefined_secundair, nodes[nodes[basin_metacol].isin(primary_values)]
         )
         if not basin_definition_primair_points.empty:
             basin_definition_primair = pd.concat([basin_definition_primair_polygon, basin_definition_primair_points])

--- a/src/ribasim_nl/ribasim_nl/set_forcing.py
+++ b/src/ribasim_nl/ribasim_nl/set_forcing.py
@@ -57,22 +57,27 @@ class SetDynamicForcing:
     def add(self) -> Model:
         """Compute basin-averaged precipitation and evaporation from LHM zarr and add to model."""
         basins = self.model.basin.area.df
+        assert basins is not None
         basin_definition = basins[["node_id", "geometry"]].copy()
 
+        like = _crop_to_gdf(self.budgets[PRECIPITATION_VAR].isel(time=0, drop=True), basin_definition)
+        assert isinstance(like, xr.DataArray)
         basin_mask = imod.prepare.rasterize(
             basin_definition,
             column="node_id",
-            like=_crop_to_gdf(self.budgets[PRECIPITATION_VAR].isel(time=0, drop=True), basin_definition),
+            like=like,
             fill=-999,
             dtype=np.int32,
         )
 
         # Build precipitation dataset
         precip_ds = _crop_to_gdf(self.budgets[[PRECIPITATION_VAR]], basin_definition)
+        assert isinstance(precip_ds, xr.Dataset)
 
         # Build evaporation dataset: use real data if available, else zeros
         if EVAPORATION_VAR in self.budgets:
             evap_ds = _crop_to_gdf(self.budgets[[EVAPORATION_VAR]], basin_definition)
+            assert isinstance(evap_ds, xr.Dataset)
         else:
             # Placeholder: zeros shaped like precipitation
             evap_da = xr.zeros_like(precip_ds[PRECIPITATION_VAR])
@@ -94,7 +99,7 @@ class SetDynamicForcing:
         cell_counts = pd.Series(counts, index=unique_ids, name="count")
         # Broadcast cell counts to match the MultiIndex (node_id, time)
         node_ids = precip_df.index.get_level_values("node_id")
-        counts_per_row = node_ids.map(cell_counts).values
+        counts_per_row = node_ids.map(cell_counts.to_dict()).values
 
         # Convert summed mm/day -> averaged mm/day -> m/s
         mm_per_day_to_m_per_s = 1 / 86400 / 1000

--- a/src/ribasim_nl/ribasim_nl/set_forcing.py
+++ b/src/ribasim_nl/ribasim_nl/set_forcing.py
@@ -50,7 +50,7 @@ class SetDynamicForcing:
         enddate: str,
     ) -> None:
         self.model = model
-        self.budgets = budgets.sel(time=slice(np.datetime64(startdate), np.datetime64(enddate)))
+        self.budgets = budgets
         self.startdate = startdate
         self.enddate = enddate
 

--- a/src/ribasim_nl/ribasim_nl/set_forcing.py
+++ b/src/ribasim_nl/ribasim_nl/set_forcing.py
@@ -1,14 +1,12 @@
-# copied from notebooks\meteo\add_meteo.py
+"""Assign dynamic precipitation and evaporation forcing from LHM zarr budgets to Ribasim Basin nodes."""
 
-import geopandas as gpd
+import imod
 import numpy as np
 import pandas as pd
-import tqdm
 import xarray as xr
-from shapely.geometry import box
-from shapely.prepared import prep
 
-from ribasim_nl import CloudStorage, Model
+from ribasim_nl import Model
+from ribasim_nl.assign_offline_budgets import _compute_budgets_per_basin, _crop_to_gdf
 
 # Makkink to open water evaporation factor, depending on the month of the year (rows)
 # and the decade in the month, starting at day 1, 11, 21 (cols). As used in Mozart.
@@ -38,179 +36,88 @@ def _open_water_factor(times: np.ndarray) -> np.ndarray:
     return EVAP_FACTOR[months, decades]
 
 
+# Variable names in the LHM zarr store
+PRECIPITATION_VAR = "precipitation_mmd"
+EVAPORATION_VAR = "evaporation_mmd"  # not yet available; zeros used as placeholder
+
+
 class SetDynamicForcing:
     def __init__(
         self,
         model: Model,
-        cloud: CloudStorage,
+        budgets: xr.Dataset,
         startdate: str,
         enddate: str,
     ) -> None:
         self.model = model
-        self.cloud = cloud
+        self.budgets = budgets.sel(time=slice(np.datetime64(startdate), np.datetime64(enddate)))
         self.startdate = startdate
         self.enddate = enddate
 
     def add(self) -> Model:
-        ############# SET THE DESIRED MODEL AND TIME PERIOD ###################
-        # authority = "Rijkswaterstaat"  # Water authority folder that is used on the Cloud Storage
-        # model = "lhm_coupled_2025_5_0"  # Model that is selected on the Cloud Storage
-        # startdate = "2017-01-01"  # Startdate of the modelrun
-        # enddate = "2017-12-31"  # Enddate of the modelrun
-        ######################################################################
-
-        # Load the precipitation, evaporation and basins
-        precip = xr.open_dataset(self.cloud.joinpath("Basisgegevens/WIWB/Meteobase.Precipitation.nc"))
-        evp = xr.open_dataset(self.cloud.joinpath("Basisgegevens/WIWB/Meteobase.Evaporation.Makkink.nc"))
-
-        # Load the basins from the model
+        """Compute basin-averaged precipitation and evaporation from LHM zarr and add to model."""
         basins = self.model.basin.area.df
+        basin_definition = basins[["node_id", "geometry"]].copy()
 
-        # Extract arrays of x and y coordinates from the meteo grids
-        xll_coords = precip["x"].values
-        yll_coords = precip["y"].values
+        basin_mask = imod.prepare.rasterize(
+            basin_definition,
+            column="node_id",
+            like=_crop_to_gdf(self.budgets[PRECIPITATION_VAR].isel(time=0, drop=True), basin_definition),
+            fill=-999,
+            dtype=np.int32,
+        )
 
-        # Get a dictionary with fractional coverage for each basin
-        fraction_map = self._get_fractional_grid_per_basin(xll_coords, yll_coords, basins)
+        # Build precipitation dataset
+        precip_ds = _crop_to_gdf(self.budgets[[PRECIPITATION_VAR]], basin_definition)
 
-        # Get the meteo input per basin as pd.DataFrame
-        meteo_time_df = self._get_meteo_per_basin(self.startdate, self.enddate, precip, evp, fraction_map)
+        # Build evaporation dataset: use real data if available, else zeros
+        if EVAPORATION_VAR in self.budgets:
+            evap_ds = _crop_to_gdf(self.budgets[[EVAPORATION_VAR]], basin_definition)
+        else:
+            # Placeholder: zeros shaped like precipitation
+            evap_da = xr.zeros_like(precip_ds[PRECIPITATION_VAR])
+            evap_da.name = EVAPORATION_VAR
+            evap_ds = evap_da.to_dataset()
 
-        # Add the meteo information to the selected model
-        new_model = self._add_meteo_to_model(meteo_time_df)
+        # Compute basin-averaged values (mm/day per basin)
+        # _compute_budgets_per_basin sums over cells; divide by cell count to get the mean
+        print("compute precipitation per basin")
+        precip_df = _compute_budgets_per_basin(precip_ds, basin_mask)
+        print("compute evaporation per basin")
+        evap_df = _compute_budgets_per_basin(evap_ds, basin_mask)
 
-        # return the new model with the meteo information added
+        # Count cells per basin for averaging
+        mask_flat = basin_mask.values.reshape(-1)
+        valid = np.isfinite(mask_flat) & (mask_flat != -999)
+        ids = mask_flat[valid].astype(np.int64)
+        unique_ids, counts = np.unique(ids, return_counts=True)
+        cell_counts = pd.Series(counts, index=unique_ids, name="count")
+        # Broadcast cell counts to match the MultiIndex (node_id, time)
+        node_ids = precip_df.index.get_level_values("node_id")
+        counts_per_row = node_ids.map(cell_counts).values
+
+        # Convert summed mm/day -> averaged mm/day -> m/s
+        mm_per_day_to_m_per_s = 1 / 86400 / 1000
+        precip_series = precip_df[PRECIPITATION_VAR] / counts_per_row * mm_per_day_to_m_per_s
+        evap_series = evap_df[EVAPORATION_VAR] / counts_per_row * mm_per_day_to_m_per_s
+
+        # Apply open-water evaporation factor
+        times = evap_series.index.get_level_values("time")
+        evap_factors = _open_water_factor(times.values)
+        evap_series = evap_series * evap_factors
+
+        # Build meteo DataFrame
+        meteo_df = pd.DataFrame(
+            {
+                "node_id": precip_series.index.get_level_values("node_id"),
+                "time": times,
+                "precipitation": precip_series.values,
+                "potential_evaporation": evap_series.values,
+            }
+        )
+
+        new_model = self._add_meteo_to_model(meteo_df)
         return new_model
-
-    def _sync_meteo_from_cloud(self) -> None:
-        """
-        Synchronize Meteo information from cloud to local directory
-
-        Function that syncs the LHM Precipitation and Makkink Evaporation (Meteobase) from the Deltares GoodCloud
-        storage to a local directory (if not available yet)
-        """
-        WIWB_dir = self.cloud.joinpath("Basisgegevens/WIWB")
-        WIWB_Precip_path = WIWB_dir / "Meteobase.Precipitation.nc"
-        WIWB_Evap_path = WIWB_dir / "Meteobase.Evaporation.Makkink.nc"
-        self.cloud.synchronize(filepaths=[WIWB_Precip_path, WIWB_Evap_path])
-        print(f"WIWB Meteo data synced from cloud. Available in {WIWB_dir}")
-
-    def _get_fractional_grid_per_basin(self, xll_coords: np.ndarray, yll_coords: np.ndarray, basins: gpd.GeoDataFrame):
-        """
-        Get the meteo grid coverage per basin, expressed as a fraction for each of the covered cells
-
-        Calculates the fractional overlap of supplied basins given a set of x and y coordinates.
-        It returns a dictionary with the touching cells (indices) for each basin, and the fractional coverage.
-        """
-        cell_area = abs((xll_coords[1] - xll_coords[0]) * (yll_coords[1] - yll_coords[0]))
-        nodeids = basins["node_id"].tolist()
-        prepared_geoms = [(nodeids[i], prep(geom)) for i, geom in enumerate(basins.geometry)]
-        node_geoms = dict(zip(nodeids, basins.geometry, strict=True))
-
-        height = len(yll_coords)
-        width = len(xll_coords)
-        fraction_map: dict[int, list[tuple[int, int, float]]] = {}
-
-        for node_id, prep_geom in tqdm.tqdm(prepared_geoms, desc="Overlapping polygons with rasters"):
-            geom = node_geoms[node_id]
-            xl, yl, xr, yu = geom.bounds
-            xmin_diff = xl - xll_coords
-            xmax_diff = xr - xll_coords
-            ymin_diff = yl - yll_coords
-            ymax_diff = yu - yll_coords
-
-            col_start = np.where(xmin_diff > 0)[0][np.argmin(xmin_diff[xmin_diff > 0])] if any(xmin_diff > 0) else 0
-            col_end = np.where(xmax_diff > 0)[0][np.argmin(xmax_diff[xmax_diff > 0])] if any(xmax_diff > 0) else 0
-            row_end = np.where(ymin_diff > 0)[0][np.argmin(ymin_diff[ymin_diff > 0])] if any(ymin_diff > 0) else 0
-            row_start = np.where(ymax_diff > 0)[0][np.argmin(ymax_diff[ymax_diff > 0])] if any(ymax_diff > 0) else 0
-
-            fraction_map[node_id] = []
-            if row_start >= row_end or row_end <= 0 or col_start >= col_end or col_end <= 0:
-                closest_row = min(max(0, row_start), height - 1)
-                closest_col = min(max(0, col_start), width - 1)
-                fraction_map[node_id].append((closest_row, closest_col, 1))
-            else:
-                for row in range(row_start, row_end):
-                    for col in range(col_start, col_end):
-                        cell_poly = box(xll_coords[col], yll_coords[row], xll_coords[col + 1], yll_coords[row + 1])
-                        if prep_geom.intersects(cell_poly):
-                            intersection = cell_poly.intersection(geom)
-                            if not intersection.is_empty:
-                                frac = intersection.area / cell_area
-                                if frac > 0:
-                                    fraction_map[node_id].append((row, col, frac))
-        return fraction_map
-
-    def _get_meteo_per_basin(
-        self,
-        startdate: str,
-        enddate: str,
-        precip: xr.Dataset,
-        evp: xr.Dataset,
-        fraction_map: dict[int, list[tuple[int, int, float]]],
-    ) -> pd.DataFrame:
-        """
-        Get dynamic meteo per basin
-
-        Function takes meteo information and extracts the required timeseries per basin, taking into account which
-        cells are covered by the basin using the fraction_map argument.
-        """
-        time = precip["time"].values
-        startdate_dt = np.datetime64(startdate)
-        enddate_dt = np.datetime64(enddate)
-        mask = (time >= startdate_dt) & (time <= enddate_dt)
-        time_indices = np.where(mask)[0]
-
-        precip_data = precip["P"].isel(time=slice(time_indices[0], time_indices[-1] + 1)).load().data
-        evp_data = evp["Evaporation"].isel(time=slice(time_indices[0], time_indices[-1] + 1)).load().data
-
-        selected_time = time[mask]
-        evap_factors = _open_water_factor(selected_time)
-
-        means: dict[int, dict[str, list[float]]] = {}
-        for node_id, pixels in tqdm.tqdm(fraction_map.items(), desc="Extracting meteo per basin"):
-            means[node_id] = {}
-            if len(pixels) == 0:
-                means[node_id]["prec"] = [np.nan] * len(time_indices)
-                means[node_id]["evp"] = [np.nan] * len(time_indices)
-                continue
-            values_P = np.stack([precip_data[:, row, col] for row, col, _ in pixels], axis=1)
-            values_ET = np.stack([evp_data[:, row, col] for row, col, _ in pixels], axis=1)
-            weights = np.array([frac for _, _, frac in pixels])
-
-            averaged_P_ms = np.average(values_P, axis=1, weights=weights) / 86400 / 1000
-            averaged_ET_ms = np.average(values_ET, axis=1, weights=weights) / 86400 / 1000 * evap_factors
-
-            means[node_id]["prec"] = averaged_P_ms.tolist()
-            means[node_id]["evp"] = averaged_ET_ms.tolist()
-
-        # Convert into the right pd.DataFrame format to add to the model
-        # pyrefly: ignore[bad-argument-type]
-        full_time_df = self._combine_meteo_into_df(means, startdate_dt, enddate_dt)
-        print("Converted the meteo data to a pd.DataFrame")
-        return full_time_df
-
-    def _combine_meteo_into_df(
-        self,
-        meteo_per_node: dict[int, dict[str, list[float]]],
-        start_date: "str | np.datetime64[int | None]",
-        end_date: "str | np.datetime64[int | None]",
-    ) -> pd.DataFrame:
-        """
-        Convert a dict with meteo info to a pd.Dataframe
-
-        Function converts a given dictionary with timeseries per basin to a proper dataframe that can be used
-        as input to Ribasim models.
-        """
-        meteo_dataframe = {nodeid: pd.DataFrame(v) for nodeid, v in meteo_per_node.items()}
-        list_of_dfs = []
-        for nodeid, df in meteo_dataframe.items():
-            df["time"] = pd.date_range(start_date, end_date)
-            df["node_id"] = nodeid
-            list_of_dfs.append(df)
-        full_time_df = pd.concat(list_of_dfs, ignore_index=True)
-        full_time_df.rename(columns={"evp": "potential_evaporation", "prec": "precipitation"}, inplace=True)
-        return full_time_df
 
     def _add_meteo_to_model(self, meteo_means: pd.DataFrame) -> Model:
         """


### PR DESCRIPTION
## Fix budget assignment for basins without a secondary counterpart

Closes #461 — Drainage fluxes polder

### Problem
In water authorities where some basins only have a primary classification (no
secondary/bergend basin exists at that location), the budget assignment would
silently fail — those primary basins would be dropped from the secondary budget
calculation entirely.

### Changes

#### `_transpose_basin_definition_polygons()` / `_split_basin_definitions()`
For cases where a primary basin has no matching secondary basin:
1. The primary basin is **kept in the primary budget analysis** (no longer dropped)
2. The primary basin geometry is **added to the secondary basin definition**, so
   secondary budgets are also rasterized and assigned using the primary polygon
   geometry

#### `plot_assign_validation()` (new public method on `AssignOfflineBudgets`)
Adds a 2×5 diagnostic plot to visually verify the budget assignment:
- **Row 0:** original basin polygon inputs + budget grids coloured by `node_id`
- **Row 1:** rasterization inputs + red/green assignment check grids
  (🟢 green = assigned, 🔴 red = missed)

Useful for diagnosing cases like #461 where budget cells fall outside any basin
polygon.

### Usage
```python
assign = AssignOfflineBudgets(zarr_path)
assign.plot_assign_validation(model_path, path="control_plot.png")