### PR TITLE
Allow unknown/extra values in the .env.

### DIFF
--- a/src/ribasim_nl/ribasim_nl/settings.py
+++ b/src/ribasim_nl/ribasim_nl/settings.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
             file_secret_settings,
         )
 
-    model_config = SettingsConfigDict(env_file=(".env"))
+    model_config = SettingsConfigDict(env_file=(".env"), extra="ignore")
 
 
 settings = Settings()


### PR DESCRIPTION
Erroring on an old value in an .env file is counterproductive.