### PR TITLE
Split HWS stages, baseline in DVC

### DIFF
--- a/data/Basisgegevens/Baseline/baseline-nl_land-j23_6-v1/.gitignore
+++ b/data/Basisgegevens/Baseline/baseline-nl_land-j23_6-v1/.gitignore
@@ -1,0 +1,1 @@
+/baseline.gdb

--- a/data/Basisgegevens/Baseline/baseline-nl_land-j23_6-v1/baseline.gdb.dvc
+++ b/data/Basisgegevens/Baseline/baseline-nl_land-j23_6-v1/baseline.gdb.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: c9d11e2cab63ac8096c553a9b491c9c3.dir
+  size: 8081071635
+  nfiles: 215
+  hash: md5
+  path: baseline.gdb

--- a/data/Rijkswaterstaat/modellen/.gitignore
+++ b/data/Rijkswaterstaat/modellen/.gitignore
@@ -2,3 +2,4 @@
 /hws_transient
 /lhm_coupled
 /rwzi
+/hws_demand

--- a/dvc.lock
+++ b/dvc.lock
@@ -115,81 +115,6 @@ stages:
       md5: 028ef680db46a6c1b7e0e3f5425c17d3.dir
       size: 1242325174
       nfiles: 2
-  aa_en_maas:
-    cmd:
-    - pixi run python notebooks/aa_en_maas/01_fix_model.py
-    - pixi run python notebooks/aa_en_maas/02_prepare_model.py
-    - pixi run python notebooks/aa_en_maas/03_parameterize_model.py
-    - pixi run python notebooks/aa_en_maas/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py AaenMaas
-    - pixi run python notebooks/07_add_dynamic_forcing.py AaenMaas
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/aa_en_maas
-      hash: md5
-      md5: beea228cde3b2a6f76b8dc4de7322d61.dir
-      size: 74464
-      nfiles: 5
-    outs:
-    - path: data/AaenMaas/modellen/AaenMaas_dynamic_model
-      hash: md5
-      md5: 9ec64ed26f74f57e060be722a0f11306.dir
-      size: 45441388
-      nfiles: 4
-  noorderzijlvest:
-    cmd:
-    - pixi run python notebooks/noorderzijlvest/01_fix_model.py
-    - pixi run python notebooks/noorderzijlvest/02_prepare_model.py
-    - pixi run python notebooks/noorderzijlvest/03_parameterize_model.py
-    - pixi run python notebooks/noorderzijlvest/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py Noorderzijlvest
-    - pixi run python notebooks/07_add_dynamic_forcing.py Noorderzijlvest
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/noorderzijlvest
-      hash: md5
-      md5: 67359e0230bf9b3e0a62dbd30e5c89e2.dir
-      size: 31750
-      nfiles: 4
-    outs:
-    - path: data/Noorderzijlvest/modellen/Noorderzijlvest_dynamic_model
-      hash: md5
-      md5: fdca370bd560f325425f3fffeacb7bec.dir
-      size: 43750788
-      nfiles: 4
-  stichtse_rijnlanden:
-    cmd:
-    - pixi run python notebooks/stichtse_rijnlanden/01_fix_model.py
-    - pixi run python notebooks/stichtse_rijnlanden/02_prepare_model.py
-    - pixi run python notebooks/stichtse_rijnlanden/03_parameterize_model.py
-    - pixi run python notebooks/stichtse_rijnlanden/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py StichtseRijnlanden
-    - pixi run python notebooks/07_add_dynamic_forcing.py StichtseRijnlanden
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/stichtse_rijnlanden
-      hash: md5
-      md5: 60294dc8e197be79c6fdc3eab29a8e60.dir
-      size: 62066
-      nfiles: 4
-    outs:
-    - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_dynamic_model
-      hash: md5
-      md5: 017b2cad3011a97ac55b116ddfe3f005.dir
-      size: 45921300
-      nfiles: 4
   bathymetry:
     cmd: pixi run python notebooks/rijkswaterstaat/1_bathymetrie.py
     deps:
@@ -202,247 +127,6 @@ stages:
       hash: md5
       md5: a0535db0cef0342e088189db921f7e68.dir
       size: 587513735
-      nfiles: 4
-  rijkswaterstaat:
-    cmd:
-    - pixi run python notebooks/rijkswaterstaat/2_basins.py
-    - pixi run python notebooks/rijkswaterstaat/3_netwerk.py
-    - pixi run python notebooks/rijkswaterstaat/4_kunstwerken.py
-    - pixi run python notebooks/rijkswaterstaat/5_model_netwerk.py
-    - pixi run python notebooks/rijkswaterstaat/6_model_sturing.py
-    - pixi run python notebooks/rijkswaterstaat/7_model_onttrekkingen.py
-    - pixi run python notebooks/rijkswaterstaat/8a_update_state.py
-    - pixi run python notebooks/rijkswaterstaat/8b_update_bc.py
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: bb4f19a6932feb77ded16685587187e3.dir
-      size: 22462618
-      nfiles: 2
-    - path: data/Rijkswaterstaat/verwerkt/bathymetrie
-      hash: md5
-      md5: a0535db0cef0342e088189db921f7e68.dir
-      size: 587513735
-      nfiles: 4
-    - path: notebooks/rijkswaterstaat
-      hash: md5
-      md5: 6f7282bed7f6a91cc0944a6babce4f86.dir
-      size: 94982
-      nfiles: 13
-    outs:
-    - path: data/Rijkswaterstaat/modellen/hws_transient
-      hash: md5
-      md5: f6446fce9ef9a08cf399cad755eae81b.dir
-      size: 48726170
-      nfiles: 2
-    - path: data/Rijkswaterstaat/verwerkt/netwerk.gpkg
-      hash: md5
-      md5: 3ab3e6925efc5e6d60a4f8d5dddfca93
-      size: 3731456
-  rijn_en_ijssel:
-    cmd:
-    - pixi run python notebooks/rijn_en_ijssel/01_fix_model.py
-    - pixi run python notebooks/rijn_en_ijssel/02_prepare_model.py
-    - pixi run python notebooks/rijn_en_ijssel/03_parameterize_model.py
-    - pixi run python notebooks/rijn_en_ijssel/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py RijnenIJssel
-    - pixi run python notebooks/07_add_dynamic_forcing.py RijnenIJssel
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/rijn_en_ijssel
-      hash: md5
-      md5: fc3f3be4ef55711c8586db93c9f17367.dir
-      size: 27348
-      nfiles: 4
-    outs:
-    - path: data/RijnenIJssel/modellen/RijnenIJssel_dynamic_model
-      hash: md5
-      md5: 3a3aeee20a79eb3abc621f0b55be0f8a.dir
-      size: 25662196
-      nfiles: 4
-  vechtstromen:
-    cmd:
-    - pixi run python notebooks/vechtstromen/01_fix_model.py
-    - pixi run python notebooks/vechtstromen/02_prepare_model.py
-    - pixi run python notebooks/vechtstromen/03_parameterize_model.py
-    - pixi run python notebooks/vechtstromen/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py Vechtstromen
-    - pixi run python notebooks/07_add_dynamic_forcing.py Vechtstromen
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/vechtstromen
-      hash: md5
-      md5: f8b5b7771d14ab55432a9b19b7150385.dir
-      size: 79528
-      nfiles: 4
-    outs:
-    - path: data/Vechtstromen/modellen/Vechtstromen_dynamic_model
-      hash: md5
-      md5: 332312bdf19860155ee5b91b9997e5db.dir
-      size: 68116900
-      nfiles: 4
-  de_dommel:
-    cmd:
-    - pixi run python notebooks/de_dommel/01_fix_model.py
-    - pixi run python notebooks/de_dommel/02_prepare_model.py
-    - pixi run python notebooks/de_dommel/03_parameterize_model.py
-    - pixi run python notebooks/de_dommel/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py DeDommel
-    - pixi run python notebooks/07_add_dynamic_forcing.py DeDommel
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/de_dommel
-      hash: md5
-      md5: 9a5faa25e2ec8a1bfc4fd1d013f6871b.dir
-      size: 56729
-      nfiles: 8
-    outs:
-    - path: data/DeDommel/modellen/DeDommel_dynamic_model
-      hash: md5
-      md5: a6bf1e867eb4e72a1555ca6c7a1dab59.dir
-      size: 70494852
-      nfiles: 4
-  brabantse_delta:
-    cmd:
-    - pixi run python notebooks/brabantse_delta/_preprocess_profielen.py
-    - pixi run python notebooks/brabantse_delta/01_fix_model.py
-    - pixi run python notebooks/brabantse_delta/02_prepare_model.py
-    - pixi run python notebooks/brabantse_delta/03_parameterize_model.py
-    - pixi run python notebooks/brabantse_delta/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py BrabantseDelta
-    - pixi run python notebooks/07_add_dynamic_forcing.py BrabantseDelta
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/brabantse_delta
-      hash: md5
-      md5: 12da3d20e1e88aa6b6bc60cc98f7eff9.dir
-      size: 57007
-      nfiles: 6
-    outs:
-    - path: data/BrabantseDelta/modellen/BrabantseDelta_dynamic_model
-      hash: md5
-      md5: 11216510fbe9c5e46484767ccc331b47.dir
-      size: 64436932
-      nfiles: 4
-  drents_overijsselse_delta:
-    cmd:
-    - pixi run python notebooks/drents_overijsselse_delta/01_fix_model.py
-    - pixi run python notebooks/drents_overijsselse_delta/02_prepare_model.py
-    - pixi run python
-      notebooks/drents_overijsselse_delta/03_parameterize_model.py
-    - pixi run python notebooks/drents_overijsselse_delta/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py DrentsOverijsselseDelta
-    - pixi run python notebooks/07_add_dynamic_forcing.py
-      DrentsOverijsselseDelta
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/drents_overijsselse_delta
-      hash: md5
-      md5: a053857a106db0d677d4236ce7586e0d.dir
-      size: 50199
-      nfiles: 4
-    outs:
-    - path:
-        data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_dynamic_model
-      hash: md5
-      md5: 6ccb619c2723f90102f4f4c48f11ae5b.dir
-      size: 40076788
-      nfiles: 4
-  vallei_en_veluwe:
-    cmd:
-    - pixi run python notebooks/vallei_en_veluwe/01_fix_model.py
-    - pixi run python notebooks/vallei_en_veluwe/02_prepare_model.py
-    - pixi run python notebooks/vallei_en_veluwe/03_parameterize_model.py
-    - pixi run python notebooks/vallei_en_veluwe/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py ValleienVeluwe
-    - pixi run python notebooks/07_add_dynamic_forcing.py ValleienVeluwe
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/vallei_en_veluwe
-      hash: md5
-      md5: 7dc23f5f52311ebdd929ecc60e17f0fb.dir
-      size: 63797
-      nfiles: 4
-    outs:
-    - path: data/ValleienVeluwe/modellen/ValleienVeluwe_dynamic_model
-      hash: md5
-      md5: 8e544324a559c57fb9b60ef6d3191311.dir
-      size: 54170860
-      nfiles: 4
-  limburg:
-    cmd:
-    - pixi run python notebooks/limburg/_preprocess_profielen.py
-    - pixi run python notebooks/limburg/01_fix_model.py
-    - pixi run python notebooks/limburg/02_prepare_model.py
-    - pixi run python notebooks/limburg/03_parameterize_model.py
-    - pixi run python notebooks/limburg/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py Limburg
-    - pixi run python notebooks/07_add_dynamic_forcing.py Limburg
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/limburg
-      hash: md5
-      md5: f786a47b185c899426842d6ba0aea044.dir
-      size: 57268
-      nfiles: 5
-    outs:
-    - path: data/Limburg/modellen/Limburg_dynamic_model
-      hash: md5
-      md5: 4ce9b21aa6206003e8b12a12c512f18f.dir
-      size: 76707668
-      nfiles: 4
-  hunze_en_aas:
-    cmd:
-    - pixi run python notebooks/hunze_en_aas/01_fix_model.py
-    - pixi run python notebooks/hunze_en_aas/02_prepare_model.py
-    - pixi run python notebooks/hunze_en_aas/03_parameterize_model.py
-    - pixi run python notebooks/hunze_en_aas/04_add_full_control.py
-    - pixi run python notebooks/05_add_bergend.py HunzeenAas
-    - pixi run python notebooks/07_add_dynamic_forcing.py HunzeenAas
-    deps:
-    - path: data/Rijkswaterstaat/modellen/rwzi
-      hash: md5
-      md5: 18ace1cf5984acb585efc3bf7e680d42.dir
-      size: 22462646
-      nfiles: 2
-    - path: notebooks/hunze_en_aas
-      hash: md5
-      md5: 66ffae95844239f81d37f7d7effd3941.dir
-      size: 36503
-      nfiles: 5
-    outs:
-    - path: data/HunzeenAas/modellen/HunzeenAas_dynamic_model
-      hash: md5
-      md5: 5546f0db3efa29faa181b8e8e3934b18.dir
-      size: 32730868
       nfiles: 4
   koppelen:
     cmd: pixi run python notebooks/koppelen_modellen.py
@@ -1476,4 +1160,63 @@ stages:
       hash: md5
       md5: 38f78b695c3aa845ddf52239fe0aa651.dir
       size: 20582581
+      nfiles: 2
+  hws_demand:
+    cmd:
+    - pixi run python notebooks/rijkswaterstaat/2_basins.py
+    - pixi run python notebooks/rijkswaterstaat/3_netwerk.py
+    - pixi run python notebooks/rijkswaterstaat/4_kunstwerken.py
+    - pixi run python notebooks/rijkswaterstaat/5_model_netwerk.py
+    - pixi run python notebooks/rijkswaterstaat/6_model_sturing.py
+    - pixi run python notebooks/rijkswaterstaat/7_model_onttrekkingen.py
+    - pixi run python notebooks/rijkswaterstaat/8a_update_state.py
+    deps:
+    - path: data/Basisgegevens/Baseline/baseline-nl_land-j23_6-v1/baseline.gdb
+      hash: md5
+      md5: c9d11e2cab63ac8096c553a9b491c9c3.dir
+      size: 8081071635
+      nfiles: 215
+    - path: data/Rijkswaterstaat/modellen/rwzi
+      hash: md5
+      md5: bb4f19a6932feb77ded16685587187e3.dir
+      size: 22462618
+      nfiles: 2
+    - path: data/Rijkswaterstaat/verwerkt/bathymetrie
+      hash: md5
+      md5: a0535db0cef0342e088189db921f7e68.dir
+      size: 587513735
+      nfiles: 4
+    - path: notebooks/rijkswaterstaat
+      hash: md5
+      md5: 8a6aed4dce2503a96226453229ea7190.dir
+      size: 93888
+      nfiles: 13
+    outs:
+    - path: data/Rijkswaterstaat/modellen/hws_demand
+      hash: md5
+      md5: 5ef46317432a5629abb00cbcd97a111c.dir
+      size: 42651802
+      nfiles: 2
+    - path: data/Rijkswaterstaat/verwerkt/netwerk.gpkg
+      hash: md5
+      md5: 603c3be5e667d4187f386e3149b9b281
+      size: 3731456
+  hws_transient:
+    cmd:
+    - pixi run python notebooks/rijkswaterstaat/8b_update_bc.py
+    deps:
+    - path: data/Rijkswaterstaat/modellen/hws_demand
+      hash: md5
+      md5: 5ef46317432a5629abb00cbcd97a111c.dir
+      size: 42651802
+      nfiles: 2
+    - path: notebooks/rijkswaterstaat/8b_update_bc.py
+      hash: md5
+      md5: 95ec3bc6ae7512f94f9fe6cd4693a85f
+      size: 4504
+    outs:
+    - path: data/Rijkswaterstaat/modellen/hws_transient
+      hash: md5
+      md5: c8399d6440cf0be8797021d95a96cc9e.dir
+      size: 48525466
       nfiles: 2

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -101,7 +101,7 @@ stages:
         - src/peilbeheerst_model/Parametrize/${item}_parametrize.py
       outs:
         - data/${item}/modellen/${item}_parameterized
-  rijkswaterstaat:
+  hws_demand:
     cmd:
       - pixi run python notebooks/rijkswaterstaat/2_basins.py
       - pixi run python notebooks/rijkswaterstaat/3_netwerk.py
@@ -110,14 +110,22 @@ stages:
       - pixi run python notebooks/rijkswaterstaat/6_model_sturing.py
       - pixi run python notebooks/rijkswaterstaat/7_model_onttrekkingen.py
       - pixi run python notebooks/rijkswaterstaat/8a_update_state.py
-      - pixi run python notebooks/rijkswaterstaat/8b_update_bc.py
     deps:
+      - data/Basisgegevens/Baseline/baseline-nl_land-j23_6-v1/baseline.gdb
       - data/Rijkswaterstaat/verwerkt/bathymetrie
       - data/Rijkswaterstaat/modellen/rwzi
       - notebooks/rijkswaterstaat
     outs:
-      - data/Rijkswaterstaat/modellen/hws_transient
+      - data/Rijkswaterstaat/modellen/hws_demand
       - data/Rijkswaterstaat/verwerkt/netwerk.gpkg
+  hws_transient:
+    cmd:
+      - pixi run python notebooks/rijkswaterstaat/8b_update_bc.py
+    deps:
+      - data/Rijkswaterstaat/modellen/hws_demand
+      - notebooks/rijkswaterstaat/8b_update_bc.py
+    outs:
+      - data/Rijkswaterstaat/modellen/hws_transient
   samenvoegen:
     cmd: pixi run python notebooks/samenvoegen_modellen.py
     deps:

--- a/notebooks/rijkswaterstaat/1_bathymetrie.py
+++ b/notebooks/rijkswaterstaat/1_bathymetrie.py
@@ -36,7 +36,7 @@ water_mask_path = out_dir / "water-mask.gpkg"
 
 
 cloud.synchronize(filepaths=[krw_poly_gpkg, water_mask_path])
-cloud.synchronize(filepaths=[baseline_file, bathymetrie_nl], overwrite=False)
+cloud.synchronize(filepaths=[bathymetrie_nl], overwrite=False)
 
 res = 5
 tile_size = 10000

--- a/notebooks/rijkswaterstaat/4_kunstwerken.py
+++ b/notebooks/rijkswaterstaat/4_kunstwerken.py
@@ -135,7 +135,6 @@ cloud.synchronize(
         primaire_kunstwerken,
     ]
 )
-cloud.synchronize(filepaths=[baseline], overwrite=False)
 
 # output
 hydamo_path = cloud.joinpath("Rijkswaterstaat/verwerkt/hydamo.gpkg")


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim-NL/issues/622. Make sure you run `pixi run install` or directly `pixi run dvc pull` to get the 7.5GB baseline once if you don't already have it.

Also ran `dvc repro hws_transient` on top of https://github.com/Deltares/Ribasim-NL/pull/625.

The old `rijkswaterstaat` stage is now split into `hws_demand` and `hws_transient` for the last step (`8b_update_bc.py`).

Also cleans up removed stages from dvc.lock, apparently that is intentionally not done automatically.