### PR TITLE
Archive Ribasim core for isolated SLURM runs

### DIFF
--- a/docs/dev/slurm.qmd
+++ b/docs/dev/slurm.qmd
@@ -25,7 +25,13 @@ On completion, job IDs are written to `repro_jobs.txt` for use with `run.sh`.
 
 ## run.sh: isolated simulation runs
 
-Copies a model and the Ribasim binary to `runs/<name>/` and submits a SLURM job. This isolates runs from the DVC pipeline and from each other, preventing Bus errors from concurrent file access.
+Copies a model to `runs/<name>/` and submits a SLURM job using the named Ribasim core configured in `scripts/install_ribasim_core.py`.
+
+As an immediate preparation step, `run.sh` runs the `archive-core` Pixi task. This task depends on `install-core`, then archives `bin/ribasim` at `/p/ribasim-nl/bin/<NAME>`. Pixi skips the copy when the input directory and installer configuration are unchanged.
+
+Named archives are immutable: `archive-core` does not replace an existing `/p/ribasim-nl/bin/<NAME>` directory. Change `NAME` when archiving a different core.
+
+The submitted SLURM job runs this archived executable, not `bin/ribasim` in the repository. The repository and its installed core can therefore change while simulations are queued or running without changing the executable used by those simulations. The exact Ribasim version is written to each SLURM log before the model starts.
 
 ```sh
 ./run.sh <name> <model_dir> [--after=<jobid>] [key=value ...]
@@ -42,11 +48,11 @@ Run `lhm_coupled` after koppelen finishes:
   --after=$(grep koppelen repro_jobs.txt | cut -f2)
 ```
 
-Run `lhm_parts` with a shorter simulation period:
+Run `lhm_coupled` with a shorter simulation period:
 
 ```sh
-./run.sh lhm_parts_1yr data/Rijkswaterstaat/modellen/lhm_parts \
-  --after=$(grep samenvoegen repro_jobs.txt | cut -f2) \
+./run.sh lhm_coupled_1yr data/Rijkswaterstaat/modellen/lhm_coupled \
+  --after=$(grep koppelen repro_jobs.txt | cut -f2) \
   endtime="2018-01-01 00:00:00"
 ```
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -94,6 +94,7 @@ install-core = { cmd = "python scripts/install_ribasim_core.py", inputs = ["scri
 
 [target.linux-64.tasks]
 install-core = { cmd = "python scripts/install_ribasim_core.py", inputs = ["scripts/install_ribasim_core.py"], outputs = ["bin/ribasim/README.md"] }
+archive-core = { cmd = "python scripts/install_ribasim_core.py --archive", depends-on = ["install-core"], inputs = ["scripts/install_ribasim_core.py", "bin/ribasim"] }
 
 # RIBASIM_HOME points to the Ribasim core installation directory.
 # Beware: the install-core task removes and recreates this directory.

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,8 @@
 #   ./run.sh lhm_parts data/Rijkswaterstaat/modellen/lhm_parts \
 #     --after=$(grep samenvoegen repro_jobs.txt | cut -f2) solver.abstol=1e-6
 #
-# The model and Ribasim core are copied to runs/<name>/ for isolation.
+# The model is copied to runs/<name>/ for isolation. The named Ribasim core
+# under /p/ribasim-nl/bin is shared by all runs.
 # TOML overrides are applied in-place before the run starts.
 
 set -euo pipefail
@@ -22,17 +23,25 @@ PARTITION=4vcpu
 TIME=7-00:00:00
 RUNS_DIR=/p/ribasim-nl/runs
 
+# Install the configured core if needed and archive it under its stable name.
+pixi run archive-core
+RIBASIM_NAME=$(pixi run python scripts/install_ribasim_core.py --print-name)
+RIBASIM_BIN="/p/ribasim-nl/bin/${RIBASIM_NAME}/bin/ribasim"
+
+if [[ ! -x "${RIBASIM_BIN}" ]]; then
+  echo "Error: archive-core did not create ${RIBASIM_BIN}." >&2
+  exit 1
+fi
+
 # Parse arguments
 NAME=$1; shift
 MODEL_DIR=$1; shift
 
 AFTER=""
-NO_COPY_RIBASIM=false
 OVERRIDES=()
 for arg in "$@"; do
   case $arg in
     --after=*) AFTER="${arg#--after=}" ;;
-    --no-copy-ribasim) NO_COPY_RIBASIM=true ;;
     *=*) OVERRIDES+=("$arg") ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
@@ -53,8 +62,8 @@ for o in "${OVERRIDES[@]+"${OVERRIDES[@]}"}"; do
 done
 
 # Create output directory so SLURM can write the log file
-if [[ -d "${RUN_DIR}/model" ]]; then
-  echo "Error: ${RUN_DIR}/model already exists. Remove it or choose a different name." >&2
+if [[ -e "${RUN_DIR}" ]]; then
+  echo "Error: ${RUN_DIR} already exists. Remove it or choose a different name." >&2
   exit 1
 fi
 mkdir -p "${RUN_DIR}"
@@ -67,21 +76,14 @@ JOB_ID=$(sbatch --parsable ${DEP_FLAG} \
 #!/bin/bash
 set -euo pipefail
 module load pixi
-cd $PWD
 
 # Setup isolated run directory
-cp -r "${MODEL_DIR}" "${RUN_DIR}/model"
-if ${NO_COPY_RIBASIM}; then
-  RIBASIM_BIN="$PWD/bin/ribasim/bin/ribasim"
-else
-  cp -r bin/ribasim "${RUN_DIR}/ribasim"
-  RIBASIM_BIN="${RUN_DIR}/ribasim/bin/ribasim"
-fi
+cp -r "${MODEL_DIR}/." "${RUN_DIR}/"
 
-# Find the TOML file in the model directory
-TOML=\$(find "${RUN_DIR}/model" -maxdepth 1 -name "*.toml" | head -1)
+# Find the TOML file in the run directory
+TOML=\$(find "${RUN_DIR}" -maxdepth 1 -name "*.toml" | head -1)
 if [[ -z "\${TOML}" ]]; then
-  echo "Error: no .toml file found in ${RUN_DIR}/model" >&2
+  echo "Error: no .toml file found in ${RUN_DIR}" >&2
   exit 1
 fi
 echo "Using TOML: \${TOML}"
@@ -90,7 +92,8 @@ echo "Using TOML: \${TOML}"
 ${QUOTED_OVERRIDES:+pixi run edit-toml "\${TOML}"${QUOTED_OVERRIDES}}
 
 # Run
-srun "\${RIBASIM_BIN}" "\${TOML}"
+"${RIBASIM_BIN}" --version
+srun "${RIBASIM_BIN}" "\${TOML}"
 EOF
 )
 

--- a/scripts/install_ribasim_core.py
+++ b/scripts/install_ribasim_core.py
@@ -1,17 +1,20 @@
-"""Download and install the Ribasim core binary into ``bin/ribasim``.
+"""Download, install, and archive the Ribasim core binary.
 
 The release zip is fetched from either GitHub releases or a MinIO S3 bucket,
-depending on the SOURCE setting below. The zip is extracted into ``bin/``
-(which contains a top-level ``ribasim`` folder).
+depending on the SOURCE setting below. By default it is installed into
+``RIBASIM_HOME``; ``--archive`` copies that installation to
+``/p/ribasim-nl/bin/<NAME>``.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import platform
 import shutil
 import subprocess
 import sys
+import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path
@@ -32,6 +35,7 @@ GITHUB_RELEASE_URL = "https://github.com/Deltares/Ribasim/releases/download/{nam
 MINIO_SERVER = "s3.deltares.nl"
 MINIO_BUCKET = "ribasim-nl"
 MINIO_FOLDER = "bin"
+HPC_BIN_DIR = Path("/p/ribasim-nl/bin")
 
 
 def _ribasim_home() -> Path:
@@ -81,17 +85,12 @@ def _extract(zip_path: Path, dest: Path) -> None:
             zf.extractall(dest)
 
 
-def main() -> int:
-    ribasim_home = _ribasim_home()
-    bin_dir = ribasim_home.parent
-    bin_dir.mkdir(parents=True, exist_ok=True)
-
-    if ribasim_home.exists():
-        shutil.rmtree(ribasim_home)
-
+def _install(ribasim_home: Path) -> None:
+    ribasim_home.parent.mkdir(parents=True, exist_ok=True)
     asset = _asset_name()
-    zip_path = bin_dir / asset
-    try:
+    with tempfile.TemporaryDirectory(dir=ribasim_home.parent) as temp_dir:
+        temp_path = Path(temp_dir)
+        zip_path = temp_path / asset
         if SOURCE == "github":
             _download_github(zip_path)
         elif SOURCE == "minio":
@@ -99,9 +98,45 @@ def main() -> int:
         else:
             raise RuntimeError(f"Unknown SOURCE: {SOURCE!r}. Use 'github' or 'minio'.")
 
-        _extract(zip_path, bin_dir)
-    finally:
-        zip_path.unlink(missing_ok=True)
+        _extract(zip_path, temp_path)
+        extracted_home = temp_path / "ribasim"
+        if not extracted_home.is_dir():
+            raise RuntimeError(f"Archive does not contain the expected 'ribasim' directory: {asset}")
+
+        if ribasim_home.exists():
+            shutil.rmtree(ribasim_home)
+        shutil.move(str(extracted_home), ribasim_home)
+
+
+def _archive(ribasim_home: Path) -> Path:
+    if not ribasim_home.is_dir():
+        raise RuntimeError(f"Ribasim core is not installed at {ribasim_home}")
+
+    archived_home = HPC_BIN_DIR / NAME
+    archived_home.parent.mkdir(parents=True, exist_ok=True)
+    if archived_home.exists():
+        return archived_home
+    shutil.copytree(ribasim_home, archived_home, symlinks=True)
+    return archived_home
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", action="store_true", help="copy RIBASIM_HOME to /p/ribasim-nl/bin/<NAME>")
+    parser.add_argument("--print-name", action="store_true", help="print NAME and exit")
+    args = parser.parse_args()
+
+    if args.print_name:
+        print(NAME)
+        return 0
+
+    ribasim_home = _ribasim_home()
+    if args.archive:
+        archived_home = _archive(ribasim_home)
+        print(f"Archived Ribasim core ({SOURCE}: {NAME}) at {archived_home}")
+        return 0
+
+    _install(ribasim_home)
 
     print(f"Installed Ribasim core ({SOURCE}: {NAME}) to {ribasim_home}")
     return 0


### PR DESCRIPTION
## Summary

- archive the configured Ribasim core under `/p/ribasim-nl/bin/<NAME>` before submitting simulations
- keep named archives immutable so queued and running jobs are unaffected by repository changes
- log the archived Ribasim version and place model contents directly in each run directory
- document the archive workflow and add input-based Pixi task caching

## Validation

- `pixi run ruff check scripts/install_ribasim_core.py`
- Python compilation and archive immutability check
- `pixi run --platform linux-64 --dry-run archive-core`
- `bash -n run.sh`
- `git diff --check`