### PR TITLE
Zonebudget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Goal
+
+Build and maintain a reproducible [DVC (Data Version Control)](https://dvc.org/) pipeline that turns source data and Python code into a nationwide [Ribasim](https://github.com/Deltares/Ribasim) schematization.
+
+## Working agreements
+
+- Use Pixi for commands and dependencies.
+- Define reproducible stages in `dvc.yaml`, with complete inputs and outputs.
+- Run only the smallest relevant DVC stage while developing. Never run `pixi run repro`; complete reproduction runs are submitted to SLURM manually.
+- Run `pixi run check` before finishing; it includes Ruff linting and formatting, and ty type checking.
+- Add tests for new behavior where practical.
+- Add type hints and concise docstrings to new Python code.
+- Use defensive programming: validate inputs and invariants, and assert assumptions close to where they are made.
+- Add reusable model-wide checks to `ribasim_nl.validation.validate_model`, with regression tests.
+- Strive for DRY (don't repeat yourself) code without introducing unnecessary abstractions.
+- Keep changes focused and maintainable; reuse existing repository patterns.
+- This repository is public, but the code is not used outside this repository. Backward compatibility is not required, so prefer clear improvements over preserving obsolete APIs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Build and maintain a reproducible [DVC (Data Version Control)](https://dvc.org/)
 ## Working agreements
 
 - Use Pixi for commands and dependencies.
+- Only support the Python and dependency versions in the lockfile; do not use compatibility features such as `from __future__ import annotations`.
 - Define reproducible stages in `dvc.yaml`, with complete inputs and outputs.
 - Run only the smallest relevant DVC stage while developing. Never run `pixi run repro`; complete reproduction runs are submitted to SLURM manually.
 - Run `pixi run check` before finishing; it includes Ruff linting and formatting, and ty type checking.

--- a/pixi.toml
+++ b/pixi.toml
@@ -47,6 +47,7 @@ quarto = ">=1.9"
 quartodoc = ">=0.11.1"
 requests = ">=2.32"
 ruff = ">=0.14"
+scipy = ">=1.18"
 seaborn = ">=0.13"
 shapely = ">=2.1"
 tomli = ">=2.2"
@@ -94,7 +95,6 @@ install-core = { cmd = "python scripts/install_ribasim_core.py", inputs = ["scri
 
 [target.linux-64.tasks]
 install-core = { cmd = "python scripts/install_ribasim_core.py", inputs = ["scripts/install_ribasim_core.py"], outputs = ["bin/ribasim/README.md"] }
-archive-core = { cmd = "python scripts/install_ribasim_core.py --archive", depends-on = ["install-core"], inputs = ["scripts/install_ribasim_core.py", "bin/ribasim"] }
 
 # RIBASIM_HOME points to the Ribasim core installation directory.
 # Beware: the install-core task removes and recreates this directory.

--- a/scripts/aggregate_model_results.py
+++ b/scripts/aggregate_model_results.py
@@ -1,0 +1,61 @@
+"""Aggregate model results over time and space."""
+
+from pathlib import Path
+
+import geopandas as gpd
+from ribasim_nl.zonebudget import (
+    NodeGroups,
+    aggregate_seasonal_results,
+    aggregate_spatial_results,
+    aggregate_time_results,
+)
+
+from ribasim_nl import Model
+
+SOURCE_MODEL = Path("data/Rijkswaterstaat/modellen/lhm_val_3yr/lhm_coupled.toml")
+ECHO_POLYGONS = Path("path/to/ECHO_toestroom_landelijk_v11.shp")
+WS_TARGET_MODEL = Path("data/Rijkswaterstaat/modellen/lhm_ws_3yr/lhm_ws.toml")
+ECHO_TARGET_MODEL = Path("data/Rijkswaterstaat/modellen/lhm_echo_3yr/lhm_echo.toml")
+
+
+def write_outputs(results, target_model: Path) -> None:
+    written_toml = results.write_visualization_model(target_model.parent)
+    written_toml.replace(target_model)
+
+
+def main() -> None:
+    model = Model.read(SOURCE_MODEL)
+    source = model.to_xugrid(add_flow=True)
+
+    authority_groups = NodeGroups.from_node_column(
+        model,
+        "meta_waterbeheerder",
+        exclude=["Rijkswaterstaat"],
+    )
+    authority_results = aggregate_spatial_results(
+        model,
+        authority_groups,
+        dataset=aggregate_time_results(source, "YS"),
+        aggregate_flow_boundaries=True,
+        flow_boundary_filter={"meta_categorie": "RWZI"},
+    )
+    write_outputs(authority_results, WS_TARGET_MODEL)
+
+    echo_polygons = gpd.read_file(ECHO_POLYGONS, columns=["ECHO_ID", "geometry"])
+    node_df = model.node.df
+    assert node_df is not None
+    assert node_df.crs is not None
+    echo_polygons = echo_polygons.set_crs(node_df.crs)
+    echo_groups = NodeGroups.from_polygons(model, echo_polygons, "ECHO_ID")
+    echo_results = aggregate_spatial_results(
+        model,
+        echo_groups,
+        dataset=aggregate_seasonal_results(source),
+        aggregate_flow_boundaries=True,
+        flow_boundary_filter={"meta_categorie": "RWZI"},
+    )
+    write_outputs(echo_results, ECHO_TARGET_MODEL)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ribasim_nl/ribasim_nl/zonebudget.py
+++ b/src/ribasim_nl/ribasim_nl/zonebudget.py
@@ -1,0 +1,1095 @@
+"""Aggregate Ribasim networks and results into visualization zones.
+
+This module groups Basin nodes, contracts internal flow paths, aggregates
+time-dependent results, and writes Ribasim-compatible visualization models.
+"""
+
+from collections.abc import Hashable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar, Self, cast
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import ribasim
+import shapely
+import xarray as xr
+import xugrid as xu
+from ribasim import __schema_version__
+from ribasim.db_utils import _set_db_schema_version
+from scipy import sparse
+from shapely.geometry import LineString
+
+BOUNDARY_NODE_TYPES = frozenset({"FlowBoundary", "LevelBoundary", "Terminal"})
+VERTICAL_FLUX_VARIABLES = (
+    "precipitation",
+    "evaporation",
+    "drainage",
+    "infiltration",
+    "surface_runoff",
+    "urban_runoff",
+)
+BASIN_ADDITIVE_VARIABLES = (
+    "storage",
+    "storage_rate",
+    "balance_error",
+    *VERTICAL_FLUX_VARIABLES,
+)
+BASIN_RATE_VARIABLES = frozenset((*BASIN_ADDITIVE_VARIABLES, "inflow_rate", "outflow_rate")) - {"storage"}
+BASIN_RESULT_ATTRIBUTES = {
+    "level": {
+        "units": "m",
+        "standard_name": "water_surface_height_above_reference_datum",
+        "long_name": "water level above reference datum",
+    },
+    "storage": {
+        "units": "m3",
+        "standard_name": "surface_water_amount",
+        "long_name": "water storage volume",
+    },
+    "inflow_rate": {
+        "units": "m3 s-1",
+        "standard_name": "water_volume_transport_in_river_channel",
+        "long_name": "water inflow rate",
+    },
+    "outflow_rate": {
+        "units": "m3 s-1",
+        "standard_name": "water_volume_transport_in_river_channel",
+        "long_name": "water outflow rate",
+    },
+    "storage_rate": {"units": "m3 s-1", "long_name": "water storage rate of change"},
+    "precipitation": {
+        "units": "m3 s-1",
+        "standard_name": "lwe_precipitation_rate",
+        "long_name": "liquid water equivalent precipitation rate",
+    },
+    "surface_runoff": {
+        "units": "m3 s-1",
+        "standard_name": "surface_runoff_flux",
+        "long_name": "surface runoff flux",
+    },
+    "evaporation": {
+        "units": "m3 s-1",
+        "standard_name": "lwe_water_evaporation_rate",
+        "long_name": "water evaporation flux",
+    },
+    "drainage": {"units": "m3 s-1", "long_name": "drainage flux"},
+    "infiltration": {"units": "m3 s-1", "long_name": "infiltration flux"},
+    "balance_error": {"units": "m3 s-1", "long_name": "water balance error"},
+    "relative_error": {"units": "1", "long_name": "relative water balance error"},
+    "convergence": {"units": "1", "long_name": "convergence indicator"},
+}
+
+
+@dataclass(frozen=True)
+class NodeGroups:
+    """Assignment of Basin nodes to spatial groups."""
+
+    basin_to_group: pd.Series
+    geometry: gpd.GeoDataFrame | None = None
+    node_to_group: pd.Series | None = None
+
+    @classmethod
+    def from_ids(cls, model: ribasim.Model, groups: Mapping[Hashable, Sequence[int]]) -> Self:
+        """Create groups from explicitly listed Basin node IDs."""
+        node_df = model.node.df
+        assert node_df is not None
+        basin_ids = set(node_df.index[node_df["node_type"] == "Basin"])
+        assignments: dict[int, Hashable] = {}
+        for group, node_ids in groups.items():
+            for node_id in node_ids:
+                if node_id not in basin_ids:
+                    raise ValueError(f"Node {node_id} is not a Basin node.")
+                if node_id in assignments:
+                    raise ValueError(f"Basin node {node_id} occurs in more than one group.")
+                assignments[node_id] = group
+        assignment = pd.Series(assignments, name="group_id", dtype="object")
+        return cls(assignment, node_to_group=assignment)
+
+    @classmethod
+    def from_node_column(
+        cls,
+        model: ribasim.Model,
+        column: str,
+        *,
+        exclude: Sequence[Hashable] = (),
+    ) -> Self:
+        """Group Basin nodes by a column, optionally leaving values ungrouped."""
+        node_df = model.node.df
+        assert node_df is not None
+        if column not in node_df:
+            raise KeyError(f"Node table has no column {column!r}.")
+        node_values = node_df[column].dropna()
+        node_values = node_values[~node_values.isin(exclude)].astype("object")
+        node_values.name = "group_id"
+        basin_values = node_values[node_values.index.isin(node_df.index[node_df["node_type"] == "Basin"])]
+        return cls(basin_values, node_to_group=node_values)
+
+    @classmethod
+    def from_polygons(
+        cls,
+        model: ribasim.Model,
+        polygons: gpd.GeoDataFrame,
+        group_column: str,
+    ) -> Self:
+        """Assign Basin node points to polygons.
+
+        A point on a boundary is accepted only when all matching polygons have the
+        same group value. Otherwise the assignment is ambiguous and raises.
+        """
+        if group_column not in polygons:
+            raise KeyError(f"Polygon table has no column {group_column!r}.")
+        node_df = model.node.df
+        assert node_df is not None
+        if polygons.crs != node_df.crs:
+            raise ValueError("Model nodes and grouping polygons must have the same CRS.")
+        if polygons[group_column].isna().any():
+            raise ValueError(f"Column {group_column!r} contains missing group values.")
+
+        basin_nodes = node_df.loc[node_df["node_type"] == "Basin"]
+        tree = shapely.STRtree(polygons.geometry.to_numpy())
+        node_positions, polygon_positions = tree.query(node_df.geometry.to_numpy(), predicate="intersects")
+        matches = pd.DataFrame(
+            {
+                "node_id": node_df.index.to_numpy()[node_positions],
+                "group_id": polygons[group_column].to_numpy()[polygon_positions],
+            }
+        ).drop_duplicates()
+        ambiguous = matches.groupby("node_id")["group_id"].nunique()
+        ambiguous = ambiguous[(ambiguous > 1) & ambiguous.index.isin(basin_nodes.index)]
+        if not ambiguous.empty:
+            candidates = matches[matches["node_id"].isin(ambiguous.index)].groupby("node_id")["group_id"].apply(list)
+            raise ValueError(f"Basin nodes intersect multiple groups: {candidates.to_dict()}")
+
+        unique_node_ids = matches.groupby("node_id")["group_id"].nunique().loc[lambda values: values == 1].index
+        node_assignment = matches[matches["node_id"].isin(unique_node_ids)].drop_duplicates("node_id")
+        node_assignment = node_assignment.set_index("node_id")["group_id"].astype("object")
+        node_assignment.name = "group_id"
+        assignment = node_assignment[node_assignment.index.isin(basin_nodes.index)]
+        geometry = polygons[[group_column, "geometry"]].dissolve(by=group_column).sort_index()
+        return cls(assignment, geometry, node_assignment)
+
+
+@dataclass(frozen=True)
+class AggregationDiagnostics:
+    """Nodes affected or skipped during aggregation."""
+
+    ungrouped_basin_ids: tuple[int, ...]
+    contracted_connector_ids: tuple[int, ...]
+
+
+@dataclass
+class AggregatedResults:
+    """Spatially aggregated results and their mixed-resolution network."""
+
+    dataset: xu.UgridDataset
+    nodes: gpd.GeoDataFrame
+    links: gpd.GeoDataFrame
+    diagnostics: AggregationDiagnostics
+    source_model: ribasim.Model
+    basin_areas: gpd.GeoDataFrame | None = None
+    budget: pd.DataFrame | None = None
+
+    def write_visualization_model(self, directory: str | Path) -> Path:
+        """Write a minimal Ribasim-shaped package for visualization tools."""
+        return write_visualization_model(self, directory)
+
+
+@dataclass(frozen=True)
+class _ContractedPath:
+    connector_id: int | None
+    from_basin_id: int
+    to_basin_id: int
+    result_link_id: int
+    link_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _BasinAggregation:
+    """Mapping and profile-area weights for aggregated Basin results."""
+
+    source_to_output: pd.Series
+    source_area: pd.Series
+    output_area: pd.Series
+
+    @classmethod
+    def from_model(
+        cls,
+        model: ribasim.Model,
+        nodes: gpd.GeoDataFrame,
+        groups: NodeGroups,
+    ) -> Self:
+        source_to_output = _source_basin_mapping(nodes, groups)
+        profile_df = model.basin.profile.df
+        if profile_df is None:
+            raise ValueError("Basin profile data is required to aggregate results.")
+        top_profiles = profile_df.sort_values("level").drop_duplicates("node_id", keep="last")
+        source_area = top_profiles.set_index("node_id")["area"].reindex(source_to_output.index)
+        invalid = source_area.isna() | (source_area <= 0)
+        if invalid.any():
+            raise ValueError(
+                f"Missing or non-positive top profile area for Basin nodes: {source_area.index[invalid].tolist()}"
+            )
+        output_area = source_area.groupby(source_to_output).sum().rename("profile_area_m2")
+        return cls(source_to_output, source_area, output_area)
+
+    def source_ids_by_output(self, output_node_ids: pd.Index) -> list[tuple[int, ...]]:
+        return [
+            tuple(int(node_id) for node_id in self.source_to_output.index[self.source_to_output == output_node_id])
+            for output_node_id in output_node_ids
+        ]
+
+
+class _NetworkAggregator:
+    anchor_types: ClassVar[frozenset[str]] = frozenset({"Basin", *BOUNDARY_NODE_TYPES})
+
+    def __init__(self, model: ribasim.Model, groups: NodeGroups):
+        self.model = model
+        self.groups = groups
+        node_df = model.node.df
+        link_df = model.link.df
+        assert node_df is not None
+        assert link_df is not None
+        self.node_df = node_df.copy()
+        self.link_df = link_df.loc[link_df["link_type"] == "flow"].copy()
+
+    def absorbed_node_groups(self) -> pd.Series:
+        """Assign conservative connector nodes enclosed by one group to that group."""
+        assignments = self.groups.basin_to_group.copy()
+        endpoints = set(self.link_df["from_node_id"]) | set(self.link_df["to_node_id"])
+        candidates = set(
+            self.node_df.index[
+                self.node_df.index.isin(endpoints) & ~self.node_df["node_type"].isin({*self.anchor_types, "UserDemand"})
+            ]
+        )
+        neighbors: dict[int, set[int]] = {int(node_id): set() for node_id in candidates}
+        for from_id, to_id in self.link_df[["from_node_id", "to_node_id"]].to_numpy(dtype=int):
+            if from_id in neighbors:
+                neighbors[from_id].add(to_id)
+            if to_id in neighbors:
+                neighbors[to_id].add(from_id)
+
+        remaining = set(candidates)
+        while remaining:
+            component = {remaining.pop()}
+            pending = list(component)
+            while pending:
+                node_id = pending.pop()
+                connected_candidates = (neighbors[node_id] & candidates) - component
+                component.update(connected_candidates)
+                remaining.difference_update(connected_candidates)
+                pending.extend(connected_candidates)
+
+            adjacent_anchors = {
+                neighbor_id
+                for node_id in component
+                for neighbor_id in neighbors[node_id]
+                if neighbor_id not in candidates
+            }
+            has_unassigned_anchor = any(
+                neighbor_id not in assignments.index and self.node_df.at[neighbor_id, "node_type"] in self.anchor_types
+                for neighbor_id in adjacent_anchors
+            )
+            adjacent_groups = assignments.reindex(list(adjacent_anchors)).dropna().unique()
+            if not has_unassigned_anchor and len(adjacent_groups) == 1:
+                assignments = pd.concat([assignments, pd.Series(adjacent_groups[0], index=list(component))])
+        return assignments
+
+    def contracted_paths(self) -> list[_ContractedPath]:
+        paths: list[_ContractedPath] = []
+        grouped_ids = set(self.groups.basin_to_group.index)
+
+        for link_id, link in self.link_df.iterrows():
+            if link.from_node_id in grouped_ids and link.to_node_id in grouped_ids:
+                integer_link_id = int(cast(Any, link_id))
+                paths.append(
+                    _ContractedPath(
+                        None,
+                        int(link.from_node_id),
+                        int(link.to_node_id),
+                        integer_link_id,
+                        (integer_link_id,),
+                    )
+                )
+
+        connector_ids = self.node_df.index[~self.node_df["node_type"].isin(self.anchor_types)]
+        for connector_id in connector_ids:
+            incoming = self.link_df[self.link_df["to_node_id"] == connector_id]
+            outgoing = self.link_df[self.link_df["from_node_id"] == connector_id]
+            if len(incoming) != 1 or len(outgoing) != 1:
+                continue
+            incoming_link = incoming.iloc[0]
+            outgoing_link = outgoing.iloc[0]
+            from_id = int(incoming_link.from_node_id)
+            to_id = int(outgoing_link.to_node_id)
+            if from_id not in grouped_ids or to_id not in grouped_ids:
+                continue
+            from_group = self.groups.basin_to_group.at[from_id]
+            to_group = self.groups.basin_to_group.at[to_id]
+            if self.node_df.at[connector_id, "node_type"] == "UserDemand" and from_group != to_group:
+                raise ValueError(
+                    f"UserDemand node {connector_id} lies between grouped Basins {from_id} and {to_id}; "
+                    "this non-conservative path cannot be aggregated."
+                )
+            paths.append(
+                _ContractedPath(
+                    int(connector_id),
+                    from_id,
+                    to_id,
+                    int(outgoing.index[0]),
+                    (int(incoming.index[0]), int(outgoing.index[0])),
+                )
+            )
+        return paths
+
+
+def _validate_regular_time(dataset: xu.UgridDataset) -> None:
+    dynamic_dataset = cast(Any, dataset)
+    if "time" not in dynamic_dataset.coords or dynamic_dataset.sizes["time"] < 3:
+        return
+    steps = np.diff(dynamic_dataset["time"].to_numpy())
+    if not np.all(steps == steps[0]):
+        raise ValueError("Temporal aggregation requires regular timesteps.")
+
+
+def _has_internal_missing_values(variable: xr.DataArray) -> bool:
+    values = variable.to_numpy()
+    time_axis = variable.get_axis_num("time")
+    values = np.moveaxis(values, time_axis, 0).reshape(values.shape[time_axis], -1)
+    populated = np.any(~pd.isna(values), axis=0)
+    return bool(pd.isna(values[:, populated]).any())
+
+
+def aggregate_time_results(dataset: xu.UgridDataset, frequency: str) -> xu.UgridDataset:
+    """Resample regular result time series to mean rates."""
+    _validate_regular_time(dataset)
+    dynamic_dataset = cast(Any, dataset)
+    time_variables = [variable for variable in dynamic_dataset.data_vars.values() if "time" in variable.dims]
+    if any(_has_internal_missing_values(variable) for variable in time_variables):
+        raise ValueError("Temporal aggregation does not support missing result values.")
+    aggregated = dynamic_dataset.resample(time=frequency).mean()
+    if isinstance(aggregated, xr.Dataset):
+        aggregated = cast(Any, xu.UgridDataset)(aggregated, dataset.grids)
+    return aggregated
+
+
+def aggregate_seasonal_results(dataset: xu.UgridDataset) -> xu.UgridDataset:
+    """Aggregate mean rates into complete April-September and October-March periods."""
+    _validate_regular_time(dataset)
+    dynamic_dataset = cast(Any, dataset)
+    time_variables = [variable for variable in dynamic_dataset.data_vars.values() if "time" in variable.dims]
+    if any(_has_internal_missing_values(variable) for variable in time_variables):
+        raise ValueError("Temporal aggregation does not support missing result values.")
+
+    times = pd.DatetimeIndex(dynamic_dataset["time"].to_numpy())
+    years = times.year - (times.month <= 3)
+    start_months = np.where((times.month >= 4) & (times.month <= 9), 4, 10)
+    period_starts = pd.DatetimeIndex(
+        [pd.Timestamp(year=int(year), month=int(month), day=1) for year, month in zip(years, start_months, strict=True)]
+    )
+    step = times[1] - times[0]
+    complete_starts = {
+        start
+        for start in period_starts.unique()
+        if start >= times[0] and start + pd.DateOffset(months=6) <= times[-1] + step
+    }
+    if not complete_starts:
+        raise ValueError("Seasonal aggregation requires at least one complete six-month period.")
+    complete = period_starts.isin(complete_starts)
+    grouped = (
+        dynamic_dataset.isel(time=np.flatnonzero(complete))
+        .assign_coords(period_start=("time", period_starts[complete]))
+        .groupby("period_start")
+        .mean("time")
+    )
+    grouped = grouped.rename(period_start="time")
+    if isinstance(grouped, xr.Dataset):
+        grouped = cast(Any, xu.UgridDataset)(grouped, dataset.grids)
+    return grouped
+
+
+def _move_line_endpoint(line: LineString, point, *, start: bool) -> LineString:
+    coordinates = list(line.coords)
+    coordinates[0 if start else -1] = point.coords[0]
+    return LineString(coordinates)
+
+
+def _group_nodes(
+    node_df: gpd.GeoDataFrame,
+    groups: NodeGroups,
+    node_to_group: pd.Series,
+    removed_node_ids: set[int],
+) -> tuple[gpd.GeoDataFrame, dict[Hashable, int], dict[int, int]]:
+    grouped = groups.basin_to_group
+    next_node_id = int(node_df.index.max()) + 1
+    unique_groups = list(pd.unique(grouped))
+    group_to_node_id = {group: next_node_id + position for position, group in enumerate(unique_groups)}
+    node_to_output_id = {
+        int(cast(Any, node_id)): int(group_to_node_id[group]) for node_id, group in node_to_group.items()
+    }
+
+    records = []
+    for group, node_id in group_to_node_id.items():
+        if groups.geometry is not None and group in groups.geometry.index:
+            group_geometry = cast(Any, groups.geometry.at[group, "geometry"])
+            geometry = group_geometry.representative_point()
+        else:
+            basin_points = node_df.loc[grouped.index[grouped == group], "geometry"]
+            geometry = basin_points.union_all().centroid
+        records.append(
+            {"node_id": node_id, "name": str(group), "node_type": "Basin", "group_id": group, "geometry": geometry}
+        )
+
+    retained = node_df.drop(index=list(removed_node_ids)).copy()
+    synthetic = gpd.GeoDataFrame(records, geometry="geometry", crs=node_df.crs).set_index("node_id")
+    output = gpd.GeoDataFrame(pd.concat([retained, synthetic]), geometry="geometry", crs=node_df.crs)
+    return output, group_to_node_id, node_to_output_id
+
+
+def _aggregate_boundary_nodes(
+    node_df: gpd.GeoDataFrame,
+    groups: NodeGroups,
+    *,
+    aggregate_flow_boundaries: bool,
+    aggregate_level_boundaries: bool,
+    flow_boundary_filter: Mapping[str, Any] | None,
+    level_boundary_filter: Mapping[str, Any] | None,
+) -> tuple[gpd.GeoDataFrame, dict[int, int], set[int]]:
+    if groups.node_to_group is None:
+        return node_df, {}, set()
+
+    configurations = (
+        ("FlowBoundary", aggregate_flow_boundaries, flow_boundary_filter),
+        ("LevelBoundary", aggregate_level_boundaries, level_boundary_filter),
+    )
+    next_node_id = int(node_df.index.max()) + 1
+    node_to_output_id: dict[int, int] = {}
+    removed_node_ids: set[int] = set()
+    records: list[dict[str, Any]] = []
+    for node_type, enabled, column_filter in configurations:
+        if not enabled:
+            continue
+        mask = node_df["node_type"] == node_type
+        for column, value in (column_filter or {}).items():
+            if column not in node_df:
+                raise KeyError(f"Node table has no boundary filter column {column!r}.")
+            mask &= node_df[column] == value
+        selected_ids = node_df.index[mask & node_df.index.isin(groups.node_to_group.index)]
+        assignments = groups.node_to_group.reindex(selected_ids).dropna()
+        for group, boundary_ids in assignments.groupby(assignments).groups.items():
+            output_id = next_node_id + len(records)
+            source_ids = [int(node_id) for node_id in boundary_ids]
+            geometry = node_df.loc[source_ids, "geometry"].union_all().centroid
+            records.append(
+                {
+                    "node_id": output_id,
+                    "name": f"{group} {node_type}",
+                    "node_type": node_type,
+                    "geometry": geometry,
+                }
+            )
+            node_to_output_id.update(dict.fromkeys(source_ids, output_id))
+            removed_node_ids.update(source_ids)
+
+    if not records:
+        return node_df, {}, set()
+    retained = node_df.drop(index=list(removed_node_ids))
+    synthetic = gpd.GeoDataFrame(records, geometry="geometry", crs=node_df.crs).set_index("node_id")
+    output = gpd.GeoDataFrame(pd.concat([retained, synthetic]), geometry="geometry", crs=node_df.crs)
+    return output, node_to_output_id, set(node_to_output_id.values())
+
+
+def _separate_parallel_group_links(
+    links: gpd.GeoDataFrame,
+    nodes: gpd.GeoDataFrame,
+    group_node_ids: set[int],
+) -> None:
+    endpoint_pairs: dict[tuple[int, int], list[int]] = {}
+    for link_id, link in links.iterrows():
+        from_id = int(link.from_node_id)
+        to_id = int(link.to_node_id)
+        if from_id in group_node_ids and to_id in group_node_ids:
+            endpoint_pair = (min(from_id, to_id), max(from_id, to_id))
+            endpoint_pairs.setdefault(endpoint_pair, []).append(int(cast(Any, link_id)))
+
+    dynamic_links = cast(Any, links)
+    for (first_id, second_id), link_ids in endpoint_pairs.items():
+        if len(link_ids) < 2:
+            continue
+        first = cast(Any, nodes.at[first_id, "geometry"])
+        second = cast(Any, nodes.at[second_id, "geometry"])
+        delta_x = second.x - first.x
+        delta_y = second.y - first.y
+        distance = float(np.hypot(delta_x, delta_y))
+        if distance == 0:
+            continue
+        offsets = np.linspace(-0.08 * distance, 0.08 * distance, len(link_ids))
+        for link_id, offset in zip(sorted(link_ids), offsets, strict=True):
+            link = cast(Any, links.loc[link_id])
+            start = cast(Any, nodes.at[int(link.from_node_id), "geometry"])
+            end = cast(Any, nodes.at[int(link.to_node_id), "geometry"])
+            control = (
+                (first.x + second.x) / 2 - delta_y / distance * offset,
+                (first.y + second.y) / 2 + delta_x / distance * offset,
+            )
+            dynamic_links.at[link_id, "geometry"] = LineString((start, control, end))
+
+
+def _build_output_network(
+    aggregator: _NetworkAggregator,
+    paths: list[_ContractedPath],
+    *,
+    aggregate_flow_boundaries: bool,
+    aggregate_level_boundaries: bool,
+    flow_boundary_filter: Mapping[str, Any] | None,
+    level_boundary_filter: Mapping[str, Any] | None,
+) -> tuple[gpd.GeoDataFrame, gpd.GeoDataFrame, list[tuple[int, ...]], AggregationDiagnostics]:
+    absorbed_groups = aggregator.absorbed_node_groups()
+    absorbed_connector_ids = set(absorbed_groups.index) - set(aggregator.groups.basin_to_group.index)
+    grouped_non_flow_ids: set[int] = set()
+    if aggregator.groups.node_to_group is not None:
+        is_non_flow_node = aggregator.node_df["node_type"].str.contains("Control") | (
+            aggregator.node_df["node_type"] == "FlowDemand"
+        )
+        grouped_non_flow_ids = set(aggregator.node_df.index[is_non_flow_node]) & set(
+            aggregator.groups.node_to_group.index
+        )
+    removed_node_ids = set(aggregator.groups.basin_to_group.index) | absorbed_connector_ids | grouped_non_flow_ids
+    node_df, group_to_node_id, node_to_output_id = _group_nodes(
+        aggregator.node_df,
+        aggregator.groups,
+        absorbed_groups,
+        removed_node_ids,
+    )
+    node_df, boundary_node_mapping, aggregated_boundary_ids = _aggregate_boundary_nodes(
+        node_df,
+        aggregator.groups,
+        aggregate_flow_boundaries=aggregate_flow_boundaries,
+        aggregate_level_boundaries=aggregate_level_boundaries,
+        flow_boundary_filter=flow_boundary_filter,
+        level_boundary_filter=level_boundary_filter,
+    )
+    node_to_output_id.update(boundary_node_mapping)
+    removed_link_ids = {link_id for path in paths for link_id in path.link_ids}
+    removed_connector_ids = {
+        *absorbed_connector_ids,
+        *(path.connector_id for path in paths if path.connector_id is not None),
+    }
+    node_df = node_df.drop(index=list(removed_connector_ids), errors="ignore")
+
+    links = aggregator.link_df.drop(index=list(removed_link_ids)).copy()
+    dynamic_links = cast(Any, links)
+    dynamic_nodes = cast(Any, node_df)
+    source_link_ids: list[tuple[int, ...]] = [(int(link_id),) for link_id in links.index]
+    for link_id, link in links.iterrows():
+        original_from = int(link.from_node_id)
+        original_to = int(link.to_node_id)
+        from_id = node_to_output_id.get(original_from, original_from)
+        to_id = node_to_output_id.get(original_to, original_to)
+        dynamic_links.at[link_id, "from_node_id"] = from_id
+        dynamic_links.at[link_id, "to_node_id"] = to_id
+        if from_id != original_from:
+            dynamic_links.at[link_id, "geometry"] = _move_line_endpoint(
+                link.geometry, dynamic_nodes.at[from_id, "geometry"], start=True
+            )
+        if to_id != original_to:
+            dynamic_links.at[link_id, "geometry"] = _move_line_endpoint(
+                link.geometry, dynamic_nodes.at[to_id, "geometry"], start=False
+            )
+
+    internal_link_ids = set(links.index[links["from_node_id"] == links["to_node_id"]])
+    if internal_link_ids:
+        keep_positions = [position for position, link_id in enumerate(links.index) if link_id not in internal_link_ids]
+        links = links.drop(index=list(internal_link_ids))
+        source_link_ids = [source_link_ids[position] for position in keep_positions]
+
+    source_ids_by_link = dict(zip(links.index, source_link_ids, strict=True))
+    group_node_ids = set(group_to_node_id.values())
+    junction_ids = set(node_df.index[node_df["node_type"] == "Junction"])
+    contracted_junction_ids: set[int] = set()
+    for junction_id in junction_ids:
+        incoming_ids = list(links.index[links["to_node_id"] == junction_id])
+        outgoing_ids = list(links.index[links["from_node_id"] == junction_id])
+        if len(incoming_ids) != 1 or len(outgoing_ids) != 1:
+            continue
+        incoming_id = incoming_ids[0]
+        outgoing_id = outgoing_ids[0]
+        from_id = int(cast(Any, links.at[incoming_id, "from_node_id"]))
+        to_id = int(cast(Any, links.at[outgoing_id, "to_node_id"]))
+        endpoint_ids = {from_id, to_id}
+        if not endpoint_ids.intersection(group_node_ids) or not endpoint_ids.intersection(aggregated_boundary_ids):
+            continue
+        current_links = cast(Any, links)
+        current_links.at[outgoing_id, "from_node_id"] = from_id
+        current_links.at[outgoing_id, "geometry"] = LineString(
+            (dynamic_nodes.at[from_id, "geometry"], dynamic_nodes.at[to_id, "geometry"])
+        )
+        links = links.drop(index=incoming_id)
+        source_ids_by_link.pop(incoming_id)
+        contracted_junction_ids.add(int(junction_id))
+    if contracted_junction_ids:
+        node_df = node_df.drop(index=list(contracted_junction_ids))
+
+    affected = links[
+        links["from_node_id"].isin(aggregated_boundary_ids) | links["to_node_id"].isin(aggregated_boundary_ids)
+    ]
+    for duplicate_ids in affected.groupby(["from_node_id", "to_node_id"], sort=False).groups.values():
+        if len(duplicate_ids) < 2:
+            continue
+        keep_id = duplicate_ids[0]
+        source_ids_by_link[keep_id] = tuple(
+            source_id for link_id in duplicate_ids for source_id in source_ids_by_link[link_id]
+        )
+        drop_ids = list(duplicate_ids[1:])
+        links = links.drop(index=drop_ids)
+        for link_id in drop_ids:
+            source_ids_by_link.pop(link_id)
+    source_link_ids = [source_ids_by_link[link_id] for link_id in links.index]
+
+    cross_group: dict[tuple[Hashable, Hashable], list[int]] = {}
+    for path in paths:
+        from_group = aggregator.groups.basin_to_group.at[path.from_basin_id]
+        to_group = aggregator.groups.basin_to_group.at[path.to_basin_id]
+        if from_group != to_group:
+            cross_group.setdefault((from_group, to_group), []).append(path.result_link_id)
+
+    next_link_id = int(aggregator.link_df.index.max()) + 1
+    new_records = []
+    for position, ((from_group, to_group), link_ids) in enumerate(cross_group.items()):
+        link_id = next_link_id + position
+        from_id = group_to_node_id[from_group]
+        to_id = group_to_node_id[to_group]
+        new_records.append(
+            {
+                "link_id": link_id,
+                "name": f"{from_group} -> {to_group}",
+                "from_node_id": from_id,
+                "to_node_id": to_id,
+                "link_type": "flow",
+                "geometry": LineString((dynamic_nodes.at[from_id, "geometry"], dynamic_nodes.at[to_id, "geometry"])),
+            }
+        )
+        source_link_ids.append(tuple(link_ids))
+    if new_records:
+        new_links = gpd.GeoDataFrame(new_records, geometry="geometry", crs=links.crs).set_index("link_id")
+        links = gpd.GeoDataFrame(pd.concat([links, new_links]), geometry="geometry", crs=links.crs)
+
+    _separate_parallel_group_links(links, node_df, group_node_ids)
+
+    is_ungrouped_basin = (aggregator.node_df["node_type"] == "Basin") & ~aggregator.node_df.index.isin(
+        aggregator.groups.basin_to_group.index
+    )
+    diagnostics = AggregationDiagnostics(
+        ungrouped_basin_ids=tuple(int(node_id) for node_id in aggregator.node_df.index[is_ungrouped_basin]),
+        contracted_connector_ids=tuple(sorted(removed_connector_ids)),
+    )
+    return node_df, links, source_link_ids, diagnostics
+
+
+def _mapping_matrix(source_ids: np.ndarray, rows: list[tuple[int, ...]]) -> sparse.csr_matrix:
+    source_lookup = {int(source_id): position for position, source_id in enumerate(source_ids)}
+    row_indices: list[int] = []
+    column_indices: list[int] = []
+    for row, ids in enumerate(rows):
+        for source_id in ids:
+            if source_id not in source_lookup:
+                raise ValueError(f"Result data does not contain ID {source_id}.")
+            row_indices.append(row)
+            column_indices.append(source_lookup[source_id])
+    return sparse.csr_matrix(
+        (np.ones(len(row_indices)), (row_indices, column_indices)),
+        shape=(len(rows), len(source_ids)),
+    )
+
+
+def _to_xugrid(
+    source: xu.UgridDataset,
+    nodes: gpd.GeoDataFrame,
+    links: gpd.GeoDataFrame,
+    source_link_ids: list[tuple[int, ...]],
+    basin_aggregation: _BasinAggregation,
+    vertical_variables: Sequence[str],
+) -> xu.UgridDataset:
+    source_data = cast(Any, source)
+    node_positions = pd.Series(np.arange(len(nodes)), index=nodes.index)
+    connectivity = np.column_stack(
+        (
+            node_positions.loc[links["from_node_id"]].to_numpy(),
+            node_positions.loc[links["to_node_id"]].to_numpy(),
+        )
+    )
+    grid = xu.Ugrid1d(
+        nodes.geometry.x.to_numpy(),
+        nodes.geometry.y.to_numpy(),
+        -1,
+        connectivity,
+        name="aggregated",
+        crs=nodes.crs,
+    )
+    node_dim = grid.node_dimension
+    edge_dim = grid.edge_dimension
+    dataset = xr.Dataset(coords={"time": source_data["time"]})
+    dataset = dataset.assign_coords(
+        node_id=(node_dim, nodes.index.to_numpy()),
+        link_id=(edge_dim, links.index.to_numpy()),
+        from_node_id=(edge_dim, links["from_node_id"].to_numpy()),
+        to_node_id=(edge_dim, links["to_node_id"].to_numpy()),
+    )
+
+    source_edge_dim = source_data.grid.edge_dimension
+    flow = source_data["flow_rate"].transpose("time", source_edge_dim)
+    link_matrix = _mapping_matrix(source_data["link_id"].to_numpy(), source_link_ids)
+    dataset["flow_rate"] = (("time", edge_dim), link_matrix.dot(flow.to_numpy().T).T)
+
+    source_node_dim = source_data.grid.node_dimension
+    source_node_ids = source_data["node_id"].to_numpy()
+    rows = basin_aggregation.source_ids_by_output(nodes.index)
+    basin_matrix = _mapping_matrix(source_node_ids, rows)
+    has_basin = np.asarray(basin_matrix.getnnz(axis=1) > 0)
+    sum_variables = tuple(dict.fromkeys((*BASIN_ADDITIVE_VARIABLES, *vertical_variables)))
+    for variable in sum_variables:
+        if variable not in source_data:
+            continue
+        values = source_data[variable].transpose("time", source_node_dim).to_numpy()
+        aggregated = basin_matrix.dot(values.T).T
+        aggregated[:, ~has_basin] = np.nan
+        dataset[variable] = (("time", node_dim), aggregated)
+
+    if "level" in source_data:
+        values = source_data["level"].transpose("time", source_node_dim).to_numpy()
+        source_weights = basin_aggregation.source_area.reindex(source_node_ids, fill_value=0).to_numpy()
+        weighted_matrix = basin_matrix.multiply(source_weights)
+        aggregated = weighted_matrix.dot(values.T).T
+        output_area = basin_aggregation.output_area.reindex(nodes.index, fill_value=0).to_numpy()
+        aggregated[:, has_basin] /= output_area[has_basin]
+        aggregated[:, ~has_basin] = np.nan
+        dataset["level"] = (("time", node_dim), aggregated)
+
+    for variable in ("relative_error", "convergence"):
+        if variable not in source_data:
+            continue
+        values = source_data[variable].transpose("time", source_node_dim).to_numpy()
+        aggregated = basin_matrix.dot(values.T).T
+        counts = np.asarray(basin_matrix.getnnz(axis=1))
+        aggregated[:, has_basin] /= counts[has_basin]
+        aggregated[:, ~has_basin] = np.nan
+        dataset[variable] = (("time", node_dim), aggregated)
+
+    inflow_rate, outflow_rate = _basin_flow_rates(dataset["flow_rate"].to_numpy(), links, nodes)
+    dataset["inflow_rate"] = (("time", node_dim), inflow_rate)
+    dataset["outflow_rate"] = (("time", node_dim), outflow_rate)
+
+    return cast(Any, xu.UgridDataset)(dataset, grid)
+
+
+def _basin_flow_rates(
+    flow: np.ndarray,
+    links: gpd.GeoDataFrame,
+    nodes: gpd.GeoDataFrame,
+) -> tuple[np.ndarray, np.ndarray]:
+    basin_ids = nodes.index[nodes["node_type"] == "Basin"]
+    node_positions = {int(node_id): position for position, node_id in enumerate(nodes.index)}
+    inflow = np.full((flow.shape[0], len(nodes)), np.nan)
+    outflow = np.full_like(inflow, np.nan)
+    for node_id in basin_ids:
+        position = node_positions[int(node_id)]
+        inflow[:, position] = 0.0
+        outflow[:, position] = 0.0
+
+    for link_position, (from_id, to_id) in enumerate(links[["from_node_id", "to_node_id"]].to_numpy(dtype=int)):
+        rates = flow[:, link_position]
+        if from_id in node_positions and nodes.at[from_id, "node_type"] == "Basin":
+            position = node_positions[from_id]
+            outflow[:, position] += np.maximum(rates, 0)
+            inflow[:, position] += np.maximum(-rates, 0)
+        if to_id in node_positions and nodes.at[to_id, "node_type"] == "Basin":
+            position = node_positions[to_id]
+            inflow[:, position] += np.maximum(rates, 0)
+            outflow[:, position] += np.maximum(-rates, 0)
+    return inflow, outflow
+
+
+def _source_basin_mapping(nodes: gpd.GeoDataFrame, groups: NodeGroups) -> pd.Series:
+    group_to_output = nodes.loc[nodes["group_id"].notna()].reset_index().set_index("group_id")["node_id"]
+    mapping = groups.basin_to_group.map(group_to_output)
+    ungrouped_ids = nodes.index[(nodes["node_type"] == "Basin") & nodes["group_id"].isna()]
+    ungrouped = pd.Series(ungrouped_ids, index=ungrouped_ids, dtype="int64")
+    return pd.concat([mapping.astype("int64"), ungrouped]).rename("output_node_id")
+
+
+def _budget_column_name(time: pd.Timestamp, term: str) -> str:
+    period = str(time.year) if time.month == 1 and time.day == 1 else time.strftime("%Y_%m")
+    return f"meta_{period}_{term}_mm_day"
+
+
+def _build_basin_budget(
+    model: ribasim.Model,
+    basin_aggregation: _BasinAggregation,
+    nodes: gpd.GeoDataFrame,
+    dataset: xu.UgridDataset,
+) -> tuple[gpd.GeoDataFrame | None, pd.DataFrame | None]:
+    if not hasattr(model, "basin"):
+        return None, None
+    area_df = model.basin.area.df
+    if area_df is None:
+        return None, None
+
+    source_areas = area_df.loc[
+        area_df["node_id"].isin(basin_aggregation.source_to_output.index), ["node_id", "geometry"]
+    ].copy()
+    source_areas["node_id"] = source_areas["node_id"].map(basin_aggregation.source_to_output)
+    basin_areas = source_areas.dissolve(by="node_id").sort_index()
+    basin_areas["meta_profile_area_m2"] = basin_aggregation.output_area.reindex(basin_areas.index)
+
+    dynamic_dataset = cast(Any, dataset)
+    times = pd.DatetimeIndex(dynamic_dataset["time"].to_numpy())
+    basin_ids = nodes.index[nodes["node_type"] == "Basin"].to_numpy()
+    node_positions = pd.Series(np.arange(len(nodes)), index=nodes.index).loc[basin_ids].to_numpy()
+    areas = basin_aggregation.output_area.reindex(basin_ids).to_numpy()
+    factor = 86_400_000.0 / areas
+    records: list[pd.DataFrame] = []
+
+    node_dim = dynamic_dataset.grid.node_dimension
+    for variable in dynamic_dataset.data_vars:
+        data_array = dynamic_dataset[variable]
+        if (
+            variable not in BASIN_RATE_VARIABLES
+            or variable in {"inflow_rate", "outflow_rate"}
+            or "time" not in data_array.dims
+            or node_dim not in data_array.dims
+        ):
+            continue
+        values = data_array.transpose("time", node_dim).to_numpy()[:, node_positions] * factor
+        records.append(
+            pd.DataFrame(
+                {
+                    "time": np.repeat(times, len(basin_ids)),
+                    "node_id": np.tile(basin_ids, len(times)),
+                    "term": variable,
+                    "direction": "vertical",
+                    "value_mm_day": values.reshape(-1),
+                }
+            )
+        )
+
+    for term, variable in (("inflow", "inflow_rate"), ("outflow", "outflow_rate")):
+        values = dynamic_dataset[variable].transpose("time", node_dim).to_numpy()[:, node_positions] * factor
+        records.append(
+            pd.DataFrame(
+                {
+                    "time": np.repeat(times, len(basin_ids)),
+                    "node_id": np.tile(basin_ids, len(times)),
+                    "term": term,
+                    "direction": term,
+                    "value_mm_day": values.reshape(-1),
+                }
+            )
+        )
+
+    budget = pd.concat(records, ignore_index=True)
+    budget["profile_area_m2"] = budget["node_id"].map(basin_aggregation.output_area)
+    group_ids = nodes["group_id"] if "group_id" in nodes else pd.Series(dtype="object")
+    budget["group_id"] = budget["node_id"].map(group_ids)
+    for (time, term), values in budget.groupby(["time", "term"], sort=False):
+        column = _budget_column_name(pd.Timestamp(cast(Any, time)), str(term))
+        normalized = values.set_index("node_id")["value_mm_day"]
+        basin_areas[column] = normalized.reindex(basin_areas.index).to_numpy()
+    return basin_areas, budget
+
+
+def aggregate_spatial_results(
+    model: ribasim.Model,
+    groups: NodeGroups,
+    *,
+    dataset: xu.UgridDataset | None = None,
+    vertical_variables: Sequence[str] = VERTICAL_FLUX_VARIABLES,
+    aggregate_flow_boundaries: bool = False,
+    aggregate_level_boundaries: bool = False,
+    flow_boundary_filter: Mapping[str, Any] | None = None,
+    level_boundary_filter: Mapping[str, Any] | None = None,
+) -> AggregatedResults:
+    """Aggregate model results while retaining ungrouped areas.
+
+    Boundary aggregation creates one node per group and boundary type at the
+    centroid of the selected source nodes. Optional filters match Node columns
+    by equality.
+    """
+    source = model.to_xugrid(add_flow=True) if dataset is None else dataset
+    aggregator = _NetworkAggregator(model, groups)
+    paths = aggregator.contracted_paths()
+    nodes, links, source_link_ids, diagnostics = _build_output_network(
+        aggregator,
+        paths,
+        aggregate_flow_boundaries=aggregate_flow_boundaries,
+        aggregate_level_boundaries=aggregate_level_boundaries,
+        flow_boundary_filter=flow_boundary_filter,
+        level_boundary_filter=level_boundary_filter,
+    )
+    basin_aggregation = _BasinAggregation.from_model(model, nodes, groups)
+    output = _to_xugrid(source, nodes, links, source_link_ids, basin_aggregation, vertical_variables)
+    basin_areas, budget = _build_basin_budget(model, basin_aggregation, nodes, output)
+    return AggregatedResults(output, nodes, links, diagnostics, model, basin_areas, budget)
+
+
+def aggregate_results(
+    model: ribasim.Model,
+    groups: NodeGroups,
+    *,
+    frequency: str | None = None,
+    seasonal: bool = False,
+    vertical_variables: Sequence[str] = VERTICAL_FLUX_VARIABLES,
+    aggregate_flow_boundaries: bool = False,
+    aggregate_level_boundaries: bool = False,
+    flow_boundary_filter: Mapping[str, Any] | None = None,
+    level_boundary_filter: Mapping[str, Any] | None = None,
+) -> AggregatedResults:
+    """Aggregate Ribasim results over time and space.
+
+    Temporal aggregation is applied first because it reduces the amount of data
+    processed by the spatial sparse matrices. Only regular time series are accepted.
+    FlowBoundary and LevelBoundary aggregation are independently configurable;
+    their optional filters match Node columns by equality.
+    """
+    if frequency is not None and seasonal:
+        raise ValueError("Choose either frequency or seasonal aggregation, not both.")
+    dataset = model.to_xugrid(add_flow=True)
+    if seasonal:
+        dataset = aggregate_seasonal_results(dataset)
+    elif frequency is not None:
+        dataset = aggregate_time_results(dataset, frequency)
+    return aggregate_spatial_results(
+        model,
+        groups,
+        dataset=dataset,
+        vertical_variables=vertical_variables,
+        aggregate_flow_boundaries=aggregate_flow_boundaries,
+        aggregate_level_boundaries=aggregate_level_boundaries,
+        flow_boundary_filter=flow_boundary_filter,
+        level_boundary_filter=level_boundary_filter,
+    )
+
+
+def _export_node_table(results: AggregatedResults) -> gpd.GeoDataFrame:
+    nodes = results.nodes.copy()
+    if "group_id" in nodes:
+        nodes = nodes.rename(columns={"group_id": "meta_group_id"})
+    defaults = {
+        "name": "",
+        "subnetwork_id": None,
+        "route_priority": None,
+        "cyclic_time": False,
+    }
+    for column, default in defaults.items():
+        if column not in nodes:
+            nodes[column] = default
+        else:
+            nodes[column] = nodes[column].fillna(default)
+    nodes.index.name = "node_id"
+    return nodes
+
+
+def _export_link_table(results: AggregatedResults) -> gpd.GeoDataFrame:
+    links = results.links.copy()
+    if "name" not in links:
+        links["name"] = ""
+    else:
+        links["name"] = links["name"].fillna("")
+    links.index.name = "link_id"
+    return links
+
+
+def _write_result_netcdf(results: AggregatedResults, results_dir: Path) -> None:
+    dataset = cast(Any, results.dataset)
+    edge_dim = dataset.grid.edge_dimension
+    node_dim = dataset.grid.node_dimension
+
+    flow = xr.Dataset(
+        data_vars={
+            "flow_rate": xr.DataArray(
+                dataset["flow_rate"].transpose("time", edge_dim).to_numpy(),
+                dims=("time", "link_id"),
+                attrs={"units": "m3 s-1"},
+            )
+        },
+        coords={
+            "time": dataset["time"].to_numpy(),
+            "link_id": dataset["link_id"].to_numpy(),
+            "from_node_id": ("link_id", dataset["from_node_id"].to_numpy()),
+            "to_node_id": ("link_id", dataset["to_node_id"].to_numpy()),
+        },
+    )
+    flow.to_netcdf(results_dir / "flow.nc")
+
+    basin_node_ids = results.nodes.index[results.nodes["node_type"] == "Basin"]
+    node_positions = pd.Series(np.arange(len(results.nodes)), index=results.nodes.index).loc[basin_node_ids].to_numpy()
+    basin_variables = {}
+    for variable, attributes in BASIN_RESULT_ATTRIBUTES.items():
+        if variable not in dataset:
+            continue
+        values = dataset[variable].transpose("time", node_dim).to_numpy()[:, node_positions]
+        basin_variables[variable] = xr.DataArray(values, dims=("time", "node_id"), attrs=attributes)
+    basin = xr.Dataset(
+        data_vars=basin_variables,
+        coords={
+            "time": xr.DataArray(
+                dataset["time"].to_numpy(),
+                dims="time",
+                attrs={"axis": "T", "standard_name": "time", "long_name": "time"},
+            ),
+            "node_id": xr.DataArray(
+                basin_node_ids.to_numpy(),
+                dims="node_id",
+                attrs={"cf_role": "timeseries_id", "long_name": "node identifier"},
+            ),
+        },
+        attrs={
+            "Conventions": "CF-1.12",
+            "references": "https://ribasim.org",
+            "ribasim_version": results.source_model.ribasim_version,
+            "title": "Ribasim results: basin",
+        },
+    )
+    basin["time"].encoding["calendar"] = "standard"
+    basin.to_netcdf(results_dir / "basin.nc")
+    if "level" in basin:
+        basin_state = basin[["level"]].isel(time=-1, drop=True)
+        basin_state.to_netcdf(results_dir / "basin_state.nc")
+
+
+def write_visualization_model(results: AggregatedResults, directory: str | Path) -> Path:
+    """Write aggregated geometry and results as a non-runnable visualization package."""
+    directory = Path(directory)
+    input_dir = directory / "input"
+    results_dir = directory / "results"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    database = input_dir / "database.gpkg"
+    if database.exists():
+        database.unlink()
+    nodes = _export_node_table(results)
+    links = _export_link_table(results)
+    nodes.to_file(database, layer="Node", driver="GPKG", index=True, fid=nodes.index.name)
+    links.to_file(database, layer="Link", driver="GPKG", index=True, fid=links.index.name)
+    if results.basin_areas is not None:
+        results.basin_areas.reset_index().to_file(database, layer="Basin / area", driver="GPKG", index=False)
+    _set_db_schema_version(database, __schema_version__)
+    _write_result_netcdf(results, results_dir)
+
+    starttime = pd.Timestamp(results.source_model.starttime).strftime("%Y-%m-%d %H:%M:%S")
+    endtime = pd.Timestamp(results.source_model.endtime).strftime("%Y-%m-%d %H:%M:%S")
+    assert results.nodes.crs is not None
+    crs = results.nodes.crs.to_string()
+    version = results.source_model.ribasim_version
+    toml = directory / "ribasim.toml"
+    toml.write_text(
+        f"starttime = {starttime}\n"
+        f"endtime = {endtime}\n"
+        f'crs = "{crs}"\n'
+        'input_dir = "input"\n'
+        'results_dir = "results"\n'
+        f'ribasim_version = "{version}"\n',
+        encoding="utf-8",
+    )
+    return toml

--- a/src/ribasim_nl/tests/test_zonebudget.py
+++ b/src/ribasim_nl/tests/test_zonebudget.py
@@ -1,0 +1,484 @@
+import sqlite3
+from types import SimpleNamespace
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+import xugrid as xu
+from ribasim import Model
+from ribasim_nl.zonebudget import NodeGroups, aggregate_results, aggregate_seasonal_results, aggregate_time_results
+from shapely.geometry import LineString, Point, box
+
+
+def _model_and_results(*, with_boundaries=False, with_boundary_junction=False, with_reverse_group_link=False):
+    node_records = [
+        (1, "Basin", Point(0, 0)),
+        (2, "Pump", Point(1, 0)),
+        (3, "Basin", Point(2, 0)),
+        (4, "Pump", Point(0, -1)),
+        (5, "LevelBoundary", Point(2, -1)),
+        (6, "Basin", Point(4, 0)),
+        (7, "Outlet", Point(3, 0)),
+        (8, "Junction", Point(3.5, 0)),
+    ]
+    if with_boundaries:
+        node_records.extend(
+            [
+                (9, "FlowBoundary", Point(-2, 1)),
+                (10, "FlowBoundary", Point(-2, -1)),
+                (11, "FlowBoundary", Point(-1, 2)),
+                (12, "LevelBoundary", Point(-1, -2)),
+            ]
+        )
+    if with_boundary_junction:
+        node_records.extend([(13, "Junction", Point(-1, 0.5)), (14, "Junction", Point(-1, -0.5))])
+    nodes = gpd.GeoDataFrame(
+        node_records,
+        columns=["node_id", "node_type", "geometry"],
+        crs=28992,
+    ).set_index("node_id")
+    link_records = [
+        (10, 1, 2),
+        (11, 2, 3),
+        (12, 1, 4),
+        (13, 4, 5),
+        (14, 3, 7),
+        (15, 7, 8),
+        (16, 8, 6),
+    ]
+    if with_boundaries:
+        if with_boundary_junction:
+            link_records.extend([(17, 9, 13), (22, 13, 1), (18, 10, 14), (23, 14, 1), (19, 11, 1), (20, 12, 1)])
+        else:
+            link_records.extend([(17, 9, 1), (18, 10, 1), (19, 11, 1), (20, 12, 1)])
+    if with_reverse_group_link:
+        link_records.append((21, 3, 1))
+    links = gpd.GeoDataFrame(
+        [
+            {
+                "link_id": link_id,
+                "from_node_id": from_id,
+                "to_node_id": to_id,
+                "link_type": "flow",
+                "geometry": LineString((nodes.at[from_id, "geometry"], nodes.at[to_id, "geometry"])),
+            }
+            for link_id, from_id, to_id in link_records
+        ],
+        crs=nodes.crs,
+    ).set_index("link_id")
+
+    node_positions = pd.Series(np.arange(len(nodes)), index=nodes.index)
+    connectivity = np.array(
+        [(node_positions[from_id], node_positions[to_id]) for _, from_id, to_id in link_records], dtype=int
+    )
+    grid = xu.Ugrid1d(
+        nodes.geometry.x.to_numpy(),
+        nodes.geometry.y.to_numpy(),
+        -1,
+        connectivity,
+        name="ribasim",
+        crs=nodes.crs,
+    )
+    time = pd.date_range("2020-01-01", periods=4, freq="h")
+    flow = np.tile(np.arange(1.0, len(links) + 1.0), (len(time), 1))
+    drainage = np.full((len(time), len(nodes)), np.nan)
+    drainage[:, [0, 2, 5]] = [1.0, 2.0, 3.0]
+    dataset = xr.Dataset(
+        data_vars={
+            "flow_rate": (("time", grid.edge_dimension), flow),
+            "drainage": (("time", grid.node_dimension), drainage),
+            "level": (("time", grid.node_dimension), drainage + 10.0),
+            "storage": (("time", grid.node_dimension), drainage * 100.0),
+            "storage_rate": (("time", grid.node_dimension), drainage - 1.5),
+        },
+        coords={
+            "time": time,
+            "link_id": (grid.edge_dimension, links.index.to_numpy()),
+            "node_id": (grid.node_dimension, nodes.index.to_numpy()),
+        },
+    )
+    results = xu.UgridDataset(dataset, grid)
+    model = SimpleNamespace(
+        node=SimpleNamespace(df=nodes),
+        link=SimpleNamespace(df=links),
+        ribasim_version="2026.1.2",
+        starttime=pd.Timestamp("2020-01-01"),
+        endtime=pd.Timestamp("2020-01-01 04:00"),
+        to_xugrid=lambda add_flow: results,
+    )
+    _add_basin_tables(model)
+    return model, results
+
+
+def _add_basin_tables(model):
+    area = gpd.GeoDataFrame(
+        {
+            "node_id": [1, 3, 6],
+            "geometry": [box(-0.4, -0.4, 0.4, 0.4), box(1.6, -0.4, 2.4, 0.4), box(3.6, -0.4, 4.4, 0.4)],
+        },
+        crs=model.node.df.crs,
+    )
+    profile = pd.DataFrame(
+        {
+            "node_id": [1, 1, 3, 3, 6, 6],
+            "level": [0.0, 1.0] * 3,
+            "area": [500.0, 1_000.0, 1_000.0, 2_000.0, 2_000.0, 4_000.0],
+        }
+    )
+    model.basin = SimpleNamespace(area=SimpleNamespace(df=area), profile=SimpleNamespace(df=profile))
+
+
+def test_mixed_resolution_aggregation():
+    model, _ = _model_and_results()
+    groups = NodeGroups.from_ids(model, {"A": [1], "B": [3]})
+
+    result = aggregate_results(model, groups)
+
+    assert result.diagnostics.contracted_connector_ids == (2,)
+    assert result.diagnostics.ungrouped_basin_ids == (6,)
+    assert set(result.links.index[:-1]) == {12, 13, 14, 15, 16}
+    assert result.links.index[-1] == 17
+    assert result.dataset["flow_rate"].sel(aggregated_nEdges=5).to_numpy().tolist() == [2.0] * 4
+
+    group_nodes = result.nodes[result.nodes["group_id"].notna()]
+    group_a_id = group_nodes.index[group_nodes["group_id"] == "A"].item()
+    assert result.links.at[12, "from_node_id"] == group_a_id
+    np.testing.assert_allclose(result.dataset["drainage"].to_numpy()[:, -2:], [[1.0, 2.0]] * 4)
+    node_position = result.nodes.index.get_loc(group_a_id)
+    assert result.dataset["inflow_rate"][:, node_position].to_numpy().tolist() == [0.0] * 4
+    assert result.dataset["outflow_rate"][:, node_position].to_numpy().tolist() == [5.0] * 4
+
+
+def test_internal_connector_and_junction_chain_is_absorbed():
+    model, _ = _model_and_results()
+
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"B": [3, 6]}))
+
+    assert not {7, 8}.intersection(result.nodes.index)
+    assert not {14, 15, 16}.intersection(result.links.index)
+    assert not (result.links["from_node_id"] == result.links["to_node_id"]).any()
+
+
+def test_grouped_controls_are_removed_but_ungrouped_controls_remain():
+    model, _ = _model_and_results()
+    model.node.df["meta_waterbeheerder"] = None
+    model.node.df.loc[[1, 3], "meta_waterbeheerder"] = ["A", "B"]
+    model.node.df.loc[9] = {"node_type": "DiscreteControl", "geometry": Point(0.5, 0), "meta_waterbeheerder": "A"}
+    model.node.df.loc[10] = {
+        "node_type": "ContinuousControl",
+        "geometry": Point(10, 0),
+        "meta_waterbeheerder": None,
+    }
+    model.node.df.loc[11] = {"node_type": "FlowDemand", "geometry": Point(0.25, 0), "meta_waterbeheerder": "A"}
+
+    result = aggregate_results(model, NodeGroups.from_node_column(model, "meta_waterbeheerder"))
+
+    assert 9 not in result.nodes.index
+    assert 10 in result.nodes.index
+    assert 11 not in result.nodes.index
+
+
+def test_node_column_values_can_remain_ungrouped():
+    model, _ = _model_and_results()
+    model.node.df["meta_waterbeheerder"] = None
+    model.node.df.loc[[1, 3], "meta_waterbeheerder"] = ["A", "Rijkswaterstaat"]
+
+    groups = NodeGroups.from_node_column(
+        model,
+        "meta_waterbeheerder",
+        exclude=["Rijkswaterstaat"],
+    )
+    result = aggregate_results(model, groups)
+
+    assert groups.basin_to_group.to_dict() == {1: "A"}
+    assert 3 in result.nodes.index
+    assert result.nodes.at[3, "node_type"] == "Basin"
+
+
+def test_basin_areas_are_dissolved_and_profile_areas_are_summed():
+    model, _ = _model_and_results()
+    _add_basin_tables(model)
+    model.basin.profile.df.loc[
+        (model.basin.profile.df["node_id"] == 3) & (model.basin.profile.df["level"] == 0.0), "area"
+    ] = 10_000.0
+
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"A": [1, 3]}))
+
+    assert result.basin_areas is not None
+    group_id = result.nodes.index[result.nodes["group_id"] == "A"].item()
+    assert set(result.basin_areas.index) == {6, group_id}
+    assert result.basin_areas.at[group_id, "meta_profile_area_m2"] == 3_000.0
+    assert result.basin_areas.at[group_id, "geometry"].area == pytest.approx(1.28)
+
+
+def test_missing_top_profile_area_is_rejected():
+    model, _ = _model_and_results()
+    _add_basin_tables(model)
+    model.basin.profile.df = model.basin.profile.df[model.basin.profile.df["node_id"] != 3]
+
+    with pytest.raises(ValueError, match=r"top profile area.*3"):
+        aggregate_results(model, NodeGroups.from_ids(model, {"A": [1, 3]}))
+
+
+def test_budget_reverses_negative_flow_and_normalizes_each_basin(tmp_path):
+    model, dataset = _model_and_results()
+    _add_basin_tables(model)
+    dataset["flow_rate"][:] = 0.0
+    dataset["flow_rate"][:, 1] = -2.0
+
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"A": [1], "B": [3]}))
+
+    assert result.budget is not None
+    assert result.basin_areas is not None
+    group_a_id = result.nodes.index[result.nodes["group_id"] == "A"].item()
+    group_b_id = result.nodes.index[result.nodes["group_id"] == "B"].item()
+    first_time = pd.Timestamp("2020-01-01")
+    budget = result.budget.set_index(["time", "node_id", "term"])
+    assert budget.at[(first_time, group_a_id, "inflow"), "value_mm_day"] == pytest.approx(172_800.0)
+    assert budget.at[(first_time, group_b_id, "outflow"), "value_mm_day"] == pytest.approx(86_400.0)
+    assert budget.at[(first_time, group_a_id, "drainage"), "value_mm_day"] == pytest.approx(86_400.0)
+    assert result.basin_areas.at[group_a_id, "meta_2020_inflow_mm_day"] == pytest.approx(172_800.0)
+
+    toml = result.write_visualization_model(tmp_path / "aggregated")
+    database = toml.parent / "input" / "database.gpkg"
+    assert "Basin / area" in set(gpd.list_layers(database)["name"])
+    exported_area = gpd.read_file(database, layer="Basin / area")
+    assert set(exported_area["node_id"]) == {group_a_id, group_b_id, 6}
+    assert "meta_2020_inflow_mm_day" in exported_area
+
+
+def test_parallel_group_links_have_distinct_interiors():
+    model, _ = _model_and_results(with_reverse_group_link=True)
+
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"A": [1], "B": [3]}))
+
+    group_ids = set(result.nodes.index[result.nodes["group_id"].notna()])
+    group_links = result.links[
+        result.links["from_node_id"].isin(group_ids) & result.links["to_node_id"].isin(group_ids)
+    ]
+    assert len(group_links) == 2
+    assert all(len(geometry.coords) == 3 for geometry in group_links.geometry)
+    assert group_links.geometry.iloc[0].coords[1] != group_links.geometry.iloc[1].coords[1]
+
+
+def test_filtered_flow_boundaries_are_aggregated_per_group():
+    model, _ = _model_and_results(with_boundaries=True)
+    model.node.df["meta_waterbeheerder"] = None
+    model.node.df.loc[[1, 9, 10, 11, 12], "meta_waterbeheerder"] = "A"
+    model.node.df["meta_category"] = None
+    model.node.df.loc[[9, 10], "meta_category"] = "RWZI"
+    model.node.df.loc[11, "meta_category"] = "OTHER"
+
+    result = aggregate_results(
+        model,
+        NodeGroups.from_node_column(model, "meta_waterbeheerder"),
+        aggregate_flow_boundaries=True,
+        flow_boundary_filter={"meta_category": "RWZI"},
+    )
+
+    assert not {9, 10}.intersection(result.nodes.index)
+    assert {11, 12}.issubset(result.nodes.index)
+    flow_boundaries = result.nodes[result.nodes["node_type"] == "FlowBoundary"]
+    assert len(flow_boundaries) == 2
+    aggregated_id = flow_boundaries.index.difference([11]).item()
+    assert flow_boundaries.at[aggregated_id, "geometry"].equals(Point(-2, 0))
+    aggregated_link_id = result.links.index[result.links["from_node_id"] == aggregated_id].item()
+    values = result.dataset["flow_rate"].where(result.dataset["link_id"] == aggregated_link_id, drop=True)
+    assert values.to_numpy().ravel().tolist() == [17.0] * 4
+
+
+def test_junction_to_aggregated_boundary_is_contracted():
+    model, _ = _model_and_results(with_boundaries=True, with_boundary_junction=True)
+    model.node.df["meta_waterbeheerder"] = None
+    model.node.df.loc[[1, 9, 10], "meta_waterbeheerder"] = "A"
+    model.node.df["meta_category"] = None
+    model.node.df.loc[[9, 10], "meta_category"] = "RWZI"
+
+    result = aggregate_results(
+        model,
+        NodeGroups.from_node_column(model, "meta_waterbeheerder"),
+        aggregate_flow_boundaries=True,
+        flow_boundary_filter={"meta_category": "RWZI"},
+    )
+
+    assert not {13, 14}.intersection(result.nodes.index)
+    group_id = result.nodes.index[result.nodes["group_id"] == "A"].item()
+    boundary_id = result.nodes.index[
+        (result.nodes["node_type"] == "FlowBoundary") & (result.nodes["name"] == "A FlowBoundary")
+    ].item()
+    link_id = result.links.index[
+        (result.links["from_node_id"] == boundary_id) & (result.links["to_node_id"] == group_id)
+    ].item()
+    values = result.dataset["flow_rate"].where(result.dataset["link_id"] == link_id, drop=True)
+    assert values.to_numpy().ravel().tolist() == [20.0] * 4
+
+
+def test_level_boundary_aggregation_has_separate_flag():
+    model, _ = _model_and_results(with_boundaries=True)
+    model.node.df["meta_waterbeheerder"] = None
+    model.node.df.loc[[1, 9, 10, 11, 12], "meta_waterbeheerder"] = "A"
+
+    result = aggregate_results(
+        model,
+        NodeGroups.from_node_column(model, "meta_waterbeheerder"),
+        aggregate_level_boundaries=True,
+    )
+
+    assert {9, 10, 11}.issubset(result.nodes.index)
+    assert 12 not in result.nodes.index
+
+
+def test_polygon_edge_is_ambiguous():
+    model, _ = _model_and_results()
+    polygons = gpd.GeoDataFrame(
+        {"zone": ["left", "right"], "geometry": [box(-1, -1, 0, 1), box(0, -1, 1, 1)]},
+        crs=model.node.df.crs,
+    )
+
+    with pytest.raises(ValueError, match="multiple groups"):
+        NodeGroups.from_polygons(model, polygons, "zone")
+
+
+def test_time_aggregation_rejects_irregular_steps():
+    _, dataset = _model_and_results()
+    dataset = dataset.assign_coords(
+        time=pd.to_datetime(["2020-01-01", "2020-01-01 01:00", "2020-01-01 03:00", "2020-01-01 04:00"], format="mixed")
+    )
+
+    with pytest.raises(ValueError, match="regular timesteps"):
+        aggregate_time_results(dataset, "D")
+
+
+def test_time_aggregation_uses_mean_rates():
+    _, dataset = _model_and_results()
+    dataset["flow_rate"][:, 0] = [1.0, 3.0, 5.0, 7.0]
+
+    aggregated = aggregate_time_results(dataset, "2h")
+
+    assert isinstance(aggregated, xu.UgridDataset)
+    assert aggregated["flow_rate"][:, 0].to_numpy().tolist() == [2.0, 6.0]
+
+
+def test_time_aggregation_keeps_signed_storage_rate():
+    _, dataset = _model_and_results()
+    dataset["storage_rate"][:, 0] = [-2.0, 4.0, -6.0, 8.0]
+
+    aggregated = aggregate_time_results(dataset, "2h")
+
+    assert aggregated["storage_rate"][:, 0].to_numpy().tolist() == [1.0, 1.0]
+    assert "storage_increase" not in aggregated
+    assert "storage_decrease" not in aggregated
+
+
+def test_storage_is_summed_and_level_is_area_weighted():
+    model, _ = _model_and_results()
+
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"A": [1, 3]}))
+
+    group_id = result.nodes.index[result.nodes["group_id"] == "A"].item()
+    position = result.nodes.index.get_loc(group_id)
+    assert result.dataset["storage"][:, position].to_numpy().tolist() == [300.0] * 4
+    assert result.dataset["storage_rate"][:, position].to_numpy().tolist() == [0.0] * 4
+    assert result.dataset["level"][:, position].to_numpy().tolist() == pytest.approx([35.0 / 3.0] * 4)
+
+
+def test_seasonal_aggregation_uses_april_and_october_boundaries():
+    _, dataset = _model_and_results()
+    daily = dataset.isel(time=np.zeros(366, dtype=int)).assign_coords(
+        time=pd.date_range("2019-10-01", periods=366, freq="D")
+    )
+    daily["flow_rate"][:, 0] = np.select(
+        [(daily["time"].dt.month >= 4) & (daily["time"].dt.month <= 9)],
+        [6.5],
+        default=2.0,
+    )
+
+    aggregated = aggregate_seasonal_results(daily)
+
+    assert aggregated["time"].to_numpy().tolist() == [
+        pd.Timestamp("2019-10-01").to_datetime64(),
+        pd.Timestamp("2020-04-01").to_datetime64(),
+    ]
+    assert aggregated["flow_rate"][:, 0].to_numpy().tolist() == [2.0, 6.5]
+
+
+def test_frequency_and_seasonal_aggregation_are_mutually_exclusive():
+    model, _ = _model_and_results()
+
+    with pytest.raises(ValueError, match="either frequency or seasonal"):
+        aggregate_results(model, NodeGroups.from_ids(model, {"A": [1]}), frequency="YS", seasonal=True)
+
+
+def test_user_demand_between_groups_is_rejected():
+    model, _ = _model_and_results()
+    model.node.df.at[2, "node_type"] = "UserDemand"
+
+    with pytest.raises(ValueError, match="non-conservative"):
+        aggregate_results(model, NodeGroups.from_ids(model, {"A": [1], "B": [3]}))
+
+
+def test_user_demand_within_group_is_internal():
+    model, _ = _model_and_results()
+    model.node.df.at[2, "node_type"] = "UserDemand"
+
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"A": [1, 3]}))
+
+    assert 2 not in result.nodes.index
+    assert not {10, 11}.intersection(result.links.index)
+
+
+def test_write_visualization_model(tmp_path):
+    model, _ = _model_and_results()
+    result = aggregate_results(model, NodeGroups.from_ids(model, {"A": [1], "B": [3]}))
+
+    toml = result.write_visualization_model(tmp_path / "aggregated")
+
+    assert toml.read_text(encoding="utf-8").splitlines() == [
+        "starttime = 2020-01-01 00:00:00",
+        "endtime = 2020-01-01 04:00:00",
+        'crs = "EPSG:28992"',
+        'input_dir = "input"',
+        'results_dir = "results"',
+        'ribasim_version = "2026.1.2"',
+    ]
+    database = toml.parent / "input" / "database.gpkg"
+    assert set(gpd.list_layers(database)["name"]) == {"Node", "Link", "Basin / area", "ribasim_metadata"}
+    assert "meta_group_id" in gpd.read_file(database, layer="Node")
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("PRAGMA table_info('Node')").fetchone()[1] == "node_id"
+        assert connection.execute("PRAGMA table_info('Link')").fetchone()[1] == "link_id"
+        assert connection.execute("SELECT value FROM ribasim_metadata WHERE key = 'schema_version'").fetchone() == (
+            "11",
+        )
+    with xr.open_dataset(toml.parent / "results" / "flow.nc") as flow:
+        assert flow.sizes == {"time": 4, "link_id": 6}
+    with xr.open_dataset(toml.parent / "results" / "basin.nc") as basin:
+        assert basin.sizes == {"time": 4, "node_id": 3}
+        assert {
+            "level",
+            "storage",
+            "inflow_rate",
+            "outflow_rate",
+            "storage_rate",
+            "drainage",
+        }.issubset(basin.data_vars)
+        assert "storage_increase" not in basin
+        assert "storage_decrease" not in basin
+        assert basin["inflow_rate"].attrs["units"] == "m3 s-1"
+        assert basin["level"].attrs["standard_name"] == "water_surface_height_above_reference_datum"
+        assert basin.attrs == {
+            "Conventions": "CF-1.12",
+            "references": "https://ribasim.org",
+            "ribasim_version": "2026.1.2",
+            "title": "Ribasim results: basin",
+        }
+    with xr.open_dataset(toml.parent / "results" / "basin_state.nc") as basin_state:
+        assert set(basin_state.data_vars) == {"level"}
+        assert basin_state.sizes == {"node_id": 3}
+    read_model = Model.read(toml)
+    assert len(read_model.node.df) == len(result.nodes)
+    assert set(read_model.to_xugrid(add_flow=True).data_vars).issuperset(
+        {"level", "storage", "inflow_rate", "outflow_rate", "storage_rate"}
+    )


### PR DESCRIPTION
This makes it possible to aggregate parts of Ribasim models over time and space. For instance, give yearly averages for each waterboard.

<img width="1096" height="800" alt="Screenshot 2026-08-11 144719" src="https://github.com/user-attachments/assets/964f0706-3a63-4370-b337-cf4ecbae0d07" />

It also adds average `mm/day` vertical fluxes which it puts on `Basin / area` columns.

---

## Summary

Add reusable spatial and temporal aggregation for Ribasim results using xarray, xugrid, and sparse matrices.

- Group Basins by IDs, node metadata, or polygons.
- Preserve ungrouped areas at their original resolution.
- Contract internal network topology and aggregate boundary flows.
- Generate annual water-authority and seasonal ECHO visualization models.
- Write Ribasim-compatible GeoPackage and NetCDF results.

## Water balance

- Match the native `basin.nc` schema and CF metadata.
- Store only signed `storage_rate`; QGIS derives `storage_increase` and `storage_decrease`.
- Sum additive quantities such as storage and fluxes.
- Calculate grouped levels as top-profile-area weighted means.
- Normalize polygon water-balance terms to mm/day.
- Write `basin_state.nc` for Ribasim/QGIS result loading.

## Additional changes

- Add SciPy for sparse aggregation matrices.
- Add repository working agreements in `AGENTS.md`.
- Both models load through `Model.read()` and `to_xugrid(add_flow=True)`.
- Verified storage sums and area-weighted levels against source results for several large water authorities.