### PR TITLE
Add regression tests for dynamical equilibrium

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,6 +22,7 @@ website:
     - title: "Contributing"
       contents:
         - dev/index.qmd
+        - dev/testing.qmd
         - dev/dvc.qmd
         - dev/type-checking.qmd
         - dev/slurm.qmd

--- a/docs/dev/index.qmd
+++ b/docs/dev/index.qmd
@@ -58,12 +58,6 @@ To run all hooks on all files manually:
 pixi run check
 ```
 
-To skip the slower DVC hooks and only run Python linting, formatting, and type checking:
-
-```sh
-pixi run pycheck
-```
-
 ## Co-development with Ribasim
 
 Ribasim-NL pins to a specific Ribasim version in `pixi.toml`.

--- a/docs/dev/testing.qmd
+++ b/docs/dev/testing.qmd
@@ -1,0 +1,33 @@
+---
+title: "Testing"
+---
+
+Run the repository checks before submitting changes:
+
+```sh
+pixi run check
+```
+
+This also runs on CI.
+
+## Model input validation
+
+`Model.validate_ribasim_nl()` runs extensible checks on model input and supplements Ribasim schema validation. Add project-wide input rules to `ribasim_nl.validation.validate_model`.
+
+## Result regression testing
+
+The dry and wet steady-state scenarios guard against a Basin losing its ability to maintain its water level. During the existing `bergend_*` and `forcing_*` DVC stages, and in `repro.sh`, the dry and wet models are run and checked. A Basin is steady-state when its final water level differs by at most 0.01 m from the mean of the final 24 hours and its storage remains positive throughout the simulation.
+
+Known level-instability exceptions are kept as explicit scenario-specific Basin node IDs in `peilbeheerst_model.steady_state_regression`. Exceptions do not bypass the positive-storage check, and an exception for a missing Basin ID fails the run.
+
+Scenario results are available for inspection in each model's `results` directory, including `output_controle.gpkg` and `output_controle.qlr`.
+
+## Completed-model result checks
+
+`Control.run()` exports selected result metrics to `results/output_controle.gpkg`. It defaults to `DYNAMIC_FORCING_METRICS`; use `STATIC_FORCING_METRICS` or `AFVOER_METRICS` for the other established workflows, or pass a custom metric set. Call `Control.validate_result_conditions()` after export to enforce conditions. It logs every violation with its Basin node ID before raising one error, so all failures can be addressed together.
+
+New completed-model checks belong on `Control` and can be called after future dynamic model exports without changing the dry/wet scenario runner.
+
+### Allowing a known exception
+
+Only after reviewing an intentional model change, add the Basin node ID to `ALLOWED_NON_STEADY_STATE_NODE_IDS` for its authority and scenario. Remove an exception once the Basin becomes steady-state again.

--- a/dvc.lock
+++ b/dvc.lock
@@ -5,60 +5,60 @@ stages:
     deps:
     - path: data/AaenMaas/modellen/AaenMaas_dynamic_model
       hash: md5
-      md5: b15be66679c38bdf60d1b16cf522c0c9.dir
-      size: 96601301
+      md5: a612f86bf75f05596888942c6dbc893c.dir
+      size: 96601199
       nfiles: 5
     - path: data/AmstelGooienVecht/modellen/AmstelGooienVecht_forcing
       hash: md5
-      md5: 2ecbd7e249f383a41d2055e4ee8608a1.dir
+      md5: 0917c8d7149b84e6544ba1da2ff0cb79.dir
       size: 46149813
       nfiles: 2
     - path: data/BrabantseDelta/modellen/BrabantseDelta_dynamic_model
       hash: md5
-      md5: b7b5e59102b4e0d0d024e7959c8658ec.dir
-      size: 125677107
+      md5: 7e507583b7aaf3ba8dcf921d9b0643af.dir
+      size: 125677053
       nfiles: 5
     - path: data/DeDommel/modellen/DeDommel_dynamic_model
       hash: md5
-      md5: 8ef6cea26a73807ca783db0bdc87f56d.dir
-      size: 130578608
+      md5: 3781b307bb3ad60e7402c03815df62de.dir
+      size: 130578703
       nfiles: 5
     - path: data/Delfland/modellen/Delfland_forcing
       hash: md5
-      md5: 80c4171d992d97db86d077c6b7b56356.dir
+      md5: 19d844ca98b903df64b611d3b9f0ea89.dir
       size: 23064757
       nfiles: 2
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_dynamic_model
       hash: md5
-      md5: 230e9d38cb203c20f087c126ef536f40.dir
-      size: 87167530
+      md5: 39e0ce48225feaafb072733f93ec5b4b.dir
+      size: 87167589
       nfiles: 5
     - path:
         data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_forcing
       hash: md5
-      md5: 7df64671a32f6777296c6bd99fc4e4e5.dir
+      md5: dc15ec23e55d2707ff90a113f81df622.dir
       size: 49971381
       nfiles: 2
     - path: data/HollandseDelta/modellen/HollandseDelta_forcing
       hash: md5
-      md5: b4b25b6b86004da76829eb3836eda9ba.dir
+      md5: d480999e727409112e20873df8170da5.dir
       size: 93483189
       nfiles: 2
     - path: data/HunzeenAas/modellen/HunzeenAas_dynamic_model
       hash: md5
-      md5: b517b2b070a736a23431f39961196f28.dir
-      size: 74145501
+      md5: 5c426152f19b79cdbbb88f4049551026.dir
+      size: 74145560
       nfiles: 5
     - path: data/Limburg/modellen/Limburg_dynamic_model
       hash: md5
-      md5: 9740babc7d84831412bfe70f71c2b537.dir
-      size: 136869812
+      md5: eaa25f2d9988eea5016ad5b684e21bfb.dir
+      size: 136870248
       nfiles: 5
     - path: data/Noorderzijlvest/modellen/Noorderzijlvest_dynamic_model
       hash: md5
-      md5: d27e66bd94923b649aa85d13a41c7226.dir
-      size: 88181726
+      md5: de6d5477ddc65bbe4f307202cc72010a.dir
+      size: 88182144
       nfiles: 5
     - path: data/Rijkswaterstaat/modellen/hws_transient
       hash: md5
@@ -67,53 +67,53 @@ stages:
       nfiles: 2
     - path: data/RijnenIJssel/modellen/RijnenIJssel_dynamic_model
       hash: md5
-      md5: 7758e510b747aca220c9b8a0930d25fd.dir
-      size: 54802005
+      md5: 93b23383e32cfce711f63a5a988cebe5.dir
+      size: 54802231
       nfiles: 5
     - path: data/Rijnland/modellen/Rijnland_forcing
       hash: md5
-      md5: 03833ec3da148d978cc9e76c3f5901ae.dir
+      md5: e290e476f2442bc101d6952785ea9afc.dir
       size: 67440821
       nfiles: 2
     - path: data/Rivierenland/modellen/Rivierenland_forcing
       hash: md5
-      md5: 4df474a39ae4279e108544d77831a1e9.dir
+      md5: 3ea86941fdabb3c8e9e8a65101b56187.dir
       size: 48156853
       nfiles: 2
     - path: data/Scheldestromen/modellen/Scheldestromen_forcing
       hash: md5
-      md5: 677cd0872a3d4158c0756fd6232a40a2.dir
+      md5: a7a814ab5924679b3d710b50817cc66d.dir
       size: 37515445
       nfiles: 2
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_forcing
       hash: md5
-      md5: 401856f94fc250da3bf25f1292ff259e.dir
+      md5: 1743f52b6481907a7a815fe2d79b690c.dir
       size: 29003957
       nfiles: 2
     - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_dynamic_model
       hash: md5
-      md5: 9560c63ecf3555293ff0834c78d04684.dir
-      size: 81530708
+      md5: 8b53f7d15f7d25ecf1cb4aa7dc3a7113.dir
+      size: 81530563
       nfiles: 5
     - path: data/ValleienVeluwe/modellen/ValleienVeluwe_dynamic_model
       hash: md5
-      md5: da1a329113dae6201d9abdb92e20513a.dir
-      size: 79203990
+      md5: e79866f4b79ad5ac75ef6d8263518b74.dir
+      size: 79203940
       nfiles: 5
     - path: data/Vechtstromen/modellen/Vechtstromen_dynamic_model
       hash: md5
-      md5: 3c7a0f658f747d9493702c1702f161be.dir
-      size: 120092999
+      md5: b764f46d31c5e0ee5bc35c17e178c6d3.dir
+      size: 120093044
       nfiles: 5
     - path: data/WetterskipFryslan/modellen/WetterskipFryslan_forcing
       hash: md5
-      md5: 81003619a3c407b6b8135386f8131c28.dir
+      md5: a35f8e98ad3e487f1de845d9060cae52.dir
       size: 187408565
       nfiles: 2
     - path: data/Zuiderzeeland/modellen/Zuiderzeeland_forcing
       hash: md5
-      md5: 5dc6225d5bc461b6fd7d61faec5d555e.dir
+      md5: 88a3bf00a98c1fcdced8f7e0c6b3b2c3.dir
       size: 39891125
       nfiles: 2
     - path: notebooks/08_samenvoegen_modellen.py
@@ -123,7 +123,7 @@ stages:
     outs:
     - path: data/Rijkswaterstaat/modellen/lhm_parts
       hash: md5
-      md5: 010fd00d5e2e108778db6707ff5e298a.dir
+      md5: 18d90df7115a7a39e064f8d075c306f0.dir
       size: 2274058422
       nfiles: 2
   bathymetry:
@@ -163,12 +163,12 @@ stages:
     deps:
     - path: data/Rijkswaterstaat/modellen/lhm_parts
       hash: md5
-      md5: 010fd00d5e2e108778db6707ff5e298a.dir
+      md5: 18d90df7115a7a39e064f8d075c306f0.dir
       size: 2274058422
       nfiles: 2
     - path: data/Rijkswaterstaat/verwerkt/netwerk.gpkg
       hash: md5
-      md5: 17fdd9689ae5b47d4081ba1c34fefa64
+      md5: faaef0b832639d59514aa8e316ff3ad0
       size: 3731456
     - path: notebooks/09_koppelen_modellen.py
       hash: md5
@@ -177,7 +177,7 @@ stages:
     outs:
     - path: data/Rijkswaterstaat/modellen/lhm_coupled
       hash: md5
-      md5: c5848d3ee43499ecbd9aab5e34729dbb.dir
+      md5: 5eda55054334068d2602ff8c53de8163.dir
       size: 1295431355
       nfiles: 4
   rwzi:
@@ -237,8 +237,8 @@ stages:
     outs:
     - path: data/AaenMaas/modellen/AaenMaas_dynamic_model
       hash: md5
-      md5: b15be66679c38bdf60d1b16cf522c0c9.dir
-      size: 96601301
+      md5: a612f86bf75f05596888942c6dbc893c.dir
+      size: 96601199
       nfiles: 5
   dynamic@brabantse_delta:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py BrabantseDelta
@@ -270,8 +270,8 @@ stages:
     outs:
     - path: data/BrabantseDelta/modellen/BrabantseDelta_dynamic_model
       hash: md5
-      md5: b7b5e59102b4e0d0d024e7959c8658ec.dir
-      size: 125677107
+      md5: 7e507583b7aaf3ba8dcf921d9b0643af.dir
+      size: 125677053
       nfiles: 5
   dynamic@de_dommel:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py DeDommel
@@ -303,8 +303,8 @@ stages:
     outs:
     - path: data/DeDommel/modellen/DeDommel_dynamic_model
       hash: md5
-      md5: 8ef6cea26a73807ca783db0bdc87f56d.dir
-      size: 130578608
+      md5: 3781b307bb3ad60e7402c03815df62de.dir
+      size: 130578703
       nfiles: 5
   dynamic@drents_overijsselse_delta:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py
@@ -339,8 +339,8 @@ stages:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_dynamic_model
       hash: md5
-      md5: 230e9d38cb203c20f087c126ef536f40.dir
-      size: 87167530
+      md5: 39e0ce48225feaafb072733f93ec5b4b.dir
+      size: 87167589
       nfiles: 5
   dynamic@hunze_en_aas:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py HunzeenAas
@@ -372,8 +372,8 @@ stages:
     outs:
     - path: data/HunzeenAas/modellen/HunzeenAas_dynamic_model
       hash: md5
-      md5: b517b2b070a736a23431f39961196f28.dir
-      size: 74145501
+      md5: 5c426152f19b79cdbbb88f4049551026.dir
+      size: 74145560
       nfiles: 5
   dynamic@limburg:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py Limburg
@@ -405,8 +405,8 @@ stages:
     outs:
     - path: data/Limburg/modellen/Limburg_dynamic_model
       hash: md5
-      md5: 9740babc7d84831412bfe70f71c2b537.dir
-      size: 136869812
+      md5: eaa25f2d9988eea5016ad5b684e21bfb.dir
+      size: 136870248
       nfiles: 5
   dynamic@noorderzijlvest:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py Noorderzijlvest
@@ -438,8 +438,8 @@ stages:
     outs:
     - path: data/Noorderzijlvest/modellen/Noorderzijlvest_dynamic_model
       hash: md5
-      md5: d27e66bd94923b649aa85d13a41c7226.dir
-      size: 88181726
+      md5: de6d5477ddc65bbe4f307202cc72010a.dir
+      size: 88182144
       nfiles: 5
   dynamic@rijn_en_ijssel:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py RijnenIJssel
@@ -471,8 +471,8 @@ stages:
     outs:
     - path: data/RijnenIJssel/modellen/RijnenIJssel_dynamic_model
       hash: md5
-      md5: 7758e510b747aca220c9b8a0930d25fd.dir
-      size: 54802005
+      md5: 93b23383e32cfce711f63a5a988cebe5.dir
+      size: 54802231
       nfiles: 5
   dynamic@stichtse_rijnlanden:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py StichtseRijnlanden
@@ -504,8 +504,8 @@ stages:
     outs:
     - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_dynamic_model
       hash: md5
-      md5: 9560c63ecf3555293ff0834c78d04684.dir
-      size: 81530708
+      md5: 8b53f7d15f7d25ecf1cb4aa7dc3a7113.dir
+      size: 81530563
       nfiles: 5
   dynamic@vallei_en_veluwe:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py ValleienVeluwe
@@ -537,8 +537,8 @@ stages:
     outs:
     - path: data/ValleienVeluwe/modellen/ValleienVeluwe_dynamic_model
       hash: md5
-      md5: da1a329113dae6201d9abdb92e20513a.dir
-      size: 79203990
+      md5: e79866f4b79ad5ac75ef6d8263518b74.dir
+      size: 79203940
       nfiles: 5
   dynamic@vechtstromen:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py Vechtstromen
@@ -570,8 +570,8 @@ stages:
     outs:
     - path: data/Vechtstromen/modellen/Vechtstromen_dynamic_model
       hash: md5
-      md5: 3c7a0f658f747d9493702c1702f161be.dir
-      size: 120092999
+      md5: b764f46d31c5e0ee5bc35c17e178c6d3.dir
+      size: 120093044
       nfiles: 5
   hws_demand:
     cmd:
@@ -706,7 +706,7 @@ stages:
       nfiles: 2
     - path: data/Rijkswaterstaat/verwerkt/netwerk.gpkg
       hash: md5
-      md5: 17fdd9689ae5b47d4081ba1c34fefa64
+      md5: faaef0b832639d59514aa8e316ff3ad0
       size: 3731456
   hws_transient:
     cmd:
@@ -803,8 +803,8 @@ stages:
       size: 7425
     - path: notebooks/rijn_en_ijssel/03_parameterize_model.py
       hash: md5
-      md5: 13ef541aece46fde171f9e1eed12d1ff
-      size: 3518
+      md5: d1817edd6674254d45066ed4ec1df237
+      size: 3549
     - path: notebooks/rijn_en_ijssel/_preprocess_profielen.py
       hash: md5
       md5: d091ad9f37ee2c5ddddd1b652cd9c9f9
@@ -816,7 +816,7 @@ stages:
     outs:
     - path: data/RijnenIJssel/modellen/RijnenIJssel_parameterized_model
       hash: md5
-      md5: 71927344b1cdf9bbfd561ac9f7bbb268.dir
+      md5: 8aed6972159937e303c0577925be7fbd.dir
       size: 4706453
       nfiles: 3
   parameterized_vallei_en_veluwe:
@@ -882,8 +882,8 @@ stages:
       size: 16191
     - path: notebooks/vallei_en_veluwe/03_parameterize_model.py
       hash: md5
-      md5: 4be09e57ce172c6ba3b21d6b3a1fc1c7
-      size: 2796
+      md5: 0a6ead8ffcfbc4081d95a5d0f406c571
+      size: 2827
     - path: notebooks/vallei_en_veluwe/_preprocess_profielen.py
       hash: md5
       md5: 0902e32583ea04eed4c997277c788fe2
@@ -992,8 +992,8 @@ stages:
       size: 18810
     - path: notebooks/vechtstromen/03_parameterize_model.py
       hash: md5
-      md5: 2ae03d84cf31fd488bf1997d1d3e2a2e
-      size: 4024
+      md5: 7538b3a3573071ca3dfe59d01ddbc044
+      size: 4055
     - path: notebooks/vechtstromen/_preprocess_profielen.py
       hash: md5
       md5: 397fd876a8690cc3b4159b89a39f2e34
@@ -1005,7 +1005,7 @@ stages:
     outs:
     - path: data/Vechtstromen/modellen/Vechtstromen_parameterized_model
       hash: md5
-      md5: 07de55e6e5e348230cb8f20eb81a4341.dir
+      md5: ba60e112d35a3515dfeb57419926d78c.dir
       size: 18800789
       nfiles: 3
   parameterized_aa_en_maas:
@@ -1088,8 +1088,8 @@ stages:
       size: 9306
     - path: notebooks/aa_en_maas/03_parameterize_model.py
       hash: md5
-      md5: 32cea663cd85178135fa390a1e48ffe9
-      size: 3894
+      md5: 70b0a58879da2748a6aed128939f1c00
+      size: 3925
     - path: notebooks/aa_en_maas/_preprocess_profielen.py
       hash: md5
       md5: c4d7b286521effdafb6aa0abc16934d1
@@ -1171,8 +1171,8 @@ stages:
       size: 14601
     - path: notebooks/brabantse_delta/03_parameterize_model.py
       hash: md5
-      md5: 0242163035f4ba267f32abd1716ea24a
-      size: 3835
+      md5: 7f5ff5795ffb8f069d46ce5dc1f3a353
+      size: 3866
     - path: notebooks/brabantse_delta/_preprocess_profielen.py
       hash: md5
       md5: 7b071cd07920573d8ed795edace855c7
@@ -1184,7 +1184,7 @@ stages:
     outs:
     - path: data/BrabantseDelta/modellen/BrabantseDelta_parameterized_model
       hash: md5
-      md5: d732f65ca1f06679aeca2dbf0bfa11ab.dir
+      md5: e90ddb7d96f122f7af12f1acc5d1913e.dir
       size: 15769749
       nfiles: 3
   parameterized_de_dommel:
@@ -1245,8 +1245,8 @@ stages:
       size: 7052
     - path: notebooks/de_dommel/03_parameterize_model.py
       hash: md5
-      md5: f6dcece29d547664607cb665ba45d2f6
-      size: 1768
+      md5: 999650d276dcbe85413f05250829d408
+      size: 1799
     - path: notebooks/de_dommel/_preprocess_profielen.py
       hash: md5
       md5: f6a23849191ecc1f73a4466e524e64a1
@@ -1349,8 +1349,8 @@ stages:
       size: 13397
     - path: notebooks/drents_overijsselse_delta/03_parameterize_model.py
       hash: md5
-      md5: fe1698c44de0e7f93fa7d158abc29387
-      size: 6403
+      md5: 649e8ed2b521d5e90ad4953e096ebcd7
+      size: 6434
     - path: notebooks/drents_overijsselse_delta/_preprocess_profielen.py
       hash: md5
       md5: 272a2c8a91a80224ff11caed3d3c2c39
@@ -1363,7 +1363,7 @@ stages:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_parameterized_model
       hash: md5
-      md5: ef22605abc0248309b554c671e25144a.dir
+      md5: 1621b5db3cbfb5d0ec6c81ecfc0ddf67.dir
       size: 7114901
       nfiles: 3
   parameterized_hunze_en_aas:
@@ -1437,8 +1437,8 @@ stages:
       size: 13240
     - path: notebooks/hunze_en_aas/03_parameterize_model.py
       hash: md5
-      md5: 84215e756e9c68354fad1a558bbab5c0
-      size: 3669
+      md5: e62047096d146b13679ddea863b99f2f
+      size: 3700
     - path: notebooks/hunze_en_aas/_preprocess_profielen.py
       hash: md5
       md5: 3410aa52b545c0c8678b5936b050199e
@@ -1454,7 +1454,7 @@ stages:
     outs:
     - path: data/HunzeenAas/modellen/HunzeenAas_parameterized_model
       hash: md5
-      md5: 80e3dfc2cf053f9c0c7ce14f01b1734b.dir
+      md5: 965d7f1829a6c2d160360ca7748465bf.dir
       size: 4952213
       nfiles: 3
   parameterized_limburg:
@@ -1517,8 +1517,8 @@ stages:
       size: 11114
     - path: notebooks/limburg/03_parameterize_model.py
       hash: md5
-      md5: 4a33046a8c168b88b45e97bc5f1e13ab
-      size: 2461
+      md5: 99b0ef8294d3269940809e59939b0125
+      size: 2492
     - path: notebooks/limburg/_preprocess_profielen.py
       hash: md5
       md5: 66a0afebf00fdfb8d88e9539b6fa285a
@@ -1593,8 +1593,8 @@ stages:
       size: 1370
     - path: notebooks/noorderzijlvest/03_parameterize_model.py
       hash: md5
-      md5: 54b40c793c95313c1ea90f0e7537a7d5
-      size: 1694
+      md5: f4ebe919a2c50bf2436a12264366427a
+      size: 1725
     - path: notebooks/noorderzijlvest/_preprocess_profielen.py
       hash: md5
       md5: d4a2e322dec96ba8a2a7b546119026eb
@@ -1685,8 +1685,8 @@ stages:
       size: 12939
     - path: notebooks/stichtse_rijnlanden/03_parameterize_model.py
       hash: md5
-      md5: e562015b0861b65d3dacd613f42b170b
-      size: 3214
+      md5: d9bab27188eadea2a19a4650546cc3ef
+      size: 3245
     - path: notebooks/stichtse_rijnlanden/_preprocess_profielen.py
       hash: md5
       md5: 296c65a65d776030414273d0d919309d
@@ -1699,12 +1699,12 @@ stages:
     - path:
         data/StichtseRijnlanden/modellen/StichtseRijnlanden_parameterized_model
       hash: md5
-      md5: 5adbb8778fff2216b174cfa02fb686b9.dir
+      md5: 7cb1a3990e4082f0a5197364ba0c7af3.dir
       size: 18366613
       nfiles: 3
     - path: data/StichtseRijnlanden/verwerkt/4_ribasim/peilgebieden_bewerkt.gpkg
       hash: md5
-      md5: 271d4aab24ac110efa95c56ed81e2f94
+      md5: 904906b41a16b5e721db882d50b45862
       size: 6492160
   bergend_aa_en_maas:
     cmd:
@@ -1744,8 +1744,8 @@ stages:
       size: 1755
     - path: notebooks/aa_en_maas/04_add_full_control.py
       hash: md5
-      md5: 6ec89aefb88bbd47a0fec0b06e4b6024
-      size: 41510
+      md5: 745f347874cdd6748dab72124d6c4dfc
+      size: 41397
     outs:
     - path: data/AaenMaas/modellen/AaenMaas_bergend_model
       hash: md5
@@ -1771,7 +1771,7 @@ stages:
       size: 561756752
     - path: data/BrabantseDelta/modellen/BrabantseDelta_parameterized_model
       hash: md5
-      md5: d732f65ca1f06679aeca2dbf0bfa11ab.dir
+      md5: e90ddb7d96f122f7af12f1acc5d1913e.dir
       size: 15769749
       nfiles: 3
     - path: data/BrabantseDelta/verwerkt/sturing/aanvoergebieden.gpkg
@@ -1784,8 +1784,8 @@ stages:
       size: 1755
     - path: notebooks/brabantse_delta/04_add_full_control.py
       hash: md5
-      md5: 5bc282991a82b45a75a0b67d1cf17667
-      size: 19665
+      md5: 025a328895e7f66eb9179a731bf8f4ee
+      size: 19552
     outs:
     - path: data/BrabantseDelta/modellen/BrabantseDelta_bergend_model
       hash: md5
@@ -1824,8 +1824,8 @@ stages:
       size: 1755
     - path: notebooks/de_dommel/04_add_full_control.py
       hash: md5
-      md5: 5fb73ef485d1dbbb0f9781b8b9d85f1d
-      size: 11007
+      md5: bbfcf4368fd083cbe9f88c53de179632
+      size: 10894
     outs:
     - path: data/DeDommel/modellen/DeDommel_bergend_model
       hash: md5
@@ -1852,7 +1852,7 @@ stages:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_parameterized_model
       hash: md5
-      md5: ef22605abc0248309b554c671e25144a.dir
+      md5: 1621b5db3cbfb5d0ec6c81ecfc0ddf67.dir
       size: 7114901
       nfiles: 3
     - path: data/DrentsOverijsselseDelta/verwerkt/sturing/aanvoergebieden.gpkg
@@ -1873,8 +1873,8 @@ stages:
       size: 1755
     - path: notebooks/drents_overijsselse_delta/04_add_full_control.py
       hash: md5
-      md5: 08dc7842b7ba3ad4799dd040d995c5cf
-      size: 32062
+      md5: 2879d3e9a8dfe41355d002132fbc5b56
+      size: 32019
     outs:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_bergend_model
@@ -1901,7 +1901,7 @@ stages:
       size: 561756752
     - path: data/HunzeenAas/modellen/HunzeenAas_parameterized_model
       hash: md5
-      md5: 80e3dfc2cf053f9c0c7ce14f01b1734b.dir
+      md5: 965d7f1829a6c2d160360ca7748465bf.dir
       size: 4952213
       nfiles: 3
     - path: data/HunzeenAas/verwerkt/sturing/aanvoergebieden.gpkg
@@ -1914,8 +1914,8 @@ stages:
       size: 1755
     - path: notebooks/hunze_en_aas/04_add_full_control.py
       hash: md5
-      md5: a22fd4b70cc8c790d9e829b412af3f33
-      size: 30003
+      md5: 2385e4f914ac96971a1b6e315c1520b4
+      size: 29890
     outs:
     - path: data/HunzeenAas/modellen/HunzeenAas_bergend_model
       hash: md5
@@ -1954,8 +1954,8 @@ stages:
       size: 1755
     - path: notebooks/limburg/04_add_full_control.py
       hash: md5
-      md5: a459cffe8d7122aed42883d1a1096072
-      size: 31510
+      md5: d4b07d305550d255fe854793065a60bd
+      size: 31397
     outs:
     - path: data/Limburg/modellen/Limburg_bergend_model
       hash: md5
@@ -1994,8 +1994,8 @@ stages:
       size: 1755
     - path: notebooks/noorderzijlvest/04_add_full_control.py
       hash: md5
-      md5: 9992699ad835522afce53ea610967b96
-      size: 13340
+      md5: d936083c50ea09697cead3bdc614398b
+      size: 13227
     outs:
     - path: data/Noorderzijlvest/modellen/Noorderzijlvest_bergend_model
       hash: md5
@@ -2021,7 +2021,7 @@ stages:
       size: 561756752
     - path: data/RijnenIJssel/modellen/RijnenIJssel_parameterized_model
       hash: md5
-      md5: 71927344b1cdf9bbfd561ac9f7bbb268.dir
+      md5: 8aed6972159937e303c0577925be7fbd.dir
       size: 4706453
       nfiles: 3
     - path: data/RijnenIJssel/verwerkt/sturing/aanvoergebieden.gpkg
@@ -2034,8 +2034,8 @@ stages:
       size: 1755
     - path: notebooks/rijn_en_ijssel/04_add_full_control.py
       hash: md5
-      md5: e58d599a59c57c4ceb6805690c114209
-      size: 14437
+      md5: 144ad3ec1a31c7a7bc9677b04b65b359
+      size: 14324
     outs:
     - path: data/RijnenIJssel/modellen/RijnenIJssel_bergend_model
       hash: md5
@@ -2062,12 +2062,12 @@ stages:
     - path:
         data/StichtseRijnlanden/modellen/StichtseRijnlanden_parameterized_model
       hash: md5
-      md5: 5adbb8778fff2216b174cfa02fb686b9.dir
+      md5: 7cb1a3990e4082f0a5197364ba0c7af3.dir
       size: 18366613
       nfiles: 3
     - path: data/StichtseRijnlanden/verwerkt/4_ribasim/peilgebieden_bewerkt.gpkg
       hash: md5
-      md5: 271d4aab24ac110efa95c56ed81e2f94
+      md5: 904906b41a16b5e721db882d50b45862
       size: 6492160
     - path: data/StichtseRijnlanden/verwerkt/sturing/aanvoergebieden.gpkg
       hash: md5
@@ -2079,8 +2079,8 @@ stages:
       size: 1755
     - path: notebooks/stichtse_rijnlanden/04_add_full_control.py
       hash: md5
-      md5: 9cb13b2a30ae902d1beb90ebafc60aa8
-      size: 17373
+      md5: bedcc2b47e9afed5869ed0e1ea0be813
+      size: 17260
     outs:
     - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_bergend_model
       hash: md5
@@ -2126,8 +2126,8 @@ stages:
       size: 1755
     - path: notebooks/vallei_en_veluwe/04_add_full_control.py
       hash: md5
-      md5: 8e29edf3c78596db9f4bbf6c485a6959
-      size: 28374
+      md5: d5510dfdd07e02f0baa6cd86344a9bcf
+      size: 28331
     outs:
     - path: data/ValleienVeluwe/modellen/ValleienVeluwe_bergend_model
       hash: md5
@@ -2153,7 +2153,7 @@ stages:
       size: 561756752
     - path: data/Vechtstromen/modellen/Vechtstromen_parameterized_model
       hash: md5
-      md5: 07de55e6e5e348230cb8f20eb81a4341.dir
+      md5: ba60e112d35a3515dfeb57419926d78c.dir
       size: 18800789
       nfiles: 3
     - path: data/Vechtstromen/verwerkt/1_ontvangen_data/LHM20230418.gdb
@@ -2171,8 +2171,8 @@ stages:
       size: 1755
     - path: notebooks/vechtstromen/04_add_full_control.py
       hash: md5
-      md5: 548964ff85e2865c7f5d90b981517db1
-      size: 31535
+      md5: 20d23fca3f41561c1272bd791169d136
+      size: 30977
     outs:
     - path: data/Vechtstromen/modellen/Vechtstromen_bergend_model
       hash: md5
@@ -2531,7 +2531,7 @@ stages:
       nfiles: 2
     - path: data/Delfland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 01c74abf924ce3d3d8d5ed0b82bf0e4c
+      md5: 4c5461d3f0c78fc5e0086bed148061b1
       size: 10645504
   profiles_amstel_gooi_en_vecht:
     cmd:
@@ -2580,7 +2580,7 @@ stages:
       nfiles: 2
     - path: data/AmstelGooienVecht/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 276484815ed21017c9b61acd48e586a6
+      md5: fd842ba0d62a7cbd6656040bb351e42b
       size: 5369856
   profiles_hollands_noorderkwartier:
     cmd:
@@ -2633,7 +2633,7 @@ stages:
       nfiles: 2
     - path: data/HollandsNoorderkwartier/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: bc5c08b71965f7c01be2b7752d9786fc
+      md5: b1dd40225eef8827cbd8d761c53d03af
       size: 40390656
   profiles_hollandse_delta:
     cmd:
@@ -2687,7 +2687,7 @@ stages:
       nfiles: 2
     - path: data/HollandseDelta/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 1d90a29380716284a50662f670f51fb5
+      md5: 0347ba436bc021597d0908dd5cc16a53
       size: 20553728
   profiles_rijnland:
     cmd:
@@ -2741,7 +2741,7 @@ stages:
       nfiles: 2
     - path: data/Rijnland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 6a110ba62b0148e967565342baf39ec8
+      md5: 4c149daa289d782eb13d245c9c66ceb8
       size: 63401984
   profiles_rivierenland:
     cmd:
@@ -2791,7 +2791,7 @@ stages:
       nfiles: 2
     - path: data/Rivierenland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 1c4b7c025b117b357a9dc665aec8800c
+      md5: d013be22a2f426bdf41ae8beaba138bc
       size: 85151744
   profiles_scheldestromen:
     cmd:
@@ -2847,7 +2847,7 @@ stages:
       nfiles: 2
     - path: data/Scheldestromen/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: b6c566233de8c3aed156c6af935eeb22
+      md5: d5600e507c98f7de90a9bf390c0ec50d
       size: 36167680
   profiles_schieland_en_de_krimpenerwaard:
     cmd:
@@ -2901,7 +2901,7 @@ stages:
       nfiles: 2
     - path: data/SchielandendeKrimpenerwaard/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 957901f691a467af60d03eba0119e20f
+      md5: 1a3390e0b7f1fb817d43e94a71ab62bf
       size: 22462464
   profiles_wetterskip_fryslan:
     cmd:
@@ -2951,7 +2951,7 @@ stages:
       nfiles: 2
     - path: data/WetterskipFryslan/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: cf98a78184593ffcd7840782cc53c853
+      md5: 07cab22486cd15e42b1dacb9726a44fa
       size: 38248448
   profiles_zuiderzeeland:
     cmd:
@@ -3000,7 +3000,7 @@ stages:
       nfiles: 2
     - path: data/Zuiderzeeland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: cce53610af5af9ab0d38e9b137840117
+      md5: 63d26f0be3cb42cc5c2e8d91f88b4f00
       size: 8634368
   forcing_delfland:
     cmd: pixi run python src/peilbeheerst_model/forcing/Delfland.py
@@ -3053,8 +3053,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/Delfland.py
       hash: md5
-      md5: 9fb8bebd6aef12d5795d68cc2b4a6bc7
-      size: 16743
+      md5: 5f5b4cce66b8061165f916933a365252
+      size: 16871
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3066,7 +3066,7 @@ stages:
     outs:
     - path: data/Delfland/modellen/Delfland_forcing
       hash: md5
-      md5: 80c4171d992d97db86d077c6b7b56356.dir
+      md5: 19d844ca98b903df64b611d3b9f0ea89.dir
       size: 23064757
       nfiles: 2
   forcing_amstel_gooi_en_vecht:
@@ -3122,8 +3122,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/AmstelGooienVecht.py
       hash: md5
-      md5: 1f902551e3396c88b39cf8772ff5d1c8
-      size: 18349
+      md5: 48d0f8e5d6a73319edb6e021fe26912d
+      size: 18477
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3135,7 +3135,7 @@ stages:
     outs:
     - path: data/AmstelGooienVecht/modellen/AmstelGooienVecht_forcing
       hash: md5
-      md5: 2ecbd7e249f383a41d2055e4ee8608a1.dir
+      md5: 0917c8d7149b84e6544ba1da2ff0cb79.dir
       size: 46149813
       nfiles: 2
   forcing_hollands_noorderkwartier:
@@ -3194,8 +3194,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/HollandsNoorderkwartier.py
       hash: md5
-      md5: 0b71b161a661e273955a7b8282f78ce6
-      size: 18238
+      md5: 8e3b3bb901209819fb2d295f44cf3383
+      size: 18366
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3208,7 +3208,7 @@ stages:
     - path:
         data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_forcing
       hash: md5
-      md5: 7df64671a32f6777296c6bd99fc4e4e5.dir
+      md5: dc15ec23e55d2707ff90a113f81df622.dir
       size: 49971381
       nfiles: 2
   forcing_hollandse_delta:
@@ -3262,8 +3262,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/HollandseDelta.py
       hash: md5
-      md5: 9755471b459de59cb39bf1d7fc1f5b2c
-      size: 16066
+      md5: 667a70b2f8f35697f96984358951e26a
+      size: 16194
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3275,7 +3275,7 @@ stages:
     outs:
     - path: data/HollandseDelta/modellen/HollandseDelta_forcing
       hash: md5
-      md5: b4b25b6b86004da76829eb3836eda9ba.dir
+      md5: d480999e727409112e20873df8170da5.dir
       size: 93483189
       nfiles: 2
   forcing_rijnland:
@@ -3329,8 +3329,8 @@ stages:
       size: 218427392
     - path: src/peilbeheerst_model/forcing/Rijnland.py
       hash: md5
-      md5: 1d23ee9d12b8dcf2a1a2c24625aa72c5
-      size: 16226
+      md5: a801bbec050f140add6172b0afb6951b
+      size: 16354
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3342,7 +3342,7 @@ stages:
     outs:
     - path: data/Rijnland/modellen/Rijnland_forcing
       hash: md5
-      md5: 03833ec3da148d978cc9e76c3f5901ae.dir
+      md5: e290e476f2442bc101d6952785ea9afc.dir
       size: 67440821
       nfiles: 2
   forcing_rivierenland:
@@ -3396,8 +3396,8 @@ stages:
       size: 108998656
     - path: src/peilbeheerst_model/forcing/Rivierenland.py
       hash: md5
-      md5: c0cf5aa58882b29f47a5ced55a684cdf
-      size: 16494
+      md5: 21f10c445bff66027329e1849711a024
+      size: 16622
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3409,7 +3409,7 @@ stages:
     outs:
     - path: data/Rivierenland/modellen/Rivierenland_forcing
       hash: md5
-      md5: 4df474a39ae4279e108544d77831a1e9.dir
+      md5: 3ea86941fdabb3c8e9e8a65101b56187.dir
       size: 48156853
       nfiles: 2
   forcing_scheldestromen:
@@ -3463,8 +3463,8 @@ stages:
       size: 72876032
     - path: src/peilbeheerst_model/forcing/Scheldestromen.py
       hash: md5
-      md5: 85b2cfd470689c711ca3b48f4e1a3bc8
-      size: 17052
+      md5: e26b1625f5319a0378dc52908c12144a
+      size: 17180
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3476,7 +3476,7 @@ stages:
     outs:
     - path: data/Scheldestromen/modellen/Scheldestromen_forcing
       hash: md5
-      md5: 677cd0872a3d4158c0756fd6232a40a2.dir
+      md5: a7a814ab5924679b3d710b50817cc66d.dir
       size: 37515445
       nfiles: 2
   forcing_schieland_en_de_krimpenerwaard:
@@ -3534,8 +3534,8 @@ stages:
       size: 66883584
     - path: src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
       hash: md5
-      md5: e42e86a4b42cbda7bccaa22088db9252
-      size: 17727
+      md5: 4ec62d2914520c2cfcb022084dea4509
+      size: 17855
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3548,7 +3548,7 @@ stages:
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_forcing
       hash: md5
-      md5: 401856f94fc250da3bf25f1292ff259e.dir
+      md5: 1743f52b6481907a7a815fe2d79b690c.dir
       size: 29003957
       nfiles: 2
   forcing_wetterskip_fryslan:
@@ -3604,8 +3604,8 @@ stages:
       size: 87060480
     - path: src/peilbeheerst_model/forcing/WetterskipFryslan.py
       hash: md5
-      md5: b0208d4a35c16ca072253df902f7afec
-      size: 16740
+      md5: 0fa32fabba16915c4bc7307cb406165a
+      size: 16868
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3617,7 +3617,7 @@ stages:
     outs:
     - path: data/WetterskipFryslan/modellen/WetterskipFryslan_forcing
       hash: md5
-      md5: 81003619a3c407b6b8135386f8131c28.dir
+      md5: a35f8e98ad3e487f1de845d9060cae52.dir
       size: 187408565
       nfiles: 2
   forcing_zuiderzeeland:
@@ -3670,8 +3670,8 @@ stages:
       size: 18821120
     - path: src/peilbeheerst_model/forcing/Zuiderzeeland.py
       hash: md5
-      md5: 323f4ce13d79e55cb92e9f41f8d31cd9
-      size: 16953
+      md5: 9aee60fde97dec1072c784bf3b840246
+      size: 17081
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3683,6 +3683,6 @@ stages:
     outs:
     - path: data/Zuiderzeeland/modellen/Zuiderzeeland_forcing
       hash: md5
-      md5: 5dc6225d5bc461b6fd7d61faec5d555e.dir
+      md5: 88a3bf00a98c1fcdced8f7e0c6b3b2c3.dir
       size: 39891125
       nfiles: 2

--- a/dvc.lock
+++ b/dvc.lock
@@ -5,60 +5,60 @@ stages:
     deps:
     - path: data/AaenMaas/modellen/AaenMaas_dynamic_model
       hash: md5
-      md5: 9565f4a3956196efe25217535be9eff1.dir
-      size: 96601309
+      md5: b15be66679c38bdf60d1b16cf522c0c9.dir
+      size: 96601301
       nfiles: 5
     - path: data/AmstelGooienVecht/modellen/AmstelGooienVecht_forcing
       hash: md5
-      md5: 9fc3772c3135ac508e9518684352e703.dir
+      md5: 2ecbd7e249f383a41d2055e4ee8608a1.dir
       size: 46149813
       nfiles: 2
     - path: data/BrabantseDelta/modellen/BrabantseDelta_dynamic_model
       hash: md5
-      md5: 8e240a268f30104dd0be21b39b909f47.dir
-      size: 125677307
+      md5: b7b5e59102b4e0d0d024e7959c8658ec.dir
+      size: 125677107
       nfiles: 5
     - path: data/DeDommel/modellen/DeDommel_dynamic_model
       hash: md5
-      md5: 87aa07cb6c9f19a3cb12d3127a865701.dir
-      size: 130578479
+      md5: 8ef6cea26a73807ca783db0bdc87f56d.dir
+      size: 130578608
       nfiles: 5
     - path: data/Delfland/modellen/Delfland_forcing
       hash: md5
-      md5: 9bc354ef83c46357e58b1a6091287b67.dir
+      md5: 80c4171d992d97db86d077c6b7b56356.dir
       size: 23064757
       nfiles: 2
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_dynamic_model
       hash: md5
-      md5: d27e354d03f77dc4a97db560aaef1616.dir
-      size: 87167503
+      md5: 230e9d38cb203c20f087c126ef536f40.dir
+      size: 87167530
       nfiles: 5
     - path:
         data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_forcing
       hash: md5
-      md5: 35634a6467890800c1c55c03d5ec6992.dir
+      md5: 7df64671a32f6777296c6bd99fc4e4e5.dir
       size: 49971381
       nfiles: 2
     - path: data/HollandseDelta/modellen/HollandseDelta_forcing
       hash: md5
-      md5: adee56ded94dbfb54fba9495ef971e80.dir
+      md5: b4b25b6b86004da76829eb3836eda9ba.dir
       size: 93483189
       nfiles: 2
     - path: data/HunzeenAas/modellen/HunzeenAas_dynamic_model
       hash: md5
-      md5: c7c0c373364babf3faac181b7c452090.dir
-      size: 74145616
+      md5: b517b2b070a736a23431f39961196f28.dir
+      size: 74145501
       nfiles: 5
     - path: data/Limburg/modellen/Limburg_dynamic_model
       hash: md5
-      md5: 1f643599c200252d98323a6edb23cf78.dir
-      size: 136870185
+      md5: 9740babc7d84831412bfe70f71c2b537.dir
+      size: 136869812
       nfiles: 5
     - path: data/Noorderzijlvest/modellen/Noorderzijlvest_dynamic_model
       hash: md5
-      md5: 4615e4821285d9d1ac382ffc2e8d2ed8.dir
-      size: 88181887
+      md5: d27e66bd94923b649aa85d13a41c7226.dir
+      size: 88181726
       nfiles: 5
     - path: data/Rijkswaterstaat/modellen/hws_transient
       hash: md5
@@ -67,53 +67,53 @@ stages:
       nfiles: 2
     - path: data/RijnenIJssel/modellen/RijnenIJssel_dynamic_model
       hash: md5
-      md5: f211224e47d08444fec82d848aa50e64.dir
-      size: 54802182
+      md5: 7758e510b747aca220c9b8a0930d25fd.dir
+      size: 54802005
       nfiles: 5
     - path: data/Rijnland/modellen/Rijnland_forcing
       hash: md5
-      md5: da4ced9d15067c29736bf77bc861b50f.dir
+      md5: 03833ec3da148d978cc9e76c3f5901ae.dir
       size: 67440821
       nfiles: 2
     - path: data/Rivierenland/modellen/Rivierenland_forcing
       hash: md5
-      md5: 4d03309cd10c27f920b0a9513fbb6fdc.dir
+      md5: 4df474a39ae4279e108544d77831a1e9.dir
       size: 48156853
       nfiles: 2
     - path: data/Scheldestromen/modellen/Scheldestromen_forcing
       hash: md5
-      md5: ff7a81690ad9628e1ad938a3c7c6d0f5.dir
+      md5: 677cd0872a3d4158c0756fd6232a40a2.dir
       size: 37515445
       nfiles: 2
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_forcing
       hash: md5
-      md5: f0064d2c2f25e18f52b2ff1815aea504.dir
+      md5: 401856f94fc250da3bf25f1292ff259e.dir
       size: 29003957
       nfiles: 2
     - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_dynamic_model
       hash: md5
-      md5: 279fdb4fb1e45e1812b8157f3827242a.dir
-      size: 81530688
+      md5: 9560c63ecf3555293ff0834c78d04684.dir
+      size: 81530708
       nfiles: 5
     - path: data/ValleienVeluwe/modellen/ValleienVeluwe_dynamic_model
       hash: md5
-      md5: 7b028834aa0aeead6b98c71d60f98c58.dir
-      size: 79204116
+      md5: da1a329113dae6201d9abdb92e20513a.dir
+      size: 79203990
       nfiles: 5
     - path: data/Vechtstromen/modellen/Vechtstromen_dynamic_model
       hash: md5
-      md5: 2424cbfd1f3abaa653c0d28df237e4c0.dir
-      size: 120093027
+      md5: 3c7a0f658f747d9493702c1702f161be.dir
+      size: 120092999
       nfiles: 5
     - path: data/WetterskipFryslan/modellen/WetterskipFryslan_forcing
       hash: md5
-      md5: 01e0518368a0677b4921245527d02960.dir
+      md5: 81003619a3c407b6b8135386f8131c28.dir
       size: 187408565
       nfiles: 2
     - path: data/Zuiderzeeland/modellen/Zuiderzeeland_forcing
       hash: md5
-      md5: 60db5dda13e9e27dc212f2a682a65e5c.dir
+      md5: 5dc6225d5bc461b6fd7d61faec5d555e.dir
       size: 39891125
       nfiles: 2
     - path: notebooks/08_samenvoegen_modellen.py
@@ -123,7 +123,7 @@ stages:
     outs:
     - path: data/Rijkswaterstaat/modellen/lhm_parts
       hash: md5
-      md5: d324c679ea3d9eab88911b0626b0d84c.dir
+      md5: 010fd00d5e2e108778db6707ff5e298a.dir
       size: 2274058422
       nfiles: 2
   bathymetry:
@@ -163,12 +163,12 @@ stages:
     deps:
     - path: data/Rijkswaterstaat/modellen/lhm_parts
       hash: md5
-      md5: d324c679ea3d9eab88911b0626b0d84c.dir
+      md5: 010fd00d5e2e108778db6707ff5e298a.dir
       size: 2274058422
       nfiles: 2
     - path: data/Rijkswaterstaat/verwerkt/netwerk.gpkg
       hash: md5
-      md5: 0474c4e29bbe2f8bac2c056a394d9601
+      md5: 17fdd9689ae5b47d4081ba1c34fefa64
       size: 3731456
     - path: notebooks/09_koppelen_modellen.py
       hash: md5
@@ -177,7 +177,7 @@ stages:
     outs:
     - path: data/Rijkswaterstaat/modellen/lhm_coupled
       hash: md5
-      md5: 2393db8b2955ae9c75307a2ca8b1f82b.dir
+      md5: c5848d3ee43499ecbd9aab5e34729dbb.dir
       size: 1295431355
       nfiles: 4
   rwzi:
@@ -237,8 +237,8 @@ stages:
     outs:
     - path: data/AaenMaas/modellen/AaenMaas_dynamic_model
       hash: md5
-      md5: 9565f4a3956196efe25217535be9eff1.dir
-      size: 96601309
+      md5: b15be66679c38bdf60d1b16cf522c0c9.dir
+      size: 96601301
       nfiles: 5
   dynamic@brabantse_delta:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py BrabantseDelta
@@ -270,8 +270,8 @@ stages:
     outs:
     - path: data/BrabantseDelta/modellen/BrabantseDelta_dynamic_model
       hash: md5
-      md5: 8e240a268f30104dd0be21b39b909f47.dir
-      size: 125677307
+      md5: b7b5e59102b4e0d0d024e7959c8658ec.dir
+      size: 125677107
       nfiles: 5
   dynamic@de_dommel:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py DeDommel
@@ -303,8 +303,8 @@ stages:
     outs:
     - path: data/DeDommel/modellen/DeDommel_dynamic_model
       hash: md5
-      md5: 87aa07cb6c9f19a3cb12d3127a865701.dir
-      size: 130578479
+      md5: 8ef6cea26a73807ca783db0bdc87f56d.dir
+      size: 130578608
       nfiles: 5
   dynamic@drents_overijsselse_delta:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py
@@ -339,8 +339,8 @@ stages:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_dynamic_model
       hash: md5
-      md5: d27e354d03f77dc4a97db560aaef1616.dir
-      size: 87167503
+      md5: 230e9d38cb203c20f087c126ef536f40.dir
+      size: 87167530
       nfiles: 5
   dynamic@hunze_en_aas:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py HunzeenAas
@@ -372,8 +372,8 @@ stages:
     outs:
     - path: data/HunzeenAas/modellen/HunzeenAas_dynamic_model
       hash: md5
-      md5: c7c0c373364babf3faac181b7c452090.dir
-      size: 74145616
+      md5: b517b2b070a736a23431f39961196f28.dir
+      size: 74145501
       nfiles: 5
   dynamic@limburg:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py Limburg
@@ -405,8 +405,8 @@ stages:
     outs:
     - path: data/Limburg/modellen/Limburg_dynamic_model
       hash: md5
-      md5: 1f643599c200252d98323a6edb23cf78.dir
-      size: 136870185
+      md5: 9740babc7d84831412bfe70f71c2b537.dir
+      size: 136869812
       nfiles: 5
   dynamic@noorderzijlvest:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py Noorderzijlvest
@@ -438,8 +438,8 @@ stages:
     outs:
     - path: data/Noorderzijlvest/modellen/Noorderzijlvest_dynamic_model
       hash: md5
-      md5: 4615e4821285d9d1ac382ffc2e8d2ed8.dir
-      size: 88181887
+      md5: d27e66bd94923b649aa85d13a41c7226.dir
+      size: 88181726
       nfiles: 5
   dynamic@rijn_en_ijssel:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py RijnenIJssel
@@ -471,8 +471,8 @@ stages:
     outs:
     - path: data/RijnenIJssel/modellen/RijnenIJssel_dynamic_model
       hash: md5
-      md5: f211224e47d08444fec82d848aa50e64.dir
-      size: 54802182
+      md5: 7758e510b747aca220c9b8a0930d25fd.dir
+      size: 54802005
       nfiles: 5
   dynamic@stichtse_rijnlanden:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py StichtseRijnlanden
@@ -504,8 +504,8 @@ stages:
     outs:
     - path: data/StichtseRijnlanden/modellen/StichtseRijnlanden_dynamic_model
       hash: md5
-      md5: 279fdb4fb1e45e1812b8157f3827242a.dir
-      size: 81530688
+      md5: 9560c63ecf3555293ff0834c78d04684.dir
+      size: 81530708
       nfiles: 5
   dynamic@vallei_en_veluwe:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py ValleienVeluwe
@@ -537,8 +537,8 @@ stages:
     outs:
     - path: data/ValleienVeluwe/modellen/ValleienVeluwe_dynamic_model
       hash: md5
-      md5: 7b028834aa0aeead6b98c71d60f98c58.dir
-      size: 79204116
+      md5: da1a329113dae6201d9abdb92e20513a.dir
+      size: 79203990
       nfiles: 5
   dynamic@vechtstromen:
     cmd: pixi run python notebooks/07_add_dynamic_forcing.py Vechtstromen
@@ -570,8 +570,8 @@ stages:
     outs:
     - path: data/Vechtstromen/modellen/Vechtstromen_dynamic_model
       hash: md5
-      md5: 2424cbfd1f3abaa653c0d28df237e4c0.dir
-      size: 120093027
+      md5: 3c7a0f658f747d9493702c1702f161be.dir
+      size: 120092999
       nfiles: 5
   hws_demand:
     cmd:
@@ -706,7 +706,7 @@ stages:
       nfiles: 2
     - path: data/Rijkswaterstaat/verwerkt/netwerk.gpkg
       hash: md5
-      md5: 0474c4e29bbe2f8bac2c056a394d9601
+      md5: 17fdd9689ae5b47d4081ba1c34fefa64
       size: 3731456
   hws_transient:
     cmd:
@@ -816,7 +816,7 @@ stages:
     outs:
     - path: data/RijnenIJssel/modellen/RijnenIJssel_parameterized_model
       hash: md5
-      md5: dbf89b174a3abdc9fd7961955bd2af8c.dir
+      md5: 71927344b1cdf9bbfd561ac9f7bbb268.dir
       size: 4706453
       nfiles: 3
   parameterized_vallei_en_veluwe:
@@ -1005,7 +1005,7 @@ stages:
     outs:
     - path: data/Vechtstromen/modellen/Vechtstromen_parameterized_model
       hash: md5
-      md5: de8bdfd83107da9c1e0c65fdcb8090d4.dir
+      md5: 07de55e6e5e348230cb8f20eb81a4341.dir
       size: 18800789
       nfiles: 3
   parameterized_aa_en_maas:
@@ -1184,7 +1184,7 @@ stages:
     outs:
     - path: data/BrabantseDelta/modellen/BrabantseDelta_parameterized_model
       hash: md5
-      md5: fd99b33aedfa76785e75d777d68898dd.dir
+      md5: d732f65ca1f06679aeca2dbf0bfa11ab.dir
       size: 15769749
       nfiles: 3
   parameterized_de_dommel:
@@ -1363,7 +1363,7 @@ stages:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_parameterized_model
       hash: md5
-      md5: 56a17dfc23e208070c0aaaa96b8fb2f5.dir
+      md5: ef22605abc0248309b554c671e25144a.dir
       size: 7114901
       nfiles: 3
   parameterized_hunze_en_aas:
@@ -1454,7 +1454,7 @@ stages:
     outs:
     - path: data/HunzeenAas/modellen/HunzeenAas_parameterized_model
       hash: md5
-      md5: 2242e6927891c5de7428f96d7d54764c.dir
+      md5: 80e3dfc2cf053f9c0c7ce14f01b1734b.dir
       size: 4952213
       nfiles: 3
   parameterized_limburg:
@@ -1699,12 +1699,12 @@ stages:
     - path:
         data/StichtseRijnlanden/modellen/StichtseRijnlanden_parameterized_model
       hash: md5
-      md5: a15458185d8152077d8020431f1ef86c.dir
+      md5: 5adbb8778fff2216b174cfa02fb686b9.dir
       size: 18366613
       nfiles: 3
     - path: data/StichtseRijnlanden/verwerkt/4_ribasim/peilgebieden_bewerkt.gpkg
       hash: md5
-      md5: f8a7e0136e821f68705d56c0ec21b126
+      md5: 271d4aab24ac110efa95c56ed81e2f94
       size: 6492160
   bergend_aa_en_maas:
     cmd:
@@ -1771,7 +1771,7 @@ stages:
       size: 561756752
     - path: data/BrabantseDelta/modellen/BrabantseDelta_parameterized_model
       hash: md5
-      md5: fd99b33aedfa76785e75d777d68898dd.dir
+      md5: d732f65ca1f06679aeca2dbf0bfa11ab.dir
       size: 15769749
       nfiles: 3
     - path: data/BrabantseDelta/verwerkt/sturing/aanvoergebieden.gpkg
@@ -1852,7 +1852,7 @@ stages:
     - path:
         data/DrentsOverijsselseDelta/modellen/DrentsOverijsselseDelta_parameterized_model
       hash: md5
-      md5: 56a17dfc23e208070c0aaaa96b8fb2f5.dir
+      md5: ef22605abc0248309b554c671e25144a.dir
       size: 7114901
       nfiles: 3
     - path: data/DrentsOverijsselseDelta/verwerkt/sturing/aanvoergebieden.gpkg
@@ -1901,7 +1901,7 @@ stages:
       size: 561756752
     - path: data/HunzeenAas/modellen/HunzeenAas_parameterized_model
       hash: md5
-      md5: 2242e6927891c5de7428f96d7d54764c.dir
+      md5: 80e3dfc2cf053f9c0c7ce14f01b1734b.dir
       size: 4952213
       nfiles: 3
     - path: data/HunzeenAas/verwerkt/sturing/aanvoergebieden.gpkg
@@ -2021,7 +2021,7 @@ stages:
       size: 561756752
     - path: data/RijnenIJssel/modellen/RijnenIJssel_parameterized_model
       hash: md5
-      md5: dbf89b174a3abdc9fd7961955bd2af8c.dir
+      md5: 71927344b1cdf9bbfd561ac9f7bbb268.dir
       size: 4706453
       nfiles: 3
     - path: data/RijnenIJssel/verwerkt/sturing/aanvoergebieden.gpkg
@@ -2062,12 +2062,12 @@ stages:
     - path:
         data/StichtseRijnlanden/modellen/StichtseRijnlanden_parameterized_model
       hash: md5
-      md5: a15458185d8152077d8020431f1ef86c.dir
+      md5: 5adbb8778fff2216b174cfa02fb686b9.dir
       size: 18366613
       nfiles: 3
     - path: data/StichtseRijnlanden/verwerkt/4_ribasim/peilgebieden_bewerkt.gpkg
       hash: md5
-      md5: f8a7e0136e821f68705d56c0ec21b126
+      md5: 271d4aab24ac110efa95c56ed81e2f94
       size: 6492160
     - path: data/StichtseRijnlanden/verwerkt/sturing/aanvoergebieden.gpkg
       hash: md5
@@ -2153,7 +2153,7 @@ stages:
       size: 561756752
     - path: data/Vechtstromen/modellen/Vechtstromen_parameterized_model
       hash: md5
-      md5: de8bdfd83107da9c1e0c65fdcb8090d4.dir
+      md5: 07de55e6e5e348230cb8f20eb81a4341.dir
       size: 18800789
       nfiles: 3
     - path: data/Vechtstromen/verwerkt/1_ontvangen_data/LHM20230418.gdb
@@ -2531,7 +2531,7 @@ stages:
       nfiles: 2
     - path: data/Delfland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: d1ac44b3a01cac3ab7dcbd32cfda89af
+      md5: 01c74abf924ce3d3d8d5ed0b82bf0e4c
       size: 10645504
   profiles_amstel_gooi_en_vecht:
     cmd:
@@ -2580,7 +2580,7 @@ stages:
       nfiles: 2
     - path: data/AmstelGooienVecht/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 8be0e30868871624708bdf1cf9f3d199
+      md5: 276484815ed21017c9b61acd48e586a6
       size: 5369856
   profiles_hollands_noorderkwartier:
     cmd:
@@ -2633,7 +2633,7 @@ stages:
       nfiles: 2
     - path: data/HollandsNoorderkwartier/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: b974e48c6143273194e2b65b8c254aec
+      md5: bc5c08b71965f7c01be2b7752d9786fc
       size: 40390656
   profiles_hollandse_delta:
     cmd:
@@ -2687,7 +2687,7 @@ stages:
       nfiles: 2
     - path: data/HollandseDelta/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 7e7bc0c2e4806b63273db964eb037b63
+      md5: 1d90a29380716284a50662f670f51fb5
       size: 20553728
   profiles_rijnland:
     cmd:
@@ -2741,7 +2741,7 @@ stages:
       nfiles: 2
     - path: data/Rijnland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: d218ebfb321e779de1fee6f91c08c3e4
+      md5: 6a110ba62b0148e967565342baf39ec8
       size: 63401984
   profiles_rivierenland:
     cmd:
@@ -2791,7 +2791,7 @@ stages:
       nfiles: 2
     - path: data/Rivierenland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 832c8bdcca4f7cfd09c4fd643f9fe891
+      md5: 1c4b7c025b117b357a9dc665aec8800c
       size: 85151744
   profiles_scheldestromen:
     cmd:
@@ -2847,7 +2847,7 @@ stages:
       nfiles: 2
     - path: data/Scheldestromen/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: c7e816914ff17d9cc2710d9017819647
+      md5: b6c566233de8c3aed156c6af935eeb22
       size: 36167680
   profiles_schieland_en_de_krimpenerwaard:
     cmd:
@@ -2896,12 +2896,12 @@ stages:
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_profiles
       hash: md5
-      md5: 76d645ad120e58b3180203be075e12b4.dir
+      md5: 8630f5b784adb79cea72e0fce11fa787.dir
       size: 4030618
       nfiles: 2
     - path: data/SchielandendeKrimpenerwaard/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 421ed518f7a4f8250ae098d20fe49fd2
+      md5: 957901f691a467af60d03eba0119e20f
       size: 22462464
   profiles_wetterskip_fryslan:
     cmd:
@@ -2951,7 +2951,7 @@ stages:
       nfiles: 2
     - path: data/WetterskipFryslan/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 83f957a91a2f4893493b27f94bc75f20
+      md5: cf98a78184593ffcd7840782cc53c853
       size: 38248448
   profiles_zuiderzeeland:
     cmd:
@@ -3000,7 +3000,7 @@ stages:
       nfiles: 2
     - path: data/Zuiderzeeland/verwerkt/profielen/network.gpkg
       hash: md5
-      md5: 3cfd752a2558b499fba470a96972fe50
+      md5: cce53610af5af9ab0d38e9b137840117
       size: 8634368
   forcing_delfland:
     cmd: pixi run python src/peilbeheerst_model/forcing/Delfland.py
@@ -3053,8 +3053,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/Delfland.py
       hash: md5
-      md5: c237d27525cea01240dbd25433aefdec
-      size: 16515
+      md5: 9fb8bebd6aef12d5795d68cc2b4a6bc7
+      size: 16743
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3066,7 +3066,7 @@ stages:
     outs:
     - path: data/Delfland/modellen/Delfland_forcing
       hash: md5
-      md5: 9bc354ef83c46357e58b1a6091287b67.dir
+      md5: 80c4171d992d97db86d077c6b7b56356.dir
       size: 23064757
       nfiles: 2
   forcing_amstel_gooi_en_vecht:
@@ -3122,8 +3122,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/AmstelGooienVecht.py
       hash: md5
-      md5: 901d0882ebfe95e6964fa9ef4f2aaee1
-      size: 18121
+      md5: 1f902551e3396c88b39cf8772ff5d1c8
+      size: 18349
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3135,7 +3135,7 @@ stages:
     outs:
     - path: data/AmstelGooienVecht/modellen/AmstelGooienVecht_forcing
       hash: md5
-      md5: 9fc3772c3135ac508e9518684352e703.dir
+      md5: 2ecbd7e249f383a41d2055e4ee8608a1.dir
       size: 46149813
       nfiles: 2
   forcing_hollands_noorderkwartier:
@@ -3194,8 +3194,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/HollandsNoorderkwartier.py
       hash: md5
-      md5: ff680ceffbb83e380f629888da9195c1
-      size: 18010
+      md5: 0b71b161a661e273955a7b8282f78ce6
+      size: 18238
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3208,7 +3208,7 @@ stages:
     - path:
         data/HollandsNoorderkwartier/modellen/HollandsNoorderkwartier_forcing
       hash: md5
-      md5: 35634a6467890800c1c55c03d5ec6992.dir
+      md5: 7df64671a32f6777296c6bd99fc4e4e5.dir
       size: 49971381
       nfiles: 2
   forcing_hollandse_delta:
@@ -3262,8 +3262,8 @@ stages:
       nfiles: 2
     - path: src/peilbeheerst_model/forcing/HollandseDelta.py
       hash: md5
-      md5: 818be856e1ed443cb746fd906a2c7807
-      size: 15838
+      md5: 9755471b459de59cb39bf1d7fc1f5b2c
+      size: 16066
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3275,7 +3275,7 @@ stages:
     outs:
     - path: data/HollandseDelta/modellen/HollandseDelta_forcing
       hash: md5
-      md5: adee56ded94dbfb54fba9495ef971e80.dir
+      md5: b4b25b6b86004da76829eb3836eda9ba.dir
       size: 93483189
       nfiles: 2
   forcing_rijnland:
@@ -3329,8 +3329,8 @@ stages:
       size: 218427392
     - path: src/peilbeheerst_model/forcing/Rijnland.py
       hash: md5
-      md5: abe82891272f5a37e7bd187df3b4c0df
-      size: 15998
+      md5: 1d23ee9d12b8dcf2a1a2c24625aa72c5
+      size: 16226
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3342,7 +3342,7 @@ stages:
     outs:
     - path: data/Rijnland/modellen/Rijnland_forcing
       hash: md5
-      md5: da4ced9d15067c29736bf77bc861b50f.dir
+      md5: 03833ec3da148d978cc9e76c3f5901ae.dir
       size: 67440821
       nfiles: 2
   forcing_rivierenland:
@@ -3396,8 +3396,8 @@ stages:
       size: 108998656
     - path: src/peilbeheerst_model/forcing/Rivierenland.py
       hash: md5
-      md5: fd798823b810af9ce559de0c027a933a
-      size: 16266
+      md5: c0cf5aa58882b29f47a5ced55a684cdf
+      size: 16494
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3409,7 +3409,7 @@ stages:
     outs:
     - path: data/Rivierenland/modellen/Rivierenland_forcing
       hash: md5
-      md5: 4d03309cd10c27f920b0a9513fbb6fdc.dir
+      md5: 4df474a39ae4279e108544d77831a1e9.dir
       size: 48156853
       nfiles: 2
   forcing_scheldestromen:
@@ -3463,8 +3463,8 @@ stages:
       size: 72876032
     - path: src/peilbeheerst_model/forcing/Scheldestromen.py
       hash: md5
-      md5: 9f4280f0f1a08a3f97de10977b784651
-      size: 16824
+      md5: 85b2cfd470689c711ca3b48f4e1a3bc8
+      size: 17052
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3476,7 +3476,7 @@ stages:
     outs:
     - path: data/Scheldestromen/modellen/Scheldestromen_forcing
       hash: md5
-      md5: ff7a81690ad9628e1ad938a3c7c6d0f5.dir
+      md5: 677cd0872a3d4158c0756fd6232a40a2.dir
       size: 37515445
       nfiles: 2
   forcing_schieland_en_de_krimpenerwaard:
@@ -3519,7 +3519,7 @@ stages:
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_profiles
       hash: md5
-      md5: 76d645ad120e58b3180203be075e12b4.dir
+      md5: 8630f5b784adb79cea72e0fce11fa787.dir
       size: 4030618
       nfiles: 2
     - path: data/SchielandendeKrimpenerwaard/verwerkt/Feedback
@@ -3534,8 +3534,8 @@ stages:
       size: 66883584
     - path: src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
       hash: md5
-      md5: a613ce2359661ee56c8fa2d21bd7fb03
-      size: 17301
+      md5: e42e86a4b42cbda7bccaa22088db9252
+      size: 17727
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3548,7 +3548,7 @@ stages:
     - path:
         data/SchielandendeKrimpenerwaard/modellen/SchielandendeKrimpenerwaard_forcing
       hash: md5
-      md5: f0064d2c2f25e18f52b2ff1815aea504.dir
+      md5: 401856f94fc250da3bf25f1292ff259e.dir
       size: 29003957
       nfiles: 2
   forcing_wetterskip_fryslan:
@@ -3604,8 +3604,8 @@ stages:
       size: 87060480
     - path: src/peilbeheerst_model/forcing/WetterskipFryslan.py
       hash: md5
-      md5: 0686266116ebaef9d76aea2191b0b455
-      size: 16512
+      md5: b0208d4a35c16ca072253df902f7afec
+      size: 16740
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3617,7 +3617,7 @@ stages:
     outs:
     - path: data/WetterskipFryslan/modellen/WetterskipFryslan_forcing
       hash: md5
-      md5: 01e0518368a0677b4921245527d02960.dir
+      md5: 81003619a3c407b6b8135386f8131c28.dir
       size: 187408565
       nfiles: 2
   forcing_zuiderzeeland:
@@ -3670,8 +3670,8 @@ stages:
       size: 18821120
     - path: src/peilbeheerst_model/forcing/Zuiderzeeland.py
       hash: md5
-      md5: 9fe74dc68d9dc555ce77fd8e83647bc8
-      size: 16725
+      md5: 323f4ce13d79e55cb92e9f41f8d31cd9
+      size: 16953
     - path: src/peilbeheerst_model/peilbeheerst_model/assign_authorities.py
       hash: md5
       md5: f0d6f439622edd3af25c557802bcb2ec
@@ -3683,6 +3683,6 @@ stages:
     outs:
     - path: data/Zuiderzeeland/modellen/Zuiderzeeland_forcing
       hash: md5
-      md5: 60db5dda13e9e27dc212f2a682a65e5c.dir
+      md5: 5dc6225d5bc461b6fd7d61faec5d555e.dir
       size: 39891125
       nfiles: 2

--- a/notebooks/aa_en_maas/03_parameterize_model.py
+++ b/notebooks/aa_en_maas/03_parameterize_model.py
@@ -2,7 +2,7 @@
 import time
 
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim import run_ribasim
 from ribasim_nl.check_basin_level import add_check_basin_level
 
@@ -131,5 +131,5 @@ model.write(ribasim_toml)
 if run_model:
     run_ribasim(ribasim_toml)
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/aa_en_maas/04_add_full_control.py
+++ b/notebooks/aa_en_maas/04_add_full_control.py
@@ -5,7 +5,6 @@ from typing import Literal
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
 from ribasim.nodes import flow_demand, outlet
 from ribasim_nl.control import (
     _offset_new_node,
@@ -18,6 +17,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely.geometry import MultiPolygon
 
 from ribasim_nl import CloudStorage, Model
@@ -1458,8 +1458,8 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
@@ -1470,32 +1470,22 @@ model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time
 update_basin_static(model=model, evaporation_mm_per_day=0.1)
 model.starttime = datetime(2020, 5, 1)
 model.endtime = datetime(2020, 9, 1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
 model.starttime = datetime(2020, 1, 1)
 model.endtime = datetime(2020, 4, 1)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/notebooks/brabantse_delta/03_parameterize_model.py
+++ b/notebooks/brabantse_delta/03_parameterize_model.py
@@ -2,7 +2,7 @@
 import time
 
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
@@ -145,5 +145,5 @@ if run_model:
 
     # # %%
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/brabantse_delta/04_add_full_control.py
+++ b/notebooks/brabantse_delta/04_add_full_control.py
@@ -1,9 +1,9 @@
 # %%
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim_nl.control import add_controllers_to_supply_area, add_controllers_to_uncontrolled_connector_nodes
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely.geometry import MultiPolygon
 
 from ribasim_nl import CloudStorage, Model
@@ -414,8 +414,8 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
@@ -428,30 +428,20 @@ model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/notebooks/de_dommel/03_parameterize_model.py
+++ b/notebooks/de_dommel/03_parameterize_model.py
@@ -1,7 +1,7 @@
 # %%
 import time
 
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
@@ -65,5 +65,5 @@ if run_model:
 
     # # %%
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/de_dommel/04_add_full_control.py
+++ b/notebooks/de_dommel/04_add_full_control.py
@@ -1,6 +1,5 @@
 # %%
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim_nl.control import (
     add_controllers_to_supply_area,
     add_controllers_to_uncontrolled_connector_nodes,
@@ -8,6 +7,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely.geometry import MultiPolygon
 
 from ribasim_nl import CloudStorage, Model
@@ -246,8 +246,8 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
@@ -273,30 +273,20 @@ model.outlet.static.df.loc[mask, "max_flow_rate"] = model.outlet.static.df.loc[m
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/notebooks/drents_overijsselse_delta/03_parameterize_model.py
+++ b/notebooks/drents_overijsselse_delta/03_parameterize_model.py
@@ -3,7 +3,7 @@ import time
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
@@ -195,6 +195,6 @@ if run_model:
     assert result.exit_code == 0
 
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 
 # %%

--- a/notebooks/drents_overijsselse_delta/04_add_full_control.py
+++ b/notebooks/drents_overijsselse_delta/04_add_full_control.py
@@ -1,6 +1,5 @@
 # %%
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim import Node
 from ribasim.nodes import level_boundary, pump
 from ribasim_nl.control import (
@@ -10,6 +9,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely import Point
 
 from ribasim_nl import CloudStorage, Model
@@ -89,17 +89,6 @@ def add_supply_area_control(
         flow_rate_afvoer=flow_rate_afvoer,
         max_flow_rate_afvoer=max_flow_rate_afvoer,
     )
-
-
-def run_model_and_control(model: Model, ribasim_toml, qlr_path):
-    model.write(ribasim_toml)
-
-    if MODEL_EXEC:
-        model.run()
-        Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
-        return Model.read(ribasim_toml)
-
-    return model
 
 
 # %%
@@ -796,18 +785,24 @@ model.outlet.static.df.loc[vechterweerd_mask, ["flow_rate", "max_flow_rate"]] = 
 # %%
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=1)
-model = run_model_and_control(model, ribasim_toml_dry, qlr_path)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model = run_model_and_control(model, ribasim_toml_wet, qlr_path)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model = run_model_and_control(model, ribasim_toml, qlr_path)
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)

--- a/notebooks/hunze_en_aas/03_parameterize_model.py
+++ b/notebooks/hunze_en_aas/03_parameterize_model.py
@@ -2,7 +2,7 @@
 import time
 
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
@@ -96,5 +96,5 @@ if run_model:
     assert result.exit_code == 0
 
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/hunze_en_aas/04_add_full_control.py
+++ b/notebooks/hunze_en_aas/04_add_full_control.py
@@ -1,6 +1,5 @@
 # %%
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim_nl.control import (
     add_controllers_to_supply_area,
     add_controllers_to_uncontrolled_connector_nodes,
@@ -9,6 +8,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 
 from ribasim_nl import CloudStorage, Model
 
@@ -748,38 +748,28 @@ configure_dorkwerd_control(model)
 # %%
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=0.1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/notebooks/limburg/03_parameterize_model.py
+++ b/notebooks/limburg/03_parameterize_model.py
@@ -2,7 +2,7 @@
 import time
 
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
     sync_min_upstream_levels_with_profile_bottoms,
@@ -86,5 +86,5 @@ if run_model:
     result = model.run()
 
     controle_output = Control(ribasim_toml=ribasim_toml)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/limburg/04_add_full_control.py
+++ b/notebooks/limburg/04_add_full_control.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
 from ribasim.nodes import flow_demand, outlet, pump
 from ribasim_nl.control import (
     _offset_new_node,
@@ -17,6 +16,7 @@ from ribasim_nl.control import (
 from ribasim_nl.coupling_level_apply import sync_static_controller_thresholds
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely.geometry import MultiPolygon, Point
 
 from ribasim_nl import CloudStorage, Model
@@ -956,8 +956,8 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
@@ -966,30 +966,20 @@ model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=0.1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/notebooks/noorderzijlvest/03_parameterize_model.py
+++ b/notebooks/noorderzijlvest/03_parameterize_model.py
@@ -1,7 +1,7 @@
 # %%
 import time
 
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
@@ -54,4 +54,4 @@ if run_model:
     assert result.exit_code == 0
 
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)

--- a/notebooks/noorderzijlvest/04_add_full_control.py
+++ b/notebooks/noorderzijlvest/04_add_full_control.py
@@ -1,7 +1,6 @@
 # %%
 
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim_nl.control import (
     add_controllers_to_supply_area,
     add_controllers_to_uncontrolled_connector_nodes,
@@ -9,6 +8,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 
 from ribasim_nl import CloudStorage, Model
 
@@ -343,8 +343,8 @@ add_controllers_to_uncontrolled_connector_nodes(
 # %%
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
@@ -377,28 +377,18 @@ junctionify(model)
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=0.1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)

--- a/notebooks/rijn_en_ijssel/03_parameterize_model.py
+++ b/notebooks/rijn_en_ijssel/03_parameterize_model.py
@@ -3,7 +3,7 @@ import time
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import sync_min_upstream_levels_with_profile_bottoms
 from ribasim_nl.parametrization.manning_level import sync_parameterized_manning_basin_levels
@@ -90,5 +90,5 @@ if run_model:
 
     # # %%
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/rijn_en_ijssel/04_add_full_control.py
+++ b/notebooks/rijn_en_ijssel/04_add_full_control.py
@@ -1,6 +1,5 @@
 # %%
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim_nl.control import (
     add_controllers_to_supply_area,
     add_controllers_to_uncontrolled_connector_nodes,
@@ -8,6 +7,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 
 from ribasim_nl import CloudStorage, Model
 
@@ -368,36 +368,26 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 # %%
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=0.1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)

--- a/notebooks/stichtse_rijnlanden/03_parameterize_model.py
+++ b/notebooks/stichtse_rijnlanden/03_parameterize_model.py
@@ -4,7 +4,7 @@ import time
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
     sync_min_upstream_levels_with_profile_bottoms,
@@ -97,5 +97,5 @@ if run_model:
     assert result.exit_code == 0
 
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/stichtse_rijnlanden/04_add_full_control.py
+++ b/notebooks/stichtse_rijnlanden/04_add_full_control.py
@@ -1,6 +1,5 @@
 # %%
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim_nl.control import (
     add_controllers_to_supply_area,
     add_controllers_to_uncontrolled_connector_nodes,
@@ -8,6 +7,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely.geometry import MultiPolygon
 
 from ribasim_nl import CloudStorage, Model
@@ -385,8 +385,8 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time.isna(), ["time"]] = model.starttime
@@ -395,30 +395,20 @@ model.discrete_control.condition.df.loc[model.discrete_control.condition.df.time
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=1)
-model.write(ribasim_toml_dry)
-
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_dry, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_dry)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model.write(ribasim_toml_wet)
-
-# run prerun model
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml_wet, qlr_path=qlr_path).run_all()
-    model = Model.read(ribasim_toml_wet)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model.write(ribasim_toml)
-# run hoofdmodel
-if MODEL_EXEC:
-    model.run()
-    Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/notebooks/vallei_en_veluwe/03_parameterize_model.py
+++ b/notebooks/vallei_en_veluwe/03_parameterize_model.py
@@ -1,7 +1,7 @@
 # %%
 import time
 
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
     sync_min_upstream_levels_with_profile_bottoms,
@@ -85,6 +85,6 @@ if run_model:
     assert result.exit_code == 0
 
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 
 # %%

--- a/notebooks/vallei_en_veluwe/04_add_full_control.py
+++ b/notebooks/vallei_en_veluwe/04_add_full_control.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
 from ribasim import Node
 from ribasim.nodes import level_boundary
 from ribasim_nl.control import (
@@ -14,6 +13,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 from shapely.ops import substring
 
 from ribasim_nl import CloudStorage, Model
@@ -177,17 +177,6 @@ def add_supply_area_control(
         flow_rate_afvoer=100.0,
         max_flow_rate_afvoer=outlet_max_flow_rate_afvoer_by_node_id,
     )
-
-
-def run_model_and_control(model: Model, ribasim_toml, qlr_path):
-    model.write(ribasim_toml)
-
-    if MODEL_EXEC:
-        model.run()
-        Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
-        return Model.read(ribasim_toml)
-
-    return model
 
 
 # %%
@@ -707,18 +696,24 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 # %%
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=1)
-model = run_model_and_control(model, ribasim_toml_dry, qlr_path)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model = run_model_and_control(model, ribasim_toml_wet, qlr_path)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model = run_model_and_control(model, ribasim_toml, qlr_path)
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)

--- a/notebooks/vechtstromen/03_parameterize_model.py
+++ b/notebooks/vechtstromen/03_parameterize_model.py
@@ -3,7 +3,7 @@ import time
 
 import geopandas as gpd
 import pandas as pd
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import AFVOER_METRICS, Control
 from ribasim_nl.check_basin_level import add_check_basin_level
 from ribasim_nl.parametrization.basin_tables import (
     apply_basin_level_overrides,
@@ -115,5 +115,5 @@ if run_model:
     assert result.exit_code == 0
 
     controle_output = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
-    indicators = controle_output.run_afvoer()
+    indicators = controle_output.run(metrics=AFVOER_METRICS)
 # %%

--- a/notebooks/vechtstromen/04_add_full_control.py
+++ b/notebooks/vechtstromen/04_add_full_control.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 import geopandas as gpd
-from peilbeheerst_model.controle_output import Control
 from ribasim import Node
 from ribasim.nodes import level_boundary
 from ribasim_nl.control import (
@@ -12,6 +11,7 @@ from ribasim_nl.control import (
 )
 from ribasim_nl.junctions import junctionify
 from ribasim_nl.parametrization.basin_tables import update_basin_static
+from ribasim_nl.run_model import run_model_and_control
 
 from ribasim_nl import CloudStorage, Model
 
@@ -60,34 +60,6 @@ def add_supply_area_control(
         flow_rate_afvoer=100.0,
         max_flow_rate_afvoer=outlet_max_flow_rate_afvoer_by_node_id,
     )
-
-
-def clean_database_sidecars(input_dir: Path) -> None:
-    for suffix in ["-wal", "-shm"]:
-        try:
-            input_dir.joinpath(f"database.gpkg{suffix}").unlink(missing_ok=True)
-        except PermissionError as error:
-            raise PermissionError(
-                f"Kan database sidecars niet opschonen in {input_dir}. "
-                "Sluit QGIS of andere programma's die de database gebruiken."
-            ) from error
-
-
-def run_model_and_control(model: Model, ribasim_toml, qlr_path):
-    ribasim_toml = Path(ribasim_toml)
-    input_dir = ribasim_toml.parent / model.input_dir
-
-    clean_database_sidecars(input_dir)
-    fill_missing_level_boundary_static_levels(model)
-    model.write(ribasim_toml)
-    clean_database_sidecars(input_dir)
-
-    if MODEL_EXEC:
-        model.run()
-        Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path).run_all()
-        return Model.read(ribasim_toml)
-
-    return model
 
 
 def set_max_flow_rate(static_df, max_flow_rate_by_node_id: dict[int, float]) -> None:
@@ -807,20 +779,29 @@ for static_df in (model.outlet.static.df, model.pump.static.df):
 # %%
 # Model run
 
-ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_wet", f"{SHORT_NAME}.toml")
-ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_dry", f"{SHORT_NAME}.toml")
+ribasim_toml_wet = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_wet", f"{SHORT_NAME}.toml")
+ribasim_toml_dry = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_steady_state_dry", f"{SHORT_NAME}.toml")
 ribasim_toml = cloud.joinpath(AUTHORITY, "modellen", f"{AUTHORITY}_full_control_model", f"{SHORT_NAME}.toml")
 
 # hoofd run met verdamping
 update_basin_static(model=model, evaporation_mm_per_day=0.5)
-model = run_model_and_control(model, ribasim_toml_dry, qlr_path)
+fill_missing_level_boundary_static_levels(model)
+model = run_model_and_control(
+    model, ribasim_toml_dry, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="dry"
+)
 
 # prerun om het model te initialiseren met neerslag
 update_basin_static(model=model, precipitation_mm_per_day=2)
-model = run_model_and_control(model, ribasim_toml_wet, qlr_path)
+fill_missing_level_boundary_static_levels(model)
+model = run_model_and_control(
+    model, ribasim_toml_wet, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario="wet"
+)
 
 # hoofd run
 update_basin_static(model=model, precipitation_mm_per_day=1.5)
-model = run_model_and_control(model, ribasim_toml, qlr_path)
+fill_missing_level_boundary_static_levels(model)
+model = run_model_and_control(
+    model, ribasim_toml, model_exec=MODEL_EXEC, qlr_path=qlr_path, authority=AUTHORITY, scenario=None
+)
 
 # %%

--- a/pixi.toml
+++ b/pixi.toml
@@ -82,7 +82,6 @@ install-dvc = "dvc pull"
 install = { depends-on = ["install-core", "install-prek", "install-dvc"] }
 repro = "dvc repro --keep-going && prek run"
 check = "prek run --all-files"
-pycheck = "prek run --all-files --skip dvc-pre-commit --skip dvc-pre-push --skip dvc-post-checkout"
 dvc-dag = { cmd = "python scripts/dvc_dag.py > docs/dev/_dvc-dag.mmd", inputs = ["dvc.yaml"], outputs = ["docs/dev/_dvc-dag.mmd"] }
 docs = { cmd = "quartodoc build && quarto preview", cwd = "docs", depends-on = ["dvc-dag"] }
 docs-render = { cmd = "quartodoc build && rm -f objects.json && quarto render --to html --execute", cwd = "docs", depends-on = ["dvc-dag"] }

--- a/src/peilbeheerst_model/forcing/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/forcing/AmstelGooienVecht.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -477,6 +477,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -487,4 +489,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/AmstelGooienVecht.py
+++ b/src/peilbeheerst_model/forcing/AmstelGooienVecht.py
@@ -471,6 +471,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/Delfland.py
+++ b/src/peilbeheerst_model/forcing/Delfland.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -419,6 +419,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -429,4 +431,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/Delfland.py
+++ b/src/peilbeheerst_model/forcing/Delfland.py
@@ -413,6 +413,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/HollandsNoorderkwartier.py
+++ b/src/peilbeheerst_model/forcing/HollandsNoorderkwartier.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -536,6 +536,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -546,4 +548,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/HollandsNoorderkwartier.py
+++ b/src/peilbeheerst_model/forcing/HollandsNoorderkwartier.py
@@ -530,6 +530,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/HollandseDelta.py
+++ b/src/peilbeheerst_model/forcing/HollandseDelta.py
@@ -485,6 +485,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 if not ribasim_model.use_validation:

--- a/src/peilbeheerst_model/forcing/HollandseDelta.py
+++ b/src/peilbeheerst_model/forcing/HollandseDelta.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -491,6 +491,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -504,4 +506,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/Rijnland.py
+++ b/src/peilbeheerst_model/forcing/Rijnland.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -441,6 +441,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -451,4 +453,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/Rijnland.py
+++ b/src/peilbeheerst_model/forcing/Rijnland.py
@@ -435,6 +435,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/Rivierenland.py
+++ b/src/peilbeheerst_model/forcing/Rivierenland.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -448,6 +448,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -458,4 +460,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/Rivierenland.py
+++ b/src/peilbeheerst_model/forcing/Rivierenland.py
@@ -442,6 +442,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/Scheldestromen.py
+++ b/src/peilbeheerst_model/forcing/Scheldestromen.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -477,6 +477,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -487,4 +489,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/Scheldestromen.py
+++ b/src/peilbeheerst_model/forcing/Scheldestromen.py
@@ -471,6 +471,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
+++ b/src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
@@ -427,6 +427,11 @@ ribasim_model.pump.static.df.loc[
     ("max_flow_rate", "meta_known_flow_rate"),
 ] = 10, True  # actually not known, but its otherwise too low
 
+ribasim_model.outlet.static.df.loc[
+    ribasim_model.outlet.static.df.node_id == 685,
+    ("max_flow_rate", "meta_known_flow_rate"),
+] = 2.0, True  # actually not known, but its otherwise too low
+
 # rescaling of outlets (and pumps)
 if RESCALE_FLOW_CAPACITIES:
     ribasim_model, from_to_node_function_table = scale_outlets_pumps(

--- a/src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
+++ b/src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
@@ -470,6 +470,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
+++ b/src/peilbeheerst_model/forcing/SchielandendeKrimpenerwaard.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -481,6 +481,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -491,4 +493,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/WetterskipFryslan.py
+++ b/src/peilbeheerst_model/forcing/WetterskipFryslan.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -447,6 +447,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -457,4 +459,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/WetterskipFryslan.py
+++ b/src/peilbeheerst_model/forcing/WetterskipFryslan.py
@@ -441,6 +441,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/forcing/Zuiderzeeland.py
+++ b/src/peilbeheerst_model/forcing/Zuiderzeeland.py
@@ -6,7 +6,7 @@ import peilbeheerst_model.ribasim_parametrization as ribasim_param
 import xarray as xr
 from peilbeheerst_model.assign_authorities import AssignAuthorities
 from peilbeheerst_model.assign_parametrization import AssignMetaData
-from peilbeheerst_model.controle_output import Control
+from peilbeheerst_model.controle_output import DYNAMIC_FORCING_METRICS, STATIC_FORCING_METRICS, Control
 from peilbeheerst_model.network_snapping import snap_model
 from peilbeheerst_model.outlet_pump_scaler import OutletPumpScalingConfig, scale_outlets_pumps
 from peilbeheerst_model.ribasim_feedback_processor import RibasimFeedbackProcessor
@@ -441,6 +441,8 @@ ribasim_param.write_steady_state_regression_models(
         scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
         for scenario in ("dry", "wet")
     },
+    authority=waterschap,
+    qlr_path=qlr_path,
 )
 ribasim_model.validate_ribasim_nl()
 
@@ -451,4 +453,5 @@ ribasim_model.basin.state.write()
 
 # model performance
 controle_output = Control(work_dir=output_dir, qlr_path=qlr_path)
-indicators = controle_output.run_dynamic_forcing() if MIXED_CONDITIONS else controle_output.run_all()
+metrics = DYNAMIC_FORCING_METRICS if MIXED_CONDITIONS else STATIC_FORCING_METRICS
+indicators = controle_output.run(metrics=metrics)

--- a/src/peilbeheerst_model/forcing/Zuiderzeeland.py
+++ b/src/peilbeheerst_model/forcing/Zuiderzeeland.py
@@ -435,6 +435,13 @@ ribasim_model.starttime = starttime
 ribasim_model.endtime = endtime
 ribasim_model.solver.saveat = saveat
 ribasim_model.write(output_dir_model_toml)
+ribasim_param.write_steady_state_regression_models(
+    output_dir_model_toml,
+    {
+        scenario: output_dir.parent / f"{waterschap}_steady_state_{scenario}" / "ribasim.toml"
+        for scenario in ("dry", "wet")
+    },
+)
 ribasim_model.validate_ribasim_nl()
 
 # run model

--- a/src/peilbeheerst_model/peilbeheerst_model/controle_output.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/controle_output.py
@@ -7,9 +7,20 @@ import geopandas as gpd
 import pandas as pd
 import xarray as xr
 
+from peilbeheerst_model.steady_state_regression import (
+    steady_state_results,
+)
 from ribasim_nl import Model
 
 logger = logging.getLogger(__name__)
+
+LEVEL_METRICS = frozenset({"initial_final_level", "min_max_level", "error", "steady_state"})
+SUPPLY_METRICS = frozenset({"aanvoer_areas", "aanvoer_afvoer_basin_nodes", "aanvoer_afvoer_pumps", "aanvoer_outlets"})
+FLOW_METRICS = frozenset({"mean_flow"})
+
+STATIC_FORCING_METRICS = LEVEL_METRICS | SUPPLY_METRICS | FLOW_METRICS | {"afvoer_mask"}
+AFVOER_METRICS = LEVEL_METRICS | FLOW_METRICS | {"afvoer_mask", "flow_rate"}
+DYNAMIC_FORCING_METRICS = SUPPLY_METRICS | FLOW_METRICS | {"water_level_bounds", "error_bounds"}
 
 
 def model_loaded(func: Callable[..., dict[str, object]]) -> Callable[..., dict[str, object]]:
@@ -40,11 +51,19 @@ def model_loaded(func: Callable[..., dict[str, object]]) -> Callable[..., dict[s
 
 
 class Control:
+    """Export model-result metrics for QGIS and validate computed conditions.
+
+    Use :meth:`run` with one of the metric sets defined in this module, or a
+    custom set of metric names, to write selected metrics to
+    ``results/output_controle.gpkg``.
+    """
+
     ds_basin: xr.Dataset | None = None
     ds_link: xr.Dataset | None = None
     model: Model | None = None
 
     def __init__(self, qlr_path=None, work_dir=None, ribasim_toml=None) -> None:
+        """Configure paths to a model's results and optional QGIS layer definition."""
         if (work_dir is None) and (ribasim_toml is None):
             raise ValueError("provide either work_dir or ribasim_toml")
         else:
@@ -64,6 +83,7 @@ class Control:
         self.path_control_dict_path = Path(self.work_dir) / "results" / "output_controle"
 
     def read_model_output(self):
+        """Load Basin and flow output together with the corresponding model."""
         ds_basin = xr.open_dataset(self.path_basin_output)
         ds_link = xr.open_dataset(self.path_link_output)
         model = Model.read(self.path_ribasim_toml)
@@ -167,25 +187,50 @@ class Control:
         return control_dict
 
     @model_loaded
-    def stationary(self, control_dict):
-        time_index = pd.DatetimeIndex(self.ds_basin["time"].values)
-        last_time = time_index[-1]
-        time_window_start = last_time - pd.Timedelta(hours=24)
-
-        level = self.ds_basin["level"]
-        average_last_values = level.sel(time=slice(time_window_start, last_time)).mean(dim="time")
-        actual_last_value = level.sel(time=last_time)
-        stationary = (abs(actual_last_value - average_last_values) <= 0.01).to_series().rename("stationary")
-        stationary_gdf = stationary.reset_index().dropna()
+    def steady_state(self, control_dict):
+        assert self.ds_basin is not None
+        steady_state_gdf = steady_state_results(self.ds_basin["level"], self.ds_basin["storage"])
 
         # Retrieve the geometries
-        stationary_gdf["geometry"] = stationary_gdf.merge(
+        steady_state_gdf["geometry"] = steady_state_gdf.merge(
             self.model.basin.node.df, on="node_id", suffixes=("", "model_")
         )["geometry"]
 
-        control_dict["stationary"] = gpd.GeoDataFrame(stationary_gdf, geometry="geometry")
+        control_dict["steady_state"] = gpd.GeoDataFrame(steady_state_gdf, geometry="geometry")
 
         return control_dict
+
+    @model_loaded
+    def validate_result_conditions(self, *, allowed_non_steady_state_node_ids: set[int] | None = None) -> None:
+        """Validate Basin result conditions after exporting output-control data.
+
+        All detected violations are logged with their Basin node IDs before one
+        exception is raised, so a single run reports every condition to fix.
+        """
+        assert self.ds_basin is not None
+        result = steady_state_results(self.ds_basin["level"], self.ds_basin["storage"]).set_index("node_id")
+        allowed_non_steady_state_node_ids = allowed_non_steady_state_node_ids or set()
+        issues: list[str] = []
+
+        missing_allowed_node_ids = allowed_non_steady_state_node_ids.difference(result.index)
+        issues.extend(
+            f"allowed non-steady-state Basin node_id={node_id} is missing from output"
+            for node_id in sorted(missing_allowed_node_ids)
+        )
+        issues.extend(
+            f"Basin node_id={node_id} reached zero storage" for node_id in result.index[~result["has_positive_storage"]]
+        )
+
+        non_steady_state = result.loc[
+            ~result["level_steady_state"] & ~result.index.isin(list(allowed_non_steady_state_node_ids))
+        ]
+        for node_id, row in non_steady_state.iterrows():
+            issues.append(f"Basin node_id={node_id} is not in steady state (deviation={row.level_deviation:.6g} m)")
+
+        for issue in issues:
+            logger.error(issue)
+        if issues:
+            raise AssertionError(f"Model result conditions failed for {len(issues)} Basin(s); see logged issues.")
 
     @model_loaded
     def find_mean_flow(self, control_dict):
@@ -327,35 +372,60 @@ class Control:
 
         return
 
-    def run_all(self) -> dict[str, object]:
+    def run(
+        self,
+        *,
+        metrics: set[str] | frozenset[str] = DYNAMIC_FORCING_METRICS,
+        skip_time_steps: int = 0,
+        autofill_missing_data: bool = False,
+    ) -> dict[str, object]:
+        """Compute selected metrics, export QGIS data, and return the collected results.
+
+        Parameters
+        ----------
+        metrics
+            Metric names to compute. Use ``STATIC_FORCING_METRICS``,
+            ``AFVOER_METRICS``, or ``DYNAMIC_FORCING_METRICS`` for the
+            established workflows.
+        skip_time_steps
+            Dynamic-forcing spin-up time steps excluded from level bounds.
+        autofill_missing_data
+            Permit ``error_bounds`` to calculate missing water-level bounds.
+        """
+        unknown_metrics = metrics.difference(STATIC_FORCING_METRICS | AFVOER_METRICS | DYNAMIC_FORCING_METRICS)
+        if unknown_metrics:
+            msg = f"Unknown output-control metrics: {sorted(unknown_metrics)}."
+            raise ValueError(msg)
+
         control_dict = self.read_model_output()
-        control_dict = self.initial_final_level(control_dict)
-        control_dict = self.min_max_level(control_dict)
-        control_dict = self.error(control_dict)
-        control_dict = self.stationary(control_dict)
-        control_dict = self.find_mean_flow(control_dict)
-        control_dict = self.water_aanvoer_areas(control_dict)
-        control_dict = self.water_aanvoer_afvoer_basin_nodes(control_dict)
-        control_dict = self.water_aanvoer_afvoer_pumps(control_dict)
-        control_dict = self.water_aanvoer_outlets(control_dict)
-        control_dict = self.mask_basins(control_dict)
+        if "initial_final_level" in metrics:
+            control_dict = self.initial_final_level(control_dict)
+        if "min_max_level" in metrics:
+            control_dict = self.min_max_level(control_dict)
+        if "error" in metrics:
+            control_dict = self.error(control_dict)
+        if "steady_state" in metrics:
+            control_dict = self.steady_state(control_dict)
+        if "water_level_bounds" in metrics:
+            control_dict = self.water_level_bounds(control_dict, skip_time_steps=skip_time_steps)
+        if "error_bounds" in metrics:
+            control_dict = self.error_bounds(control_dict, autofill_missing_data=autofill_missing_data)
+        if "mean_flow" in metrics:
+            control_dict = self.find_mean_flow(control_dict)
+        if "aanvoer_areas" in metrics:
+            control_dict = self.water_aanvoer_areas(control_dict)
+        if "aanvoer_afvoer_basin_nodes" in metrics:
+            control_dict = self.water_aanvoer_afvoer_basin_nodes(control_dict)
+        if "aanvoer_afvoer_pumps" in metrics:
+            control_dict = self.water_aanvoer_afvoer_pumps(control_dict)
+        if "aanvoer_outlets" in metrics:
+            control_dict = self.water_aanvoer_outlets(control_dict)
+        if "afvoer_mask" in metrics:
+            control_dict = self.mask_basins(control_dict)
+        if "flow_rate" in metrics:
+            control_dict = self.flow_rate(control_dict)
 
         self.store_data(data=control_dict, output_path=self.path_control_dict_path)
-
-        return control_dict
-
-    def run_afvoer(self) -> dict[str, object]:
-        control_dict = self.read_model_output()
-        control_dict = self.initial_final_level(control_dict)
-        control_dict = self.min_max_level(control_dict)
-        control_dict = self.error(control_dict)
-        control_dict = self.stationary(control_dict)
-        control_dict = self.find_mean_flow(control_dict)
-        control_dict = self.mask_basins(control_dict)
-        control_dict = self.flow_rate(control_dict)
-
-        self.store_data(data=control_dict, output_path=self.path_control_dict_path)
-
         return control_dict
 
     @model_loaded
@@ -471,44 +541,4 @@ class Control:
         )
 
         # return updated analysed data collector
-        return control_dict
-
-    def run_dynamic_forcing(self, **kwargs) -> dict[str, object]:
-        """Run the output control formatting for varying forcing conditions.
-
-        :param kwargs: optional arguments, which are passed on to the various method-calls within this collective data
-            analysis call
-
-        :key autofill_missing_data: autofill water level bounds if missing, defaults to False
-        :key skip_time_steps: number of time-steps considered as spin-up time and so skipped in analysis, defaults to 0
-        :key suppress_file_warning: suppress warning for potentially incompatible *.qlr-file, defaults to False
-
-        :return: analysed data collector
-        :rtype: dict
-        """
-        # optional arguments
-        autofill_missing_data: bool = kwargs.get("autofill_missing_data", False)
-        skip_time_steps: int = kwargs.get("skip_time_steps", 0)
-        suppress_file_warning: bool = kwargs.get("suppress_file_warning", False)
-
-        # analyse output data
-        control_dict = self.read_model_output()
-        control_dict = self.water_level_bounds(control_dict, skip_time_steps=skip_time_steps)
-        control_dict = self.error_bounds(control_dict, autofill_missing_data=autofill_missing_data)
-        control_dict = self.water_aanvoer_areas(control_dict)
-        control_dict = self.water_aanvoer_afvoer_basin_nodes(control_dict)
-        control_dict = self.water_aanvoer_afvoer_pumps(control_dict)
-        control_dict = self.water_aanvoer_outlets(control_dict)
-        control_dict = self.find_mean_flow(control_dict)
-
-        # check for dynamic forcing specific *.qlr
-        filename_cc_qlr = "output_controle_cc.qlr"
-        if not suppress_file_warning and not str(self.qlr_path).endswith(filename_cc_qlr):
-            logger.warning(f"*.qlr-file is different from default for dynamic forcing: {filename_cc_qlr}")
-            logger.warning(f"*.qlr-file may not be compatible with dynamic forcing: {self.qlr_path}")
-
-        # export analysed data
-        self.store_data(control_dict, self.path_control_dict_path)
-
-        # return analysed data collector
         return control_dict

--- a/src/peilbeheerst_model/peilbeheerst_model/data/output_controle.qlr
+++ b/src/peilbeheerst_model/peilbeheerst_model/data/output_controle.qlr
@@ -13,7 +13,7 @@
           <Option/>
         </customproperties>
       </layer-tree-layer>
-      <layer-tree-layer source="./output_controle.gpkg|layername=stationary" providerKey="ogr" checked="Qt::Unchecked" legend_split_behavior="0" expanded="0" patch_size="-1,-1" name="stationary" legend_exp="" id="stationary_e9c6d7bb_fac1_481a_a1c7_4212b203e851">
+      <layer-tree-layer source="./output_controle.gpkg|layername=steady_state" providerKey="ogr" checked="Qt::Unchecked" legend_split_behavior="0" expanded="0" patch_size="-1,-1" name="steady_state" legend_exp="" id="steady_state_e9c6d7bb_fac1_481a_a1c7_4212b203e851">
         <customproperties>
           <Option/>
         </customproperties>
@@ -859,12 +859,12 @@ def my_form_open(dialog, layer, feature):
       <mapTip enabled="1"></mapTip>
     </maplayer>
     <maplayer readOnly="0" simplifyLocal="1" legendPlaceholderImage="" symbologyReferenceScale="-1" autoRefreshMode="Disabled" simplifyAlgorithm="0" maxScale="0" simplifyMaxScale="1" simplifyDrawingHints="0" geometry="Point" autoRefreshTime="0" labelsEnabled="0" type="vector" minScale="100000000" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" wkbType="Point" refreshOnNotifyMessage="" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories">
-      <id>stationary_e9c6d7bb_fac1_481a_a1c7_4212b203e851</id>
-      <datasource>./output_controle.gpkg|layername=stationary</datasource>
+      <id>steady_state_e9c6d7bb_fac1_481a_a1c7_4212b203e851</id>
+      <datasource>./output_controle.gpkg|layername=steady_state</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>stationary</layername>
+      <layername>steady_state</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
           <wkt></wkt>
@@ -1058,7 +1058,7 @@ def my_form_open(dialog, layer, feature):
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 forceraster="0" type="categorizedSymbol" symbollevels="0" referencescale="-1" attr="stationary" enableorderby="0">
+      <renderer-v2 forceraster="0" type="categorizedSymbol" symbollevels="0" referencescale="-1" attr="steady_state" enableorderby="0">
         <categories>
           <category type="string" uuid="0" render="true" value="False" label="False" symbol="0"/>
           <category type="string" uuid="1" render="true" value="True" label="True" symbol="1"/>
@@ -1193,7 +1193,7 @@ def my_form_open(dialog, layer, feature):
       <customproperties>
         <Option type="Map">
           <Option type="List" name="dualview/previewExpressions">
-            <Option type="QString" value="&quot;stationary&quot;"/>
+            <Option type="QString" value="&quot;steady_state&quot;"/>
           </Option>
           <Option type="int" value="0" name="embeddedWidgets/count"/>
           <Option type="invalid" name="variableNames"/>
@@ -1288,7 +1288,7 @@ def my_form_open(dialog, layer, feature):
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="NoFlag" name="stationary">
+        <field configurationFlags="NoFlag" name="steady_state">
           <editWidget type="TextEdit">
             <config>
               <Option/>
@@ -1299,37 +1299,37 @@ def my_form_open(dialog, layer, feature):
       <aliases>
         <alias index="0" field="fid" name=""/>
         <alias index="1" field="node_id" name=""/>
-        <alias index="2" field="stationary" name=""/>
+        <alias index="2" field="steady_state" name=""/>
       </aliases>
       <splitPolicies>
         <policy field="fid" policy="Duplicate"/>
         <policy field="node_id" policy="Duplicate"/>
-        <policy field="stationary" policy="Duplicate"/>
+        <policy field="steady_state" policy="Duplicate"/>
       </splitPolicies>
       <defaults>
         <default field="fid" expression="" applyOnUpdate="0"/>
         <default field="node_id" expression="" applyOnUpdate="0"/>
-        <default field="stationary" expression="" applyOnUpdate="0"/>
+        <default field="steady_state" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
         <constraint field="fid" constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1"/>
         <constraint field="node_id" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
-        <constraint field="stationary" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="steady_state" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
       </constraints>
       <constraintExpressions>
         <constraint field="fid" exp="" desc=""/>
         <constraint field="node_id" exp="" desc=""/>
-        <constraint field="stationary" exp="" desc=""/>
+        <constraint field="steady_state" exp="" desc=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
         <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortExpression="&quot;stationary&quot;" sortOrder="1" actionWidgetStyle="dropDown">
+      <attributetableconfig sortExpression="&quot;steady_state&quot;" sortOrder="1" actionWidgetStyle="dropDown">
         <columns>
           <column type="field" width="-1" name="fid" hidden="0"/>
           <column type="field" width="-1" name="node_id" hidden="0"/>
-          <column type="field" width="-1" name="stationary" hidden="0"/>
+          <column type="field" width="-1" name="steady_state" hidden="0"/>
           <column type="actions" width="-1" hidden="1"/>
         </columns>
       </attributetableconfig>
@@ -1364,21 +1364,21 @@ def my_form_open(dialog, layer, feature):
       <editable>
         <field editable="1" name="fid"/>
         <field editable="1" name="node_id"/>
-        <field editable="1" name="stationary"/>
+        <field editable="1" name="steady_state"/>
       </editable>
       <labelOnTop>
         <field labelOnTop="0" name="fid"/>
         <field labelOnTop="0" name="node_id"/>
-        <field labelOnTop="0" name="stationary"/>
+        <field labelOnTop="0" name="steady_state"/>
       </labelOnTop>
       <reuseLastValue>
         <field reuseLastValue="0" name="fid"/>
         <field reuseLastValue="0" name="node_id"/>
-        <field reuseLastValue="0" name="stationary"/>
+        <field reuseLastValue="0" name="steady_state"/>
       </reuseLastValue>
       <dataDefinedFieldProperties/>
       <widgets/>
-      <previewExpression>"stationary"</previewExpression>
+      <previewExpression>"steady_state"</previewExpression>
       <mapTip enabled="1"></mapTip>
     </maplayer>
     <maplayer readOnly="0" simplifyLocal="1" legendPlaceholderImage="" symbologyReferenceScale="-1" autoRefreshMode="Disabled" simplifyAlgorithm="0" maxScale="0" simplifyMaxScale="1" simplifyDrawingHints="0" geometry="Point" autoRefreshTime="0" labelsEnabled="0" type="vector" minScale="100000000" hasScaleBasedVisibilityFlag="0" simplifyDrawingTol="1" wkbType="Point" refreshOnNotifyMessage="" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories">

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -139,7 +139,7 @@ def write_steady_state_regression_models(
         scenario_model = Model.read(model_path)
         starttime = scenario_model.starttime
         endtime = scenario_model.endtime
-        scenario_model.basin.time = None
+        scenario_model.basin.time.df = None
         set_static_forcing(
             timesteps=2,
             timestep_size="d",

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -112,6 +112,49 @@ def set_static_forcing(
     ribasim_model.endtime = time_range[-1].to_pydatetime()
 
 
+def write_steady_state_regression_models(
+    model_path: Path,
+    output_paths: dict[str, Path],
+    *,
+    dry_evaporation_mm_per_day: float = 1.0,
+    wet_precipitation_mm_per_day: float = 2.0,
+) -> None:
+    """Write constant dry and wet forcing variants of an existing model.
+
+    The source model is read separately for each variant so that the dynamic
+    production model remains unchanged. Its simulation period, controls, and
+    level boundaries are retained; only Basin meteo forcing is replaced.
+    """
+    required_scenarios = {"dry", "wet"}
+    if set(output_paths) != required_scenarios:
+        msg = f"Expected output paths for {sorted(required_scenarios)}, got {sorted(output_paths)}."
+        raise ValueError(msg)
+
+    for scenario, forcing in {
+        "dry": {"precipitation": 0.0, "potential_evaporation": dry_evaporation_mm_per_day},
+        "wet": {"precipitation": wet_precipitation_mm_per_day, "potential_evaporation": 0.0},
+    }.items():
+        scenario_model = Model.read(model_path)
+        starttime = scenario_model.starttime
+        endtime = scenario_model.endtime
+        scenario_model.basin.time.df = None
+        set_static_forcing(
+            timesteps=2,
+            timestep_size="d",
+            start_time=starttime,
+            forcing_dict={
+                key: convert_mm_day_to_m_sec(value)
+                for key, value in {**forcing, "drainage": 0.0, "infiltration": 0.0}.items()
+            },
+            ribasim_model=scenario_model,
+        )
+        scenario_model.starttime = starttime
+        scenario_model.endtime = endtime
+        output_path = output_paths[scenario]
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        scenario_model.write(output_path)
+
+
 def set_dynamic_forcing(
     ribasim_model: Model, time: typing.Sequence[datetime.datetime], forcing: dict[str, Any]
 ) -> None:

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -140,6 +140,7 @@ def write_steady_state_regression_models(
         starttime = scenario_model.starttime
         endtime = scenario_model.endtime
         scenario_model.basin.time.df = None
+        scenario_model.basin.time.filepath = None  # not needed from ribasim v2026.1.3
         set_static_forcing(
             timesteps=2,
             timestep_size="d",

--- a/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/ribasim_parametrization.py
@@ -116,10 +116,12 @@ def write_steady_state_regression_models(
     model_path: Path,
     output_paths: dict[str, Path],
     *,
+    authority: str,
+    qlr_path: Path,
     dry_evaporation_mm_per_day: float = 1.0,
     wet_precipitation_mm_per_day: float = 2.0,
 ) -> None:
-    """Write constant dry and wet forcing variants of an existing model.
+    """Write, run, export, and validate constant dry and wet forcing variants.
 
     The source model is read separately for each variant so that the dynamic
     production model remains unchanged. Its simulation period, controls, and
@@ -137,7 +139,7 @@ def write_steady_state_regression_models(
         scenario_model = Model.read(model_path)
         starttime = scenario_model.starttime
         endtime = scenario_model.endtime
-        scenario_model.basin.time.df = None
+        scenario_model.basin.time = None
         set_static_forcing(
             timesteps=2,
             timestep_size="d",
@@ -153,6 +155,16 @@ def write_steady_state_regression_models(
         output_path = output_paths[scenario]
         output_path.parent.mkdir(parents=True, exist_ok=True)
         scenario_model.write(output_path)
+
+        from peilbeheerst_model.controle_output import STATIC_FORCING_METRICS, Control
+        from peilbeheerst_model.steady_state_regression import allowed_non_steady_state_node_ids
+
+        scenario_model.run()
+        control = Control(ribasim_toml=output_path, qlr_path=qlr_path)
+        control.run(metrics=STATIC_FORCING_METRICS)
+        control.validate_result_conditions(
+            allowed_non_steady_state_node_ids=allowed_non_steady_state_node_ids(authority, scenario)
+        )
 
 
 def set_dynamic_forcing(

--- a/src/peilbeheerst_model/peilbeheerst_model/steady_state_regression.py
+++ b/src/peilbeheerst_model/peilbeheerst_model/steady_state_regression.py
@@ -1,0 +1,56 @@
+"""Regression checks for Basin water-level steady state."""
+
+import pandas as pd
+import xarray as xr
+
+ALLOWED_NON_STEADY_STATE_NODE_IDS = {
+    "DeDommel": {"wet": {1708}},
+    "RijnenIJssel": {"wet": {835}},
+    "StichtseRijnlanden": {"wet": {1877}},
+}
+
+
+def allowed_non_steady_state_node_ids(authority: str | None, scenario: str | None) -> set[int]:
+    """Return approved level-instability exceptions for a model scenario."""
+    return ALLOWED_NON_STEADY_STATE_NODE_IDS.get(authority, {}).get(scenario, set())
+
+
+def steady_state_results(
+    level: xr.DataArray, storage: xr.DataArray | None = None, *, tolerance: float = 0.01
+) -> pd.DataFrame:
+    """Return the final-24-hour steady-state result for every Basin.
+
+    A Basin that reaches zero storage at any point in the simulation is not in
+    steady state, even when its final water level is constant.
+    """
+    if not {"time", "node_id"}.issubset(level.dims):
+        msg = "Basin level data must have 'time' and 'node_id' dimensions."
+        raise ValueError(msg)
+    if tolerance < 0:
+        msg = "Steady-state tolerance must be non-negative."
+        raise ValueError(msg)
+
+    time_index = pd.DatetimeIndex(level["time"].values)
+    if time_index.empty:
+        msg = "Basin level data contains no time steps."
+        raise ValueError(msg)
+
+    last_time = time_index[-1]
+    last_day = level.sel(time=slice(last_time - pd.Timedelta(hours=24), last_time))
+    result = pd.concat(
+        [
+            last_day.mean(dim="time").to_series().rename("mean_level"),
+            level.sel(time=last_time).to_series().rename("final_level"),
+        ],
+        axis=1,
+    ).reset_index()
+    result["level_deviation"] = (result["final_level"] - result["mean_level"]).abs()
+    result["level_steady_state"] = result["level_deviation"].le(tolerance) & result["level_deviation"].notna()
+    result["has_positive_storage"] = True
+    if storage is not None:
+        if not {"time", "node_id"}.issubset(storage.dims):
+            msg = "Basin storage data must have 'time' and 'node_id' dimensions."
+            raise ValueError(msg)
+        result["has_positive_storage"] = storage.min(dim="time").to_series().gt(0).reindex(result["node_id"]).to_numpy()
+    result["steady_state"] = result["level_steady_state"] & result["has_positive_storage"]
+    return result.sort_values("node_id").reset_index(drop=True)

--- a/src/ribasim_nl/ribasim_nl/run_model.py
+++ b/src/ribasim_nl/ribasim_nl/run_model.py
@@ -6,10 +6,42 @@ import sys
 from collections import namedtuple
 from datetime import timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ribasim.cli import _find_cli
 
+if TYPE_CHECKING:
+    from ribasim_nl.model import Model
+
 RunSpecs = namedtuple("RunSpecs", ["exit_code", "simulation_time"])
+
+
+def run_model_and_control(
+    model: "Model",
+    ribasim_toml: Path,
+    *,
+    model_exec: bool,
+    qlr_path: Path,
+    authority: str | None = None,
+    scenario: str | None = None,
+) -> "Model":
+    """Write a model and optionally run, export, and validate its result metrics."""
+    model.write(ribasim_toml)
+    if not model_exec:
+        return model
+
+    from peilbeheerst_model.controle_output import STATIC_FORCING_METRICS, Control
+    from peilbeheerst_model.steady_state_regression import allowed_non_steady_state_node_ids
+
+    from ribasim_nl.model import Model
+
+    model.run()
+    control = Control(ribasim_toml=ribasim_toml, qlr_path=qlr_path)
+    control.run(metrics=STATIC_FORCING_METRICS)
+    control.validate_result_conditions(
+        allowed_non_steady_state_node_ids=allowed_non_steady_state_node_ids(authority, scenario)
+    )
+    return Model.read(ribasim_toml)
 
 
 def parse_computation_time(line: str) -> timedelta | None:

--- a/src/ribasim_nl/ribasim_nl/set_forcing.py
+++ b/src/ribasim_nl/ribasim_nl/set_forcing.py
@@ -106,6 +106,7 @@ class SetDynamicForcing:
             Updated Ribasim model with dynamic meteo forcing in ``basin.time``.
         """
         self.model.basin.time.df = None
+        self.model.basin.time.filepath = None  # not needed from ribasim v2026.1.3
 
         basins = self.model.basin.area.df
         assert basins is not None


### PR DESCRIPTION
## Result regression testing

The dry and wet steady-state scenarios guard against a Basin losing its ability to maintain its water level. During the existing `bergend_*` and `forcing_*` DVC stages, and in `repro.sh`, the dry and wet models are run and checked. A Basin is steady-state when its final water level differs by at most 0.01 m from the mean of the final 24 hours and its storage remains positive throughout the simulation.

Known level-instability exceptions are kept as explicit scenario-specific Basin node IDs in `peilbeheerst_model.steady_state_regression`. Exceptions do not bypass the positive-storage check, and an exception for a missing Basin ID fails the run.

Scenario results are available for inspection in each model's `results` directory, including `output_controle.gpkg` and `output_controle.qlr`.

## Completed-model result checks

`Control.run()` exports selected result metrics to `results/output_controle.gpkg`. It defaults to `DYNAMIC_FORCING_METRICS`; use `STATIC_FORCING_METRICS` or `AFVOER_METRICS` for the other established workflows, or pass a custom metric set. Call `Control.validate_result_conditions()` after export to enforce conditions. It logs every violation with its Basin node ID before raising one error, so all failures can be addressed together.

New completed-model checks belong on `Control` and can be called after future dynamic model exports without changing the dry/wet scenario runner.

### Allowing a known exception

Only after reviewing an intentional model change, add the Basin node ID to `ALLOWED_NON_STEADY_STATE_NODE_IDS` for its authority and scenario. Remove an exception once the Basin becomes steady-state again.
