### PR TITLE
Repair profiles

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1290,13 +1290,13 @@ stages:
     deps:
     - path: src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
       hash: md5
-      md5: f4a4086de19ced4bed5d65b97b7a3f9a
-      size: 18742
+      md5: d90f497dae88eb11d6654889b268dbcd
+      size: 19731
     outs:
     - path: data/Delfland/modellen/Delfland_parameterized
       hash: md5
-      md5: fa2f8fea0ac69e02cf7c619dbd88f6bb.dir
-      size: 10879157
+      md5: d3afc4bae184188e40fe510be4ee4b9f.dir
+      size: 12402869
       nfiles: 2
   peilbeheerst@amstel_gooi_en_vecht:
     cmd:

--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -277,6 +277,8 @@ ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] =
 
 ribasim_model.basin.area.df["meta_streefpeil"] = ribasim_model.basin.area.df["meta_streefpeil"].astype(float)
 
+ribasim_param.clean_tables(ribasim_model, waterschap)
+
 # set basin profiles and add storing basins where applicable
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=100)
 

--- a/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/AmstelGooienVecht_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -287,11 +288,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -247,6 +247,7 @@ for splitted_basin_path, basin_id in zip(
 
 node_cache.set_meta_category(ribasim_model)
 ribasim_model.write(ribasim_work_dir_model_toml)
+del node_cache
 
 # set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud)  # , min_area=100

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -257,11 +258,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Delfland_parametrize.py
@@ -19,7 +19,7 @@ from ribasim_nl.control import (
     set_node_functions,
 )
 from ribasim_nl.profiles import implement
-from ribasim_nl.split_basins import SplitBasins
+from ribasim_nl.split_basins import NodeMetaCache, SplitBasins
 from shapely import Point
 
 from peilbeheerst_model import supply
@@ -234,6 +234,8 @@ ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 
 ribasim_param.clean_tables(ribasim_model, waterschap)
 
+# split large basins: "boezems"
+node_cache = NodeMetaCache(ribasim_model)
 for splitted_basin_path, basin_id in zip(
     [splitted_basin_2_path, splitted_basin_9_path, splitted_basin_10_path], [2, 9, 10], strict=True
 ):
@@ -243,19 +245,11 @@ for splitted_basin_path, basin_id in zip(
     )
     ribasim_model = splitter.run()
 
+node_cache.set_meta_category(ribasim_model)
 ribasim_model.write(ribasim_work_dir_model_toml)
 
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud)  # , min_area=100
-
-# Migrate meta_categorie from the state to the node table as this prior is completely filled
-basin_node_mask = ribasim_model.node.df["node_type"] == "Basin"
-basin_node_meta = ribasim_model.node.df.loc[basin_node_mask, []].merge(
-    ribasim_model.basin.state.df[["node_id", "meta_categorie"]],
-    left_index=True,
-    right_on="node_id",
-    how="left",
-)
-ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.set_index("node_id")["meta_categorie"]
 
 # set forcing
 if DYNAMIC_CONDITIONS:
@@ -435,8 +429,7 @@ ribasim_model.pump.static.df.loc[
 
 # Manning resistance
 # there is a MR without geometry and without links for some reason
-mr_null_geom = ribasim_model.manning_resistance.node.df[ribasim_model.manning_resistance.node.df.geometry.isna()].index
-ribasim_model.node.df = ribasim_model.node.df.drop(mr_null_geom)
+ribasim_model.node.df = ribasim_model.node.df.dropna(subset="geometry")
 # lower the difference in waterlevel for each manning node
 ribasim_model.manning_resistance.static.df["length"] = 100.0
 ribasim_model.manning_resistance.static.df["manning_n"] = 0.01

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -267,11 +268,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandsNoorderkwartier_parametrize.py
@@ -20,7 +20,7 @@ from ribasim_nl.control import (
     set_node_functions,
 )
 from ribasim_nl.profiles import implement
-from ribasim_nl.split_basins import SplitBasins
+from ribasim_nl.split_basins import NodeMetaCache, SplitBasins
 from shapely import Point
 
 from peilbeheerst_model import supply
@@ -242,11 +242,14 @@ ribasim_param.FlowBoundaries_to_LevelBoundaries(ribasim_model=ribasim_model, def
 ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 
 # split basins to improve model convergence
+node_cache = NodeMetaCache(ribasim_model)
 splitter = SplitBasins(model=ribasim_model, splitted_basin_path=splitted_basin_3_path, basin_node_id_to_split=3)
 ribasim_model = splitter.run()
-
+node_cache.set_meta_category(ribasim_model)
 ribasim_model.write(ribasim_work_dir_model_toml)
+del node_cache
 
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10)
 
 # Migrate meta_categorie from the state to the node table as this prior is completely filled

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -679,11 +680,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/HollandseDelta_parametrize.py
@@ -669,6 +669,9 @@ ribasim_model.basin.area.df.loc[ribasim_model.basin.area.df["meta_streefpeil"] =
     unknown_streefpeil
 )
 
+ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=10)
 
 # set forcing

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -205,16 +205,6 @@ del node_cache
 # set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 
-# Migrate meta_categorie from the state to the node table as this prior is completely filled
-basin_node_mask = ribasim_model.node.df["node_type"] == "Basin"
-basin_node_meta = ribasim_model.node.df.loc[basin_node_mask, []].merge(
-    ribasim_model.basin.state.df[["node_id", "meta_categorie"]],
-    left_index=True,
-    right_on="node_id",
-    how="left",
-)
-ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.set_index("node_id")["meta_categorie"]
-
 # set forcing
 if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -20,7 +20,7 @@ from ribasim_nl.control import (
     set_node_functions,
 )
 from ribasim_nl.profiles import implement
-from ribasim_nl.split_basins import SplitBasins
+from ribasim_nl.split_basins import NodeMetaCache, SplitBasins
 from shapely import Point
 
 from peilbeheerst_model import supply
@@ -185,8 +185,10 @@ ribasim_param.FlowBoundaries_to_LevelBoundaries(ribasim_model=ribasim_model, def
 
 # add outlet
 ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
+ribasim_param.clean_tables(ribasim_model, waterschap)
 
 # loop through all splitted basins
+node_cache = NodeMetaCache(ribasim_model)
 for splitted_basin_path, basin_id in zip(
     [splitted_basin_1_path, splitted_basin_15_path, splitted_basin_22_path], [1, 15, 22], strict=True
 ):
@@ -196,8 +198,11 @@ for splitted_basin_path, basin_id in zip(
     )
     ribasim_model = splitter.run()
 
+node_cache.set_meta_category(ribasim_model)
 ribasim_model.write(ribasim_work_dir_model_toml)
+del node_cache
 
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 
 # Migrate meta_categorie from the state to the node table as this prior is completely filled

--- a/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rijnland_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -210,11 +211,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -6,6 +6,7 @@ import warnings
 import geopandas as gpd
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import shapely
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -423,11 +424,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Rivierenland_parametrize.py
@@ -413,6 +413,9 @@ ribasim_model.node.df.loc[ribasim_model.tabulated_rating_curve.node.df.index, "m
 )
 ribasim_model.node.df.loc[ribasim_model.pump.node.df.index, "meta_node_id"] = ribasim_model.pump.node.df.index
 
+ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 
 # set forcing

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -203,11 +204,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Scheldestromen_parametrize.py
@@ -193,6 +193,9 @@ for node_type in ["LevelBoundary", "TabulatedRatingCurve", "Pump"]:
     mask = ribasim_model.node.df["node_type"] == node_type
     ribasim_model.node.df.loc[mask, "meta_node_id"] = ribasim_model.node.df.loc[mask].index
 
+ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 
 # set forcing

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -354,11 +355,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/SchielandendeKrimpenerwaard_parametrize.py
@@ -344,7 +344,9 @@ ribasim_param.validate_basin_area(ribasim_model)
 # check target levels at manning nodes
 ribasim_param.validate_manning_basins(ribasim_model)
 
-# TODO: Replace standard profile by determined profiles (and add storing basins where applicable)
+ribasim_param.clean_tables(ribasim_model, waterschap)
+
+# set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 
 # set forcing

--- a/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
@@ -5,6 +5,7 @@ import warnings
 
 import geopandas as gpd
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -525,11 +526,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/WetterskipFryslan_parametrize.py
@@ -21,7 +21,7 @@ from ribasim_nl.control import (
     set_node_functions,
 )
 from ribasim_nl.profiles import implement
-from ribasim_nl.split_basins import SplitBasins
+from ribasim_nl.split_basins import NodeMetaCache, SplitBasins
 from shapely import Point
 
 from peilbeheerst_model import supply
@@ -498,7 +498,10 @@ ribasim_param.FlowBoundaries_to_LevelBoundaries(ribasim_model=ribasim_model, def
 # add outlet
 ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 
+ribasim_param.clean_tables(ribasim_model, waterschap)
+
 # loop through all splitted basins
+node_cache = NodeMetaCache(ribasim_model)
 for splitted_basin_path, basin_id in zip(
     [splitted_basin_6_path, splitted_basin_16_path, splitted_basin_21_path], [6, 16, 21], strict=True
 ):
@@ -508,21 +511,14 @@ for splitted_basin_path, basin_id in zip(
     )
     ribasim_model = splitter.run()
 
+node_cache.set_meta_category(ribasim_model)
 ribasim_model.write(ribasim_work_dir_model_toml)
+del node_cache
 
+# set basin profiles
 ribasim_model.use_validation = True
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
 ribasim_model.write(ribasim_work_dir_model_toml)
-
-# Migrate meta_categorie from the state to the node table as this prior is completely filled
-basin_node_mask = ribasim_model.node.df["node_type"] == "Basin"
-basin_node_meta = ribasim_model.node.df.loc[basin_node_mask, []].merge(
-    ribasim_model.basin.state.df[["node_id", "meta_categorie"]],
-    left_index=True,
-    right_on="node_id",
-    how="left",
-)
-ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.set_index("node_id")["meta_categorie"]
 
 # set forcing
 if DYNAMIC_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -19,7 +19,7 @@ from ribasim_nl.control import (
     set_node_functions,
 )
 from ribasim_nl.profiles import implement
-from ribasim_nl.split_basins import SplitBasins
+from ribasim_nl.split_basins import NodeMetaCache, SplitBasins
 from shapely import Point
 
 from ribasim_nl import CloudStorage, Model, SetDynamicForcing, settings
@@ -556,6 +556,7 @@ ribasim_param.add_outlets(ribasim_model, delta_crest_level=0.10)
 ribasim_param.clean_tables(ribasim_model, waterschap)
 
 # loop through all splitted basins
+node_cache = NodeMetaCache(ribasim_model)
 for splitted_basin_path, basin_id in zip(
     [splitted_basin_16_path, splitted_basin_31_path, splitted_basin_73_path], [16, 31, 73], strict=True
 ):
@@ -565,20 +566,12 @@ for splitted_basin_path, basin_id in zip(
     )
     ribasim_model = splitter.run()
 
+node_cache.set_meta_category(ribasim_model)
 ribasim_model.write(ribasim_work_dir_model_toml)
+del node_cache
 
 # set basin profiles
 implement.set_basin_profiles(ribasim_model, waterschap, cloud=cloud, min_area=1000)
-
-# Migrate meta_categorie from the state to the node table as this prior is completely filled
-basin_node_mask = ribasim_model.node.df["node_type"] == "Basin"
-basin_node_meta = ribasim_model.node.df.loc[basin_node_mask, []].merge(
-    ribasim_model.basin.state.df[["node_id", "meta_categorie"]],
-    left_index=True,
-    right_on="node_id",
-    how="left",
-)
-ribasim_model.node.df.loc[basin_node_mask, "meta_categorie"] = basin_node_meta.set_index("node_id")["meta_categorie"]
 
 # set forcing
 if DYNAMIC_CONDITIONS:

--- a/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
+++ b/src/peilbeheerst_model/Parametrize/Zuiderzeeland_parametrize.py
@@ -4,6 +4,7 @@ import datetime
 import warnings
 
 import peilbeheerst_model.ribasim_parametrization as ribasim_param
+import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
 from peilbeheerst_model.controle_output import Control
@@ -578,11 +579,12 @@ if DYNAMIC_CONDITIONS:
     # Add dynamic meteo and groundwater from LHM zarr
     lhm_budget_path = cloud.joinpath("Basisgegevens/LHM/4.3/results/LHM_433_budgets_update")
     cloud.synchronize(filepaths=[lhm_budget_path], overwrite=False)
-    offline_budgets = AssignOfflineBudgets(lhm_budget_path)
+    budgets = xr.open_zarr(str(lhm_budget_path)).sel(time=slice(starttime, endtime))
+    offline_budgets = AssignOfflineBudgets(budgets)
 
     forcing = SetDynamicForcing(
         model=ribasim_model,
-        budgets=offline_budgets.budgets,
+        budgets=budgets,
         startdate=starttime,
         enddate=endtime,
     )

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -2446,7 +2446,8 @@ def clean_tables(ribasim_model: Model, waterschap: str) -> None:
 
     # add category in the .node table
     if "meta_categorie" in ribasim_model.node.df.columns:
-        return  # skip column creation if already present
+        # return  # skip column creation if already present
+        ribasim_model.node.df = ribasim_model.node.df.drop(columns=["meta_categorie"])
 
     basin_node = ribasim_model.basin.node.df.merge(
         right=ribasim_model.basin.state.df[["node_id", "meta_categorie"]],

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -2444,7 +2444,10 @@ def clean_tables(ribasim_model: Model, waterschap: str) -> None:
 
     # section below as asked by D2HYDRO
 
-    # #add category in the .node table
+    # add category in the .node table
+    if "meta_categorie" in ribasim_model.node.df.columns:
+        return  # skip column creation if already present
+
     basin_node = ribasim_model.basin.node.df.merge(
         right=ribasim_model.basin.state.df[["node_id", "meta_categorie"]],
         how="left",

--- a/src/peilbeheerst_model/profiles/gen_profiles.py
+++ b/src/peilbeheerst_model/profiles/gen_profiles.py
@@ -161,9 +161,8 @@ def _sync(cloud: CloudStorage, water_authority: str, overwrite: bool, *extra_fil
     cloud.download_verwerkt(water_authority, overwrite=overwrite)
     cloud.download_basisgegevens(["Hydrotypen"], overwrite=overwrite)
     for f in extra_file:
-        if f is None:
-            continue
-        cloud.download_file(cloud.joinurl(water_authority, f))
+        if f is not None:
+            cloud.download_file(cloud.joinurl(water_authority, f))
     print(f"\rSynced with the GoodCloud: {water_authority}")
 
 
@@ -175,9 +174,14 @@ def _read_basins(cloud: CloudStorage, water_authority: str) -> gpd.GeoDataFrame:
 
     :return: basin dataset (polygons)
     """
+    # read data
     fn = cloud.joinpath(water_authority, "modellen", f"{water_authority}_parameterized", "input", "database.gpkg")
-    gdf = gpd.read_file(fn, layer="Basin / area")
-    return gdf[gdf["node_id"] == gdf["meta_node_id"]]
+    nodes = gpd.read_file(fn, layer="Node", fid_as_index=True, use_arrow=True)
+    basins = gpd.read_file(fn, layer="Basin / area")
+
+    # exclude storing basins
+    non_storing = nodes[nodes["meta_categorie"] != "bergend"].index
+    return basins[basins["node_id"].isin(non_storing)]
 
 
 def _read_cross_sections(cloud: CloudStorage, water_authority: str) -> gpd.GeoDataFrame:

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -534,6 +534,9 @@ class AssignOfflineBudgets:
 
             nodes = nodes.join(df_cat, how="left").reset_index(drop=False)
 
+        # TODO: fix upstream - some basin nodes have NaN in meta_categorie; they won't be assigned offline forcing
+        nodes = nodes.dropna(subset=[basin_metacol])
+
         self._validate_meta_basin_column(nodes, basin_metacol, expected_values=primary_values | secondary_values)
 
         # split based on meta_label in Ribasim model definition

--- a/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
+++ b/src/ribasim_nl/ribasim_nl/assign_offline_budgets.py
@@ -118,7 +118,7 @@ class AssignOfflineBudgets:
         self,
         model: Model | Path | str,
         basin_split: str = "area",
-        basin_subtype: str = "state",
+        basin_subtype: str = "node",
         basin_metacol: str = "meta_categorie",
         primary_values: set[str] | None = None,
         secondary_values: set[str] | None = None,
@@ -165,7 +165,7 @@ class AssignOfflineBudgets:
         basin_split : str, optional
             Table to split basins, by default "area"
         basin_subtype : str, optional
-            optional table to find basin_metacol if not in node-table, by default "state"
+            optional table to find basin_metacol if not in node-table, by default "node"
         basin_metacol : str, optional
             colomn to contain primary and secondary values, by default "meta_categorie"
         primary_values: set[str]
@@ -485,7 +485,7 @@ class AssignOfflineBudgets:
         self,
         ribasim_model: Model,
         basin_split: str = "area",
-        basin_subtype: str = "state",
+        basin_subtype: str = "node",
         basin_metacol: str = "meta_categorie",
         primary_values: set[str] | None = None,
         secondary_values: set[str] | None = None,
@@ -499,7 +499,7 @@ class AssignOfflineBudgets:
         basin_split : str, optional
             Table to be splitted, by default "area"
         basin_subtype : str, optional
-            subtype to optionally read basin_metacol from, by default "state"
+            subtype to optionally read basin_metacol from, by default "node"
         basin_metacol : str, optional
             column with category, by default "meta_categorie"
         basin_primary : str, optional

--- a/src/ribasim_nl/ribasim_nl/profiles/implement.py
+++ b/src/ribasim_nl/ribasim_nl/profiles/implement.py
@@ -190,7 +190,7 @@ def set_basin_profiles(ribasim_model: Model, water_authority: str, **kwargs) -> 
     ribasim_model.basin.profile.df = _profiles.sort_values(["node_id", "level"], ignore_index=True).combine_first(  # pyrefly: ignore[bad-assignment]
         _basin_profile.sort_values(["node_id", "level"], ignore_index=True)
     )[_basin_profile.columns]
-    del _basin_profile
+    del _basin_profile, _profiles
 
     # duplicate all basin-tables
     basin_node = ribasim_model.basin.node.df

--- a/src/ribasim_nl/ribasim_nl/profiles/implement.py
+++ b/src/ribasim_nl/ribasim_nl/profiles/implement.py
@@ -216,6 +216,7 @@ def set_basin_profiles(ribasim_model: Model, water_authority: str, **kwargs) -> 
 
     # basin state category ('bergend')
     basin_state["meta_categorie"] = "bergend"
+    basin_node["meta_categorie"] = "bergend"
 
     # move storing basins' location and set Manning's node location
     basin_node["flowing_geometry"] = basin_node["geometry"].copy()

--- a/src/ribasim_nl/ribasim_nl/profiles/run.py
+++ b/src/ribasim_nl/ribasim_nl/profiles/run.py
@@ -18,7 +18,6 @@ LOG = logging.getLogger(__name__)
 _KNOWN_KWARGS: set[str] = {
     "debug",
     "epsg",
-    "filter_basins",
     "target_levels",
     "create_depth_profile_lines",
     "kw_make_depth_profile",
@@ -155,7 +154,6 @@ def main(
     # optional arguments
     debug: bool = kwargs.get("debug", False)
     epsg: int = kwargs.get("epsg", 28992)
-    filter_basins: bool = kwargs.get("filter_basins", True)
     # > target levels
     target_levels: gpd.GeoDataFrame = kwargs.get("target_levels", data[0])
     # > generation of depth profile lines
@@ -203,14 +201,6 @@ def main(
     if main_route_from_hydro_objects:
         assert col_ho_main_route is not None
         _validate_hydro_objects_main_routing(hydro_objects, col_ho_main_route, val_ho_main_route)
-
-    # filter basins
-    if filter_basins:
-        basins = basins[basins["node_id"] == basins["meta_node_id"]]
-
-    # filter basins
-    if filter_basins:
-        basins = basins[basins["node_id"] == basins["meta_node_id"]]
 
     # creating depth profile-lines
     if create_depth_profile_lines and cross_sections is not None:

--- a/src/ribasim_nl/ribasim_nl/split_basins.py
+++ b/src/ribasim_nl/ribasim_nl/split_basins.py
@@ -294,3 +294,33 @@ class SplitBasins:
             rows = table.df.loc[table.df.node_id == original_node_id].copy()
             rows["node_id"] = new_node_id
             table.df = pd.concat([table.df, rows], ignore_index=True)  # pyrefly: ignore[bad-assignment]
+
+
+class NodeMetaCache:
+    """Caching of 'meta_categorie'-data"""
+
+    def __init__(self, model: Model):
+        """Store the 'meta_categorie' as a series (node ID as index)."""
+        self.meta_category = self.get_meta_category(model)
+
+    @staticmethod
+    def get_meta_category(model: Model) -> pd.Series:
+        """Get the 'meta_categorie'-data."""
+        assert model.node.df is not None
+        nodes = model.node.df.copy(deep=True)
+        return nodes["meta_categorie"]
+
+    def set_meta_category(self, model: Model, fill_nan: bool = True) -> Model:
+        """(Re)set the 'meta_category'-data.
+
+        Optionally set all non-cached 'meta_categorie'-data to 'doorgaand' (default).
+        """
+        assert model.node.df is not None
+        nodes = model.node.df
+        nodes["meta_categorie"] = self.meta_category.copy(deep=True)
+        if fill_nan:
+            nodes.loc[nodes["node_type"] == "Basin", "meta_categorie"] = nodes.loc[
+                nodes["node_type"] == "Basin", "meta_categorie"
+            ].fillna("doorgaand")
+        model.node.df = nodes.copy()  # pyrefly: ignore[bad-assignment]
+        return model


### PR DESCRIPTION
Crash(es) as described in #584 resulted from two different model changes:
1. The profile-generator filtered storing basins by flagging them based on `node_id != meta_node_id`, which used to be a proxy for storing basins. However, the addition of basin-splitting (#582) resulted in the new basins - non-storing - to have the same mismatch, i.e., `node_id != meta_node_id`. Instead, the `"meta_categorie"`-column in the `Node`-table will be used to flag storing basins.
2. The use of the `"meta_categorie"`-column of the `Node`-table resulted in a heavy reliance on this data, which was wrongly processed when the `clean_tables()`-function was called twice within the same parametrisation-script. This issue has been resolved as well by removing the `"meta_categorie"`-column before (re)defining it; otherwise, duplicates would be generated (namely `"meta_categorie_x"`- and `"meta_categorie_y"`-columns).

This `PR` fixes #584.