### PR TITLE
Fix `ribasim_nl_data_dir` to `./data`

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,5 +1,4 @@
 RIBASIM_HOME='bin/ribasim'
 D3D_HOME='c:/Program Files/Deltares/D-HYDRO Suite 2026.01 1D2D/plugins/DeltaShell.Dimr/kernels/x64'
-RIBASIM_NL_DATA_DIR='data'
 RIBASIM_NL_CLOUD_PASS=''
 OVERWRITE_FILES_FROM_CLOUD='true'

--- a/docs/cloudstorage.qmd
+++ b/docs/cloudstorage.qmd
@@ -11,10 +11,9 @@ For the API docs, see the [CloudStorage reference](reference/CloudStorage.qmd).
 
 Before you can interact with the cloud storage, you need to configure the access.
 The section on [environment variables](/dev/index.qmd#sec-environment-variables) documents how to do this.
-The two relevant variables here are:
+The relevant variable here is:
 
 - `RIBASIM_NL_CLOUD_PASS`: password for the cloud, to be requested at Deltares
-- `RIBASIM_NL_DATA_DIR`: directory with your local copy of data in the Ribasim-NL cloud
 
 The password can currently only be shared among project collaborators since not all input data is public.
 The output models, both nationwide (folder Rijkswaterstaat) and per water board, are public.

--- a/docs/dev/index.qmd
+++ b/docs/dev/index.qmd
@@ -101,7 +101,6 @@ Several settings need to be configured via environment variables, managed by [py
 | `ribasim_home` | `RIBASIM_HOME` | Root of the Ribasim core installation |
 | `d3d_home` | `D3D_HOME` | Root of the Delft3D installation |
 | `ribasim_nl_cloud_pass` | `RIBASIM_NL_CLOUD_PASS` | Password for [cloud storage](/cloudstorage.qmd) access |
-| `ribasim_nl_data_dir` | `RIBASIM_NL_DATA_DIR` | Local directory for data files |
 | `overwrite_files_from_cloud` | `OVERWRITE_FILES_FROM_CLOUD` | Whether cloud downloads overwrite local files |
 
 In the root of the repository is a `.env.default` file with the defaults that can serve as a template.

--- a/notebooks/koppelen_modellen.py
+++ b/notebooks/koppelen_modellen.py
@@ -7,7 +7,7 @@ import geopandas as gpd
 import pandas as pd
 from networkx import NetworkXNoPath
 from ribasim_nl.aquo import waterbeheercode
-from ribasim_nl.settings import settings
+from ribasim_nl.settings import data_dir
 from shapely.geometry import LineString, Point
 from tqdm import tqdm
 
@@ -23,7 +23,6 @@ SNAP_DISTANCE = 20
 MIN_LEVEL_DIFF = 0.04  # Minimum level difference for the control
 MIN_BASIN_OUTLET_DIFF = 0.5
 # Configuration
-data_dir = settings.ribasim_nl_data_dir
 
 remove_nodes = [
     3401752,  # Dokwerd NZV

--- a/notebooks/nl-kunstwerken.py
+++ b/notebooks/nl-kunstwerken.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 import requests
+from ribasim_nl.settings import data_dir
 from shapely.geometry import Point
 
 from ribasim_nl import settings
@@ -16,7 +17,7 @@ from ribasim_nl import settings
 
 
 # environment variables
-DATA_DIR = settings.ribasim_nl_data_dir
+DATA_DIR = data_dir
 RIBASIM_NL_CLOUD_PASS = settings.ribasim_nl_cloud_pass
 
 EXCEL_FILE = r"# Overzicht kunstwerken primaire keringen waterschappen_ET.xlsx"

--- a/notebooks/ribasim_delwaq/ER_to_delwaq/ER_data_conversion_delwaq.py
+++ b/notebooks/ribasim_delwaq/ER_to_delwaq/ER_data_conversion_delwaq.py
@@ -21,13 +21,13 @@ geinterpoleerd. 3.emissieoorzaken zonder detail. Hierbij zijn alleen de ER steek
 bekend en wordt er tussen deze jaren geinterpoleerd.
 """
 
-import os
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 from ER_GAF_fractions_func import compute_overlap_df
+from ribasim_nl.settings import data_dir
 
 conv_yr2sec = 60 * 60 * 24 * 365.25
 conv_kg2g = 1000
@@ -181,7 +181,7 @@ schematisatie = "Ribasim-NL"  # $ was 'LKM25', moet nieuwe bestandstructuur kome
 inputdir = (
     "P:/krw-verkenner/01_landsdekkende_schematisatie/LKM25 schematisatie/OverigeEmissies/KRW_Tussenevaluatie_2024/"
 )
-model_path = Path(os.environ["RIBASIM_NL_DATA_DIR"]) / "DeDommel/modellen/DeDommel_2025_7_0"
+model_path = data_dir / "DeDommel/modellen/DeDommel_2025_7_0"
 basin_node_path = model_path / "database.gpkg"
 
 # -------------------------------Import data------------------------------------

--- a/notebooks/ribasim_delwaq/ER_to_delwaq/README.md
+++ b/notebooks/ribasim_delwaq/ER_to_delwaq/README.md
@@ -15,7 +15,7 @@ The conversion script `ER_data_conversion_delwaq.py` is an adaptation of:
 
 1. **Download Ribasim model** via `notebooks/rwzi/add_rwzi_model.py`
 
-   Ensure that the environment variable `RIBASIM_NL_DATA_DIR` is used as the location
+   The model data is located in the `data` directory at the root of the repository.
 
 2. **Run Ribasim model** for the desired period (can be short for tests)
 

--- a/notebooks/samenvoegen_modellen.py
+++ b/notebooks/samenvoegen_modellen.py
@@ -3,12 +3,11 @@ from pathlib import Path
 from typing import Any
 
 from ribasim_nl.aquo import waterbeheercode
-from ribasim_nl.settings import settings
+from ribasim_nl.settings import data_dir
 
 from ribasim_nl import Model, concat, prefix_index
 
 # %%
-data_dir = settings.ribasim_nl_data_dir
 
 # Write intermediate models for debugging or scaling tests
 write_intermediate_models: bool = False

--- a/notebooks/uitlaten_inlaten.py
+++ b/notebooks/uitlaten_inlaten.py
@@ -5,6 +5,7 @@ import fiona
 import geopandas as gpd
 import pandas as pd
 import requests
+from ribasim_nl.settings import data_dir
 from shapely.geometry import Point
 
 from hydamo import HyDAMO, code_utils
@@ -22,10 +23,9 @@ warnings.simplefilter("ignore", UserWarning)
 
 
 # environment variables
-DATA_DIR = settings.ribasim_nl_data_dir
+DATA_DIR = data_dir
 RIBASIM_NL_CLOUD_PASS = settings.ribasim_nl_cloud_pass
 
-DATA_DIR = Path(DATA_DIR)
 EXCEL_FILE = r"uitlaten_inlaten.xlsx"
 CRS = 28992
 RIBASIM_NL_CLOUD_USER = "nhi_api"

--- a/src/peilbeheerst_model/02_crossings_to_ribasim_notebook.py
+++ b/src/peilbeheerst_model/02_crossings_to_ribasim_notebook.py
@@ -2,10 +2,11 @@ from pathlib import Path
 
 import pandas as pd
 from peilbeheerst_model.crossings_to_ribasim import CrossingsToRibasim, RibasimNetwork
+from ribasim_nl.settings import data_dir
 
-from ribasim_nl import Model, settings
+from ribasim_nl import Model
 
-base_path = settings.ribasim_nl_data_dir
+base_path = data_dir
 
 # # Amstel, Gooi en Vecht
 model_characteristics = {
@@ -809,7 +810,7 @@ network.WriteResults(model=model, checks=checks)
 # # Wetterskip
 # %%
 authority = "WetterskipFryslan"
-base_path = settings.ribasim_nl_data_dir
+base_path = data_dir
 
 model_characteristics = {
     # model description

--- a/src/peilbeheerst_model/Shortest_path/08_shortest_path_Wetterskip.py
+++ b/src/peilbeheerst_model/Shortest_path/08_shortest_path_Wetterskip.py
@@ -15,10 +15,11 @@ import numpy as np
 import pandas as pd
 import shapely
 import tqdm.auto as tqdm
+from ribasim_nl.settings import data_dir
 from shapely.geometry import LineString, Point
 from shapely.wkt import dumps
 
-from ribasim_nl import CloudStorage, geometry, settings
+from ribasim_nl import CloudStorage, geometry
 
 cloud = CloudStorage()
 # ### Load Data
@@ -28,7 +29,7 @@ waterschap = "WetterskipFryslan"
 
 # Define crossings file path
 data_path = cloud.joinpath(waterschap, "verwerkt/Crossings/wetterskip_crossings_v06.gpkg")
-base_path = settings.ribasim_nl_data_dir
+base_path = data_dir
 output_path = f"{waterschap}/verwerkt/Data_shortest_path/Wetterskip_shortest_path.gpkg"
 output_path = Path(base_path) / output_path  # add the base path
 
@@ -404,7 +405,7 @@ for index, rhws in tqdm.tqdm(gdf_rhws.iterrows(), total=len(gdf_rhws), colour="b
         plt_paths.plot(ax=ax, color="purple", label="shortest paths")
         ax.legend()
         path_figs = (
-            settings.ribasim_nl_data_dir
+            data_dir
             / "WetterskipFryslan/verwerkt/Data_shortest_path/Figures/shortest_path_{waterschap}_RHWS_{index}_new"
         )
         plt.savefig(
@@ -436,8 +437,7 @@ for index, rhws in tqdm.tqdm(gdf_rhws.iterrows(), total=len(gdf_rhws), colour="b
         for key, value in objects.items():
             # For each GeoDataFrame, save it to a layer in the GeoPackage
             path_gpkg = (
-                settings.ribasim_nl_data_dir
-                / "WetterskipFryslan/Data_shortest_path/Geopackages/{waterschap}_unconnected_{index}.gpkg"
+                data_dir / "WetterskipFryslan/Data_shortest_path/Geopackages/{waterschap}_unconnected_{index}.gpkg"
             )
             value.to_file(
                 # f"./shortest_path/Geopackages/{waterschap}_unconnected_{index}.gpkg", layer=key, driver="GPKG"

--- a/src/peilbeheerst_model/peilbeheerst_model/crossings_to_ribasim.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/crossings_to_ribasim.py
@@ -7,10 +7,11 @@ import numpy as np
 import pandas as pd
 import ribasim
 from bokeh.palettes import Category10
+from ribasim_nl.settings import data_dir
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon
 from shapely.wkt import loads
 
-from ribasim_nl import CloudStorage, Model, settings
+from ribasim_nl import CloudStorage, Model
 
 
 class CrossingsToRibasim:
@@ -1835,7 +1836,7 @@ class RibasimNetwork:
         checks : _type_
             _description_
         """
-        dir_path = settings.ribasim_nl_data_dir
+        dir_path = data_dir
         dir_path = Path(dir_path) / self.model_characteristics["waterschap"]
 
         ##### write the model to the Z drive #####
@@ -1892,7 +1893,7 @@ class RibasimNetwork:
 
         ##### copy symbology for the Ribasim model #####
         if self.model_characteristics["write_symbology"]:
-            checks_symbology_path = settings.ribasim_nl_data_dir / "Basisgegevens/QGIS_qlr/visualisation_Ribasim.qlr"
+            checks_symbology_path = data_dir / "Basisgegevens/QGIS_qlr/visualisation_Ribasim.qlr"
             checks_symbology_path_new = (
                 Path(dir_path)
                 / "modellen"
@@ -1967,7 +1968,7 @@ class RibasimNetwork:
         if self.model_characteristics["write_symbology"]:
             # dont change the paths below!
 
-            checks_symbology_path = settings.ribasim_nl_data_dir / "Basisgegevens/QGIS_qlr/visualisation_checks.qlr"
+            checks_symbology_path = data_dir / "Basisgegevens/QGIS_qlr/visualisation_checks.qlr"
 
             checks_symbology_path_new = (
                 Path(dir_path)

--- a/src/peilbeheerst_model/peilbeheerst_model/parse_crossings.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/parse_crossings.py
@@ -13,9 +13,10 @@ import pandas as pd
 import pydantic
 import shapely.ops
 import tqdm.auto as tqdm
+from ribasim_nl.settings import data_dir
 from shapely.geometry import LineString, MultiLineString, MultiPoint, Point, Polygon
 
-from ribasim_nl import CloudStorage, settings
+from ribasim_nl import CloudStorage
 
 
 class ParseCrossings:
@@ -125,7 +126,7 @@ class ParseCrossings:
         self.disable_progress = disable_progress
 
         # read all layers of geopackage
-        base_path = settings.ribasim_nl_data_dir
+        base_path = data_dir
         gpkg_path = Path(base_path) / gpkg_path  # add the base path
         self.df_gpkg = {L: gpd.read_file(gpkg_path, layer=L) for L in fiona.listlayers(gpkg_path)}
 

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -18,11 +18,12 @@ import tqdm.auto as tqdm
 import xarray as xr
 from ribasim.nodes import continuous_control
 from ribasim_nl.case_conversions import pascal_to_snake_case
+from ribasim_nl.settings import data_dir
 from shapely.geometry import LineString, Point
 
 from peilbeheerst_model import supply
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
-from ribasim_nl import CloudStorage, Model, settings
+from ribasim_nl import CloudStorage, Model
 
 logger = logging.getLogger(__name__)
 
@@ -810,7 +811,7 @@ def write_ribasim_model_GoodCloud(ribasim_model, work_dir, waterschap, include_r
     Also clear the directory of modellen/parametereized, as there may be old results in it.
     The log file of the feedback form is not included to avoid cluttering.'
     """
-    destination_path = settings.ribasim_nl_data_dir / waterschap / "modellen" / f"{waterschap}_parameterized/"
+    destination_path = data_dir / waterschap / "modellen" / f"{waterschap}_parameterized/"
 
     # clear the modellen/parameterized dir
     if destination_path.exists():

--- a/src/ribasim_nl/ribasim_nl/__init__.py
+++ b/src/ribasim_nl/ribasim_nl/__init__.py
@@ -9,7 +9,7 @@ from ribasim_nl.network_validator import NetworkValidator
 from ribasim_nl.reset_index import prefix_index, reset_index
 from ribasim_nl.rwzi import merge_rwzi_model
 from ribasim_nl.set_forcing import SetDynamicForcing
-from ribasim_nl.settings import settings
+from ribasim_nl.settings import data_dir, settings
 from ribasim_nl.transboundary_inflow import add_transboundary_inflow, import_transboundary_inflow
 
 __all__ = [
@@ -20,6 +20,7 @@ __all__ = [
     "SetDynamicForcing",
     "add_transboundary_inflow",
     "concat",
+    "data_dir",
     "import_transboundary_inflow",
     "junctionify",
     "merge_rwzi_model",

--- a/src/ribasim_nl/ribasim_nl/cloud.py
+++ b/src/ribasim_nl/ribasim_nl/cloud.py
@@ -8,6 +8,7 @@ from xml.etree import ElementTree
 
 import requests
 
+from .settings import data_dir as _default_data_dir
 from .settings import settings
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ class ModelVersion:
 class CloudStorage:
     """Connect a local 'data_dir` to cloud-storage."""
 
-    data_dir: Path = settings.ribasim_nl_data_dir
+    data_dir: Path = _default_data_dir
     user: str = RIBASIM_NL_CLOUD_USER
     url: str = BASE_URL
     password: str = field(repr=False, default=settings.ribasim_nl_cloud_pass)
@@ -88,7 +89,7 @@ class CloudStorage:
 
         # check if data_dir is specified and convert to Path
         if self.data_dir is None:
-            raise ValueError("""'data_dir' is None. Provide it or set environment variable RIBASIM_NL_DATA_DIR.""")
+            raise ValueError("'data_dir' is None. Provide it.")
 
         self.data_dir = Path(self.data_dir)
 

--- a/src/ribasim_nl/ribasim_nl/settings.py
+++ b/src/ribasim_nl/ribasim_nl/settings.py
@@ -2,11 +2,12 @@ from pathlib import Path
 
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
+data_dir = Path(__file__).parents[3] / "data"
+
 
 class Settings(BaseSettings):
     ribasim_home: Path = Path("bin/ribasim")
     d3d_home: Path = Path("c:/Program Files/Deltares/D-HYDRO Suite 2026.01 1D2D/plugins/DeltaShell.Dimr/kernels/x64")
-    ribasim_nl_data_dir: Path = Path("data")
     ribasim_nl_cloud_pass: str = ""
     overwrite_files_from_cloud: bool = True
     minio_access_key: str = ""

--- a/src/ribasim_nl/tests/test_cloud.py
+++ b/src/ribasim_nl/tests/test_cloud.py
@@ -138,5 +138,4 @@ def test_settings():
     os.environ["RIBASIM_NL_CLOUD_PASS"] = "test"  # noqa: S105
     nsettings = Settings(_env_file="foo.env", ribasim_home=Path("custom_ribasim"))
     assert nsettings.ribasim_home == Path("custom_ribasim")
-    assert nsettings.ribasim_nl_data_dir == Path("data")
     assert nsettings.ribasim_nl_cloud_pass == "test"  # noqa: S105


### PR DESCRIPTION
This was already the case for a while. No need to make it configurable.

Now under `ribasim_nl.settings.data_dir`, or `ribasim_nl.data_dir`. Also now it is an absolute path, so the working directory no longer matters.